### PR TITLE
Saving a bit of memory

### DIFF
--- a/pol-core/bscript/CMakeLists.txt
+++ b/pol-core/bscript/CMakeLists.txt
@@ -34,6 +34,7 @@ SET (SOURCES  # sorted !
 	symcont.cpp
 	tkn_strm.cpp 
 	token.cpp
+	tokens.cpp
 	userfunc.cpp
 )
 

--- a/pol-core/bscript/berror.cpp
+++ b/pol-core/bscript/berror.cpp
@@ -72,7 +72,7 @@ namespace Pol {
 	  return "Error";
 	}
 
-	int BError::typeOfInt() const
+	u8 BError::typeOfInt() const
 	{
 	  return OTError;
 	}

--- a/pol-core/bscript/berror.h
+++ b/pol-core/bscript/berror.h
@@ -40,7 +40,7 @@ namespace Pol {
 	  virtual char packtype() const POL_OVERRIDE;
 	  virtual const char* typetag() const POL_OVERRIDE;
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 
 	  virtual bool isEqual( const BObjectImp& objimp ) const POL_OVERRIDE;
 	  virtual bool isTrue() const POL_OVERRIDE;

--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -59,51 +59,58 @@ namespace Pol {
 	class BObjectImp : public ref_counted
 	{
 	public:
-	  enum BObjectType
+      /**
+       * Specify the object type for the child classes
+       *
+       * @warning This is directly returned by TypeOfInt(), so don't forget to
+       *          keep constants inside basic.em in sync! It is better to always
+       *          add new values at the end and use explicit int conversion to
+       *          avoid breaking backward compatibility.
+       */
+	  enum BObjectType : u8
 	  {
-		OTUnknown,
-		OTUninit,
-		OTString,
-		OTLong,
-		OTDouble,
-		OTArray,
-		OTApplicPtr,
-		OTApplicObj,
-		OTError,
-		OTDictionary,
-		OTStruct,
-		OTPacket,
-		OTBinaryFile,
-		OTXMLFile,
-		OTXMLNode,
-		OTXMLAttributes,
-		OTPolCoreRef,
+		OTUnknown = 0,
+		OTUninit = 1,
+		OTString = 2,
+		OTLong = 3,
+		OTDouble = 4,
+		OTArray = 5,
+		OTApplicPtr = 6,
+		OTApplicObj = 7,
+		OTError = 8,
+		OTDictionary = 9,
+		OTStruct = 10,
+		OTPacket = 11,
+		OTBinaryFile = 12,
+		OTXMLFile = 13,
+		OTXMLNode = 14,
+		OTXMLAttributes = 15,
+		OTPolCoreRef = 16,
 
 		// non direct used constants (for TypeOfInt) start
-		OTAccountRef,
-		OTConfigFileRef,
-		OTConfigElemRef,
-		OTDataFileRef,
-		OTDataElemRef,
-		OTGuildRef,
-		OTPartyRef,
-		OTBoundingBox,
-		OTDebugContext,
-		OTScriptExRef,
-		OTPackage,
-		OTMenuRef,
-		OTMobileRef,
-		OTOfflineMobileRef,
-		OTItemRef,
-		OTBoatRef,
-		OTMultiRef,
-		OTClientRef,
+		OTAccountRef = 17,
+		OTConfigFileRef = 18,
+		OTConfigElemRef = 19,
+		OTDataFileRef = 20,
+		OTDataElemRef = 21,
+		OTGuildRef = 22,
+		OTPartyRef = 23,
+		OTBoundingBox = 24,
+		OTDebugContext = 25,
+		OTScriptExRef = 26,
+		OTPackage = 27,
+		OTMenuRef = 28,
+		OTMobileRef = 29,
+		OTOfflineMobileRef = 30,
+		OTItemRef = 31,
+		OTBoatRef = 32,
+		OTMultiRef = 33,
+		OTClientRef = 34,
 		// non direct used Constants (for TypeOfInt) end
 
-		OTSQLConnection,
-		OTSQLResultSet,
-		OTSQLRow
-
+		OTSQLConnection = 35,
+		OTSQLResultSet = 36,
+		OTSQLRow = 37,
 	  };
 
 #if INLINE_BOBJECTIMP_CTOR
@@ -139,7 +146,7 @@ namespace Pol {
 
 	  virtual size_t sizeEstimate() const = 0;
 	  virtual const char* typeOf() const;
-	  virtual int typeOfInt() const;
+	  virtual u8 typeOfInt() const;
 
 
 	  virtual std::string pack() const;
@@ -861,7 +868,7 @@ namespace Pol {
 	  T* operator->( );
 
 	  virtual const char* typeOf() const POL_OVERRIDE = 0;
-	  virtual int typeOfInt() const POL_OVERRIDE = 0;
+	  virtual u8 typeOfInt() const POL_OVERRIDE = 0;
 	  virtual BObjectImp* copy() const POL_OVERRIDE = 0;
 	  virtual size_t sizeEstimate() const POL_OVERRIDE;
 

--- a/pol-core/bscript/bscript-2013.vcxproj
+++ b/pol-core/bscript/bscript-2013.vcxproj
@@ -247,6 +247,7 @@
     <ClCompile Include="symcont.cpp" />
     <ClCompile Include="tkn_strm.cpp" />
     <ClCompile Include="token.cpp" />
+    <ClCompile Include="tokens.cpp" />
     <ClCompile Include="userfunc.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/pol-core/bscript/bscript-2013.vcxproj.filters
+++ b/pol-core/bscript/bscript-2013.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClCompile Include="userfunc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tokens.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="berror.h">

--- a/pol-core/bscript/bstruct.cpp
+++ b/pol-core/bscript/bstruct.cpp
@@ -92,7 +92,7 @@ namespace Pol {
 	{
 	  return "Struct";
 	}
-	int BStruct::typeOfInt() const
+	u8 BStruct::typeOfInt() const
 	{
 	  return OTStruct;
 	}

--- a/pol-core/bscript/bstruct.h
+++ b/pol-core/bscript/bstruct.h
@@ -55,7 +55,7 @@ namespace Pol {
 	  virtual size_t sizeEstimate() const POL_OVERRIDE;
 	  virtual void packonto( std::ostream& os ) const POL_OVERRIDE;
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 
 	  virtual ContIterator* createIterator( BObject* pIterVal ) POL_OVERRIDE;
 

--- a/pol-core/bscript/dict.cpp
+++ b/pol-core/bscript/dict.cpp
@@ -351,7 +351,7 @@ namespace Pol {
 	{
 	  return "Dictionary";
 	}
-	int BDictionary::typeOfInt() const
+	u8 BDictionary::typeOfInt() const
 	{
 	  return OTDictionary;
 	}

--- a/pol-core/bscript/dict.h
+++ b/pol-core/bscript/dict.h
@@ -48,7 +48,7 @@ namespace Pol {
 	  virtual size_t sizeEstimate() const POL_OVERRIDE;
 	  virtual void packonto( std::ostream& os ) const POL_OVERRIDE;
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 
 	  virtual ContIterator* createIterator( BObject* pIterVal ) POL_OVERRIDE;
 

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -238,7 +238,7 @@ namespace Pol {
 	}
 
 
-	int BObjectImp::typeOfInt() const
+	u8 BObjectImp::typeOfInt() const
 	{
 	  return type_;
 	}

--- a/pol-core/bscript/tokens.cpp
+++ b/pol-core/bscript/tokens.cpp
@@ -1,0 +1,35 @@
+/*
+History
+=======
+2015/12/29 Bodom: created this file
+
+Notes
+=======
+
+*/
+
+
+# include "tokens.h"
+
+
+namespace Pol {
+  namespace Clib {
+    /**
+     * Template specialization for outputting the token type
+     */
+    template <>
+    std::string tostring( const Bscript::BTokenType& v )
+    {
+      return tostring(static_cast<int>(v));
+    }
+
+    /**
+     * Template specialization for outputting the token ID
+     */
+    template <>
+    std::string tostring( const Bscript::BTokenId& v )
+    {
+      return tostring(static_cast<int>(v));
+    }
+  }
+}

--- a/pol-core/bscript/tokens.h
+++ b/pol-core/bscript/tokens.h
@@ -9,242 +9,274 @@ Notes
 
 #ifndef __TOKENS_H
 #define __TOKENS_H
+
+#include "../clib/rawtypes.h"
+
 namespace Pol {
   namespace Bscript {
-	enum BTokenType
-	{
-	  TYP_TERMINATOR,
-	  TYP_OPERAND,
-	  TYP_OPERATOR,			 // BINARY implied
-	  TYP_UNARY_OPERATOR,
-	  TYP_LEFTPAREN,
-	  TYP_RIGHTPAREN,
-	  TYP_LEFTBRACKET,
-	  TYP_RIGHTBRACKET,
 
-	  TYP_TESTMAX = TYP_RIGHTBRACKET,
+    /**
+     * The token type
+     *
+     * This also gets outputted to the compiled bytecode.
+     * Using hardcoded int conversion for better backward compatibility: every
+     * insertion in the middle of it done in the past shifted forward all the bytes
+     *
+     * @note 20151229 Bodom
+     *       This seems to be the first byte on the outputted bytecode, but not always.
+     *       It looks like over time it also assumed different meaning, like saying the
+     *       number of parameters in a method call. Type names may be out to date.
+     */
+    enum BTokenType : u8
+    {
+      TYP_TERMINATOR = 0x00,
+      TYP_OPERAND = 0x01,
+      TYP_OPERATOR = 0x02, // BINARY implied
+      TYP_UNARY_OPERATOR = 0x03,
+      TYP_LEFTPAREN = 0x04,
+      TYP_RIGHTPAREN = 0x05,
+      TYP_LEFTBRACKET = 0x06,
+      TYP_RIGHTBRACKET = 0x07,
 
-	  TYP_RESERVED,
+      TYP_TESTMAX = TYP_RIGHTBRACKET,
 
-	  TYP_LABEL,   // a GOTO/GOSUB label
+      TYP_RESERVED = 0x08,
 
-	  TYP_FUNC,	// func returning something
-	  TYP_METHOD,  // object method
+      TYP_LABEL = 0x09, // a GOTO/GOSUB label
 
-	  TYP_USERFUNC,
+      TYP_FUNC = 0x10, // func returning something
+      TYP_METHOD = 0x1a, // object method
 
-	  TYP_SEPARATOR,
-	  TYP_DELIMITER,
+      TYP_USERFUNC = 0x1b,
 
-	  TYP_CONTROL,
+      TYP_SEPARATOR = 0x1c,
+      TYP_DELIMITER = 0x1d,
 
-	  TYP_LEFTBRACE,
-	  TYP_RIGHTBRACE,
+      TYP_CONTROL = 0x1e,
 
-	  TYP_NUMTYPES
-	};
+      TYP_LEFTBRACE = 0x1f,
+      TYP_RIGHTBRACE = 0x20,
 
-	enum BTokenId
-	{
-	  TOK_LONG,											   // 0
-	  TOK_DOUBLE,
-	  TOK_STRING,   //  "string literal"
+      TYP_NUMTYPES = 0x21,
+    };
 
-	  TOK_IDENT, // variable identifier, i.e. A, AB, A$ */
+    /**
+     * The token ID: what this token is
+     *
+     * This will be outputted on the compiled bytecode as 2nd byte.
+     * Tokens above 0xFF cannot be outputted and are used only internally
+     * by the compiler: please remember to allocate your new token in the
+     * upper space if it is not meant to be outputted.
+     *
+     * Using hardcoded int conversion for better backward compatibility: every
+     * insertion in the middle of it done in the past shifted forward all the
+     * tokens, invalidating bytecode documentation.
+     */
+    enum BTokenId : u16
+    {
+      // --- LOWER SPACE 0x00-0xFF: TOKENS OUTPUTTED TO THE BYTECODE ---
+      TOK_LONG = 0x00,
+      TOK_DOUBLE = 0x01,
+      TOK_STRING = 0x02, //  "string literal"
 
-	  TOK_ADD,
-	  TOK_SUBTRACT,										   // 5
-	  TOK_MULT,
-	  TOK_DIV,
+      TOK_IDENT = 0x03, // variable identifier, i.e. A, AB, A$ */
 
-	  TOK_ASSIGN,
-	  INS_ASSIGN_CONSUME,
+      TOK_ADD = 0x04,
+      TOK_SUBTRACT = 0x05,
+      TOK_MULT = 0x06,
+      TOK_DIV = 0x07,
 
-	  TOK_PLUSEQUAL,
-	  TOK_MINUSEQUAL,
-	  TOK_TIMESEQUAL,
-	  TOK_DIVIDEEQUAL,
-	  TOK_MODULUSEQUAL,
-	  TOK_INSERTINTO,
+      TOK_ASSIGN = 0x08,
+      INS_ASSIGN_CONSUME = 0x09,
 
-	  /* comparison operators */
-	  TOK_LESSTHAN,
-	  TOK_LESSEQ,											 // 15
-	  TOK_GRTHAN,
-	  TOK_GREQ,
+      TOK_PLUSEQUAL = 0x0a,
+      TOK_MINUSEQUAL = 0x0b,
+      TOK_TIMESEQUAL = 0x0c,
+      TOK_DIVIDEEQUAL = 0x0d,
+      TOK_MODULUSEQUAL = 0x0e,
+      TOK_INSERTINTO = 0x0f,
 
-	  TOK_AND,
-	  TOK_OR,
+      // comparison operators
+      TOK_LESSTHAN = 0x10,
+      TOK_LESSEQ = 0x11,
+      TOK_GRTHAN = 0x12,
+      TOK_GREQ = 0x13,
 
-	  /* equalite/inequality operators */
-	  TOK_EQUAL,											  // 20
-	  TOK_NEQ,
+      TOK_AND = 0x14,
+      TOK_OR = 0x15,
 
-	  /* unary operators */
-	  TOK_UNPLUS,
-	  TOK_UNMINUS,
-	  TOK_LOG_NOT,
-	  TOK_BITWISE_NOT,										// 25
+      // equalite/inequality operators */
+      TOK_EQUAL = 0x16,
+      TOK_NEQ = 0x17,
 
-	  TOK_CONSUMER,
+      // unary operators
+      TOK_UNPLUS = 0x18,
+      TOK_UNMINUS = 0x19,
+      TOK_LOG_NOT = 0x1a,
+      TOK_BITWISE_NOT = 0x1b,
 
-	  TOK_ARRAY_SUBSCRIPT,
+      TOK_CONSUMER = 0x1c,
 
-	  TOK_ADDMEMBER,
-	  TOK_DELMEMBER,
-	  TOK_CHKMEMBER,										  // 30
+      TOK_ARRAY_SUBSCRIPT = 0x1d,
 
-	  CTRL_STATEMENTBEGIN,
-	  CTRL_PROGEND,
-	  CTRL_MAKELOCAL,
-	  CTRL_JSR_USERFUNC,
-	  INS_POP_PARAM,										  // 35
-	  CTRL_LEAVE_BLOCK,		// offset is number of variables to remove
+      TOK_ADDMEMBER = 0x1e,
+      TOK_DELMEMBER = 0x1f,
+      TOK_CHKMEMBER = 0x20,
 
-	  RSV_JMPIFFALSE,
-	  RSV_JMPIFTRUE,
+      CTRL_STATEMENTBEGIN = 0x21,
+      CTRL_PROGEND = 0x22,
+      CTRL_MAKELOCAL = 0x23,
+      CTRL_JSR_USERFUNC = 0x24,
+      INS_POP_PARAM = 0x25,
+      CTRL_LEAVE_BLOCK = 0x26, // offset is number of variables to remove
 
-	  RSV_GOTO,
-	  RSV_RETURN,											 // 40
-	  RSV_EXIT,
+      RSV_JMPIFFALSE = 0x27,
+      RSV_JMPIFTRUE = 0x28,
 
-	  RSV_LOCAL,
-	  RSV_GLOBAL,
-	  RSV_VAR,
+      RSV_GOTO = 0x29,
+      RSV_RETURN = 0x2a,
+      RSV_EXIT = 0x2b,
 
-	  RSV_FUNCTION,										   // 45
+      RSV_LOCAL = 0x2c,
+      RSV_GLOBAL = 0x2d,
+      RSV_VAR = 0x2e,
 
-	  INS_DECLARE_ARRAY,
+      RSV_FUNCTION = 0x2f,
 
-	  TOK_FUNC,
-	  TOK_USERFUNC,
-	  TOK_ERROR,
-	  TOK_IN,												 // 50
-	  TOK_LOCALVAR,
-	  TOK_GLOBALVAR,
-	  INS_INITFOREACH,
-	  INS_STEPFOREACH,
-	  INS_CASEJMP,											// 55
-	  INS_GET_ARG,
-	  TOK_ARRAY,
+      INS_DECLARE_ARRAY = 0x30,
 
-	  INS_CALL_METHOD,
+      TOK_FUNC = 0x31,
+      TOK_USERFUNC = 0x32,
+      TOK_ERROR = 0x33,
+      TOK_IN = 0x34,
+      TOK_LOCALVAR = 0x35,
+      TOK_GLOBALVAR = 0x36,
+      INS_INITFOREACH = 0x37,
+      INS_STEPFOREACH = 0x38,
+      INS_CASEJMP = 0x39,
+      INS_GET_ARG = 0x3a,
+      TOK_ARRAY = 0x3b,
 
-	  TOK_DICTIONARY,										 // 60
-	  TOK_STACK,
-	  INS_INITFOR,
-	  INS_NEXTFOR,
-	  TOK_REFTO,
-	  INS_POP_PARAM_BYREF,									// 65
-	  TOK_MODULUS,
+      INS_CALL_METHOD = 0x3c,
 
-	  TOK_BSLEFT,
-	  TOK_BSRIGHT,
-	  TOK_BITAND,
-	  TOK_BITOR,
-	  TOK_BITXOR,
+      TOK_DICTIONARY = 0x3d,
+      TOK_STACK = 0x3e,
+      INS_INITFOR = 0x3f,
+      INS_NEXTFOR = 0x40,
+      TOK_REFTO = 0x41,
+      INS_POP_PARAM_BYREF = 0x42,
+      TOK_MODULUS = 0x43,
 
-	  TOK_STRUCT,											 // 70
-	  INS_SUBSCRIPT_ASSIGN,
-	  INS_SUBSCRIPT_ASSIGN_CONSUME,
-	  INS_MULTISUBSCRIPT,
-	  INS_MULTISUBSCRIPT_ASSIGN,
-	  INS_ASSIGN_LOCALVAR,									// 75
-	  INS_ASSIGN_GLOBALVAR,
+      TOK_BSLEFT = 0x44,
+      TOK_BSRIGHT = 0x45,
+      TOK_BITAND = 0x46,
+      TOK_BITOR = 0x47,
+      TOK_BITXOR = 0x48,
 
-	  INS_GET_MEMBER,
-	  INS_SET_MEMBER,
-	  INS_SET_MEMBER_CONSUME,
+      TOK_STRUCT = 0x49,
+      INS_SUBSCRIPT_ASSIGN = 0x4a,
+      INS_SUBSCRIPT_ASSIGN_CONSUME = 0x4b,
+      INS_MULTISUBSCRIPT = 0x4c,
+      INS_MULTISUBSCRIPT_ASSIGN = 0x4d,
+      INS_ASSIGN_LOCALVAR = 0x4e,
+      INS_ASSIGN_GLOBALVAR = 0x4f,
 
-	  INS_ADDMEMBER2,										 // 80
-	  INS_ADDMEMBER_ASSIGN,
-	  INS_UNINIT,
-	  INS_DICTIONARY_ADDMEMBER,
+      INS_GET_MEMBER = 0x50,
+      INS_SET_MEMBER = 0x51,
+      INS_SET_MEMBER_CONSUME = 0x52,
 
-	  INS_GET_MEMBER_ID,
-	  INS_SET_MEMBER_ID,									  // 85
-	  INS_SET_MEMBER_ID_CONSUME,
-	  INS_CALL_METHOD_ID,
+      INS_ADDMEMBER2 = 0x53,
+      INS_ADDMEMBER_ASSIGN = 0x54,
+      INS_UNINIT = 0x55,
+      INS_DICTIONARY_ADDMEMBER = 0x56,
 
-	  TOK_EQUAL1,
+      INS_GET_MEMBER_ID = 0x57,
+      INS_SET_MEMBER_ID = 0x58,
+      INS_SET_MEMBER_ID_CONSUME = 0x59,
+      INS_CALL_METHOD_ID = 0x5a,
 
-	  INS_SET_MEMBER_ID_CONSUME_PLUSEQUAL,
-	  INS_SET_MEMBER_ID_CONSUME_MINUSEQUAL,
-	  INS_SET_MEMBER_ID_CONSUME_TIMESEQUAL,
-	  INS_SET_MEMBER_ID_CONSUME_DIVIDEEQUAL,
-	  INS_SET_MEMBER_ID_CONSUME_MODULUSEQUAL,
+      TOK_EQUAL1 = 0x5b,
 
-	  // TokenIds that aren't part of emitted code:
+      INS_SET_MEMBER_ID_CONSUME_PLUSEQUAL = 0x5c,
+      INS_SET_MEMBER_ID_CONSUME_MINUSEQUAL = 0x5d,
+      INS_SET_MEMBER_ID_CONSUME_TIMESEQUAL = 0x5e,
+      INS_SET_MEMBER_ID_CONSUME_DIVIDEEQUAL = 0x5f,
+      INS_SET_MEMBER_ID_CONSUME_MODULUSEQUAL = 0x60,
 
-	  TOK_SEMICOLON = 256,
-	  TOK_COMMA,
-	  TOK_LPAREN,							 // used only by parser
-	  TOK_RPAREN,
-	  TOK_TERM,						// ID 24  // terminator, ';', etc.
-	  TOK_LBRACKET,
-	  TOK_RBRACKET,
-	  TOK_LBRACE,
-	  TOK_RBRACE,
+      // --- UPPER SPACE 0x0100-0xFFFF: TOKENS THAT AREN'T PART OF EMITTED CODE ---
+      //
+      // these can be safely renumbered any time, but must start from 0x100
 
-	  RSV_FOREACH,
-	  RSV_ENDFOREACH,		 // RSV_IN: use TOK_IN
+      TOK_SEMICOLON = 0x100,
+      TOK_COMMA,
+      TOK_LPAREN,
+      TOK_RPAREN,
+      TOK_TERM, // terminator, ';', etc.
+      TOK_LBRACKET,
+      TOK_RBRACKET,
+      TOK_LBRACE,
+      TOK_RBRACE,
 
-	  RSV_DECLARE,
-	  RSV_FUTURE,
-	  RSV_BREAK,
-	  RSV_CONTINUE,		// 270
-	  RSV_USE_MODULE,
-	  RSV_INCLUDE_FILE,
+      RSV_FOREACH,
+      RSV_ENDFOREACH, // RSV_IN: use TOK_IN
 
-	  RSV_FOR,
-	  RSV_NEXT,
-	  RSV_TO,
-	  RSV_STEP,
-	  RSV_THEN,
-	  RSV_ST_IF,
-	  RSV_ELSE,
-	  RSV_ELSEIF,		   // 280
-	  RSV_ENDIF,
-	  RSV_GOSUB,
-	  RSV_BEGIN,
-	  RSV_ENDB,
-	  RSV_DO,
-	  RSV_WHILE,
-	  RSV_OPTION_BRACKETED,
+      RSV_DECLARE,
+      RSV_FUTURE,
+      RSV_BREAK,
+      RSV_CONTINUE,
+      RSV_USE_MODULE,
+      RSV_INCLUDE_FILE,
 
-	  CTRL_LABEL,	// LABEL:
-	  CTRL_NOTHING,
-	  RSV_CONST,			// 290
-	  RSV_ENDWHILE,
-	  RSV_REPEAT,
-	  RSV_UNTIL,
-	  RSV_ENDFOR,
-	  RSV_ENDFUNCTION,
+      RSV_FOR,
+      RSV_NEXT,
+      RSV_TO,
+      RSV_STEP,
+      RSV_THEN,
+      RSV_ST_IF,
+      RSV_ELSE,
+      RSV_ELSEIF,
+      RSV_ENDIF,
+      RSV_GOSUB,
+      RSV_BEGIN,
+      RSV_ENDB,
+      RSV_DO,
+      RSV_WHILE,
+      RSV_OPTION_BRACKETED,
 
-	  RSV_SWITCH,
-	  RSV_CASE,
-	  RSV_DEFAULT,
-	  RSV_ENDSWITCH,
+      CTRL_LABEL, // LABEL:
+      CTRL_NOTHING,
+      RSV_CONST,
+      RSV_ENDWHILE,
+      RSV_REPEAT,
+      RSV_UNTIL,
+      RSV_ENDFOR,
+      RSV_ENDFUNCTION,
 
-	  RSV_COLON,			 // 300
-	  RSV_PROGRAM,
-	  RSV_ENDPROGRAM,
-	  RSV_ENUM,
-	  RSV_ENDENUM,
-	  RSV_EXPORTED,
-	  TOK_MEMBER,
-	  TOK_DICTKEY,
-	  RSV_DOWHILE,
+      RSV_SWITCH,
+      RSV_CASE,
+      RSV_DEFAULT,
+      RSV_ENDSWITCH,
 
-	  TOK_UNUSED
-	};
+      RSV_COLON,
+      RSV_PROGRAM,
+      RSV_ENDPROGRAM,
+      RSV_ENUM,
+      RSV_ENDENUM,
+      RSV_EXPORTED,
+      TOK_MEMBER,
+      TOK_DICTKEY,
+      RSV_DOWHILE,
 
-	enum ESCRIPT_CASE_TYPES
-	{
-	  CASE_TYPE_LONG = 255,
-	  CASE_TYPE_DEFAULT = 254,
-	  CASE_STRING_MAXLEN = 253
-	};
+      TOK_UNUSED,
+    };
+
+    enum ESCRIPT_CASE_TYPES : u8
+    {
+      CASE_TYPE_LONG = 255,
+      CASE_TYPE_DEFAULT = 254,
+      CASE_STRING_MAXLEN = 253
+    };
+
   }
 }
 #endif

--- a/pol-core/bscript/tokens.h
+++ b/pol-core/bscript/tokens.h
@@ -62,6 +62,11 @@ namespace Pol {
       TYP_NUMTYPES = 0x21,
     };
 
+    inline std::ostream& operator<<( std::ostream& out, const BTokenType& tok )
+    {
+      return out << static_cast<int>(tok);
+    }
+
     /**
      * The token ID: what this token is
      *
@@ -271,6 +276,11 @@ namespace Pol {
 
       TOK_UNUSED,
     };
+
+    inline std::ostream& operator<<( std::ostream& out, const BTokenId& tok )
+    {
+      return out << static_cast<int>(tok);
+    }
 
     enum ESCRIPT_CASE_TYPES : u8
     {

--- a/pol-core/bscript/tokens.h
+++ b/pol-core/bscript/tokens.h
@@ -11,10 +11,12 @@ Notes
 #define __TOKENS_H
 
 #include "../clib/rawtypes.h"
+#include "../clib/stlutil.h"
+
 
 namespace Pol {
-  namespace Bscript {
 
+  namespace Bscript {
     /**
      * The token type
      *
@@ -276,7 +278,12 @@ namespace Pol {
       CASE_TYPE_DEFAULT = 254,
       CASE_STRING_MAXLEN = 253
     };
-
   }
+
+  namespace Clib {
+    template <> std::string tostring( const Bscript::BTokenType& v );
+    template <> std::string tostring( const Bscript::BTokenId& v );
+  }
+
 }
 #endif

--- a/pol-core/pol/accounts/acscrobj.cpp
+++ b/pol-core/pol/accounts/acscrobj.cpp
@@ -65,7 +65,7 @@ namespace Pol {
 	{
 	  return "AccountRef";
 	}
-	int AccountObjImp::typeOfInt() const
+	u8 AccountObjImp::typeOfInt() const
 	{
 	  return OTAccountRef;
 	}

--- a/pol-core/pol/accounts/acscrobj.h
+++ b/pol-core/pol/accounts/acscrobj.h
@@ -41,7 +41,7 @@ namespace Pol {
 		Bscript::BApplicObj< AccountPtrHolder >( &accountobjimp_type, other )
 	  {}
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;

--- a/pol-core/pol/binaryfilescrobj.h
+++ b/pol-core/pol/binaryfilescrobj.h
@@ -79,7 +79,7 @@ namespace Pol {
 	  virtual std::string getStringRep() const POL_OVERRIDE;
       virtual size_t sizeEstimate() const POL_OVERRIDE;
 	  virtual const char* typeOf() const POL_OVERRIDE { return "BinaryFile"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTBinaryFile; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTBinaryFile; }
 	  virtual bool isTrue() const POL_OVERRIDE;
 	  virtual bool isEqual( const Bscript::BObjectImp& objimp ) const POL_OVERRIDE;
 

--- a/pol-core/pol/exscrobj.cpp
+++ b/pol-core/pol/exscrobj.cpp
@@ -45,7 +45,7 @@ namespace Pol {
 	{
 	  return "ScriptExRef";
 	}
-	int ScriptExObjImp::typeOfInt() const
+	u8 ScriptExObjImp::typeOfInt() const
 	{
 	  return OTScriptExRef;
 	}

--- a/pol-core/pol/exscrobj.h
+++ b/pol-core/pol/exscrobj.h
@@ -30,7 +30,7 @@ namespace Pol {
 	public:
 	  explicit ScriptExObjImp( UOExecutor* uoexec );
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -4252,11 +4252,8 @@ namespace Pol {
     */
     void Character::addBuff( u16 icon, u16 duration, u32 cl_name, u32 cl_descr, std::vector<u32> arguments )
     {
-      if( client != NULL && buffs_.find(icon) != buffs_.end() )
-      {
-        // Icon is already present, must send a remove packet first or client will not update
-        send_buff_message( this, icon, false );
-      }
+      // Icon is already present, must send a remove packet first or client will not update
+      delBuff(icon);
 
       Core::gameclock_t end = Core::read_gameclock() + duration;
       buffs_[icon] = { end, cl_name, cl_descr, arguments };
@@ -4386,6 +4383,8 @@ namespace Pol {
 
       size += 3 * sizeof(void*)+to_be_reportable_.size() * ( sizeof(USERIAL)+3 * sizeof( void* ) );
       size += 3 * sizeof(void*)+reportable_.size() * ( sizeof(reportable_t)+3 * sizeof( void* ) );
+
+      size += 3 * sizeof(void*) + buffs_.size() * ( sizeof(u16) + sizeof(Buff) + sizeof(void*) );
 
       return size;
 

--- a/pol-core/pol/module/cfgmod.cpp
+++ b/pol-core/pol/module/cfgmod.cpp
@@ -101,7 +101,7 @@ namespace Pol {
 	{
 	  return "ConfigFileRef";
 	}
-	int EConfigFileRefObjImp::typeOfInt() const
+	u8 EConfigFileRefObjImp::typeOfInt() const
 	{
 	  return OTConfigFileRef;
 	}
@@ -118,7 +118,7 @@ namespace Pol {
 	{
 	  return "ConfigElemRef";
 	}
-	int EConfigElemRefObjImp::typeOfInt() const
+	u8 EConfigElemRefObjImp::typeOfInt() const
 	{
 	  return OTConfigElemRef;
 	}

--- a/pol-core/pol/module/cfgmod.h
+++ b/pol-core/pol/module/cfgmod.h
@@ -58,7 +58,7 @@ namespace Pol {
 	  EConfigFileRefObjImp( ref_ptr<Core::StoredConfigFile> rcfile );
 	  virtual Bscript::BObjectRef OperSubscript( const Bscript::BObject& obj ) POL_OVERRIDE;
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy() const POL_OVERRIDE;
 	};
 
@@ -73,7 +73,7 @@ namespace Pol {
 	  virtual Bscript::BObjectRef get_member( const char* membername ) POL_OVERRIDE;
 	  virtual Bscript::BObjectRef get_member_id( const int id ) POL_OVERRIDE; //id test
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy() const POL_OVERRIDE;
 	};
 

--- a/pol-core/pol/module/datastore.cpp
+++ b/pol-core/pol/module/datastore.cpp
@@ -250,7 +250,7 @@ namespace Pol {
 	{
 	  return "DataFileRef";
 	}
-	int DataFileRefObjImp::typeOfInt() const
+	u8 DataFileRefObjImp::typeOfInt() const
 	{
 	  return OTDataFileRef;
 	}
@@ -361,7 +361,7 @@ namespace Pol {
 	{
 	  return "DataElemRef";
 	}
-	int DataElemRefObjImp::typeOfInt() const
+	u8 DataElemRefObjImp::typeOfInt() const
 	{
 	  return OTDataElemRef;
 	}

--- a/pol-core/pol/module/datastoreimp.h
+++ b/pol-core/pol/module/datastoreimp.h
@@ -85,7 +85,7 @@ namespace Pol {
 	  explicit DataFileRefObjImp( DataFileContentsRef dfref );
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy() const POL_OVERRIDE;
 
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
@@ -111,7 +111,7 @@ namespace Pol {
 	public:
 	  DataElemRefObjImp( DataFileContentsRef dfcontents, DataFileElementRef dflem );
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy() const POL_OVERRIDE;
 
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;

--- a/pol-core/pol/module/guildmod.cpp
+++ b/pol-core/pol/module/guildmod.cpp
@@ -88,7 +88,7 @@ namespace Pol {
 	public:
 	  EGuildRefObjImp( Core::GuildRef gref );
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual BObjectImp* copy() const POL_OVERRIDE;
 	  virtual bool isTrue() const POL_OVERRIDE;
 	  virtual bool isEqual( const BObjectImp& objimp ) const POL_OVERRIDE;
@@ -109,7 +109,7 @@ namespace Pol {
 	{
 	  return "GuildRef";
 	}
-	int EGuildRefObjImp::typeOfInt() const
+	u8 EGuildRefObjImp::typeOfInt() const
 	{
 	  return OTGuildRef;
 	}

--- a/pol-core/pol/module/npcmod.cpp
+++ b/pol-core/pol/module/npcmod.cpp
@@ -154,7 +154,7 @@ namespace Pol {
       BoundingBoxObjImp( ) : BApplicObj<Mobile::BoundingBox>( &bounding_box_type ) {}
       explicit BoundingBoxObjImp( const Mobile::BoundingBox& b ) : BApplicObj<Mobile::BoundingBox>( &bounding_box_type, b ) {}
 	  virtual const char* typeOf() const POL_OVERRIDE { return "BoundingBox"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTBoundingBox; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTBoundingBox; }
 	  virtual BObjectImp* copy() const POL_OVERRIDE { return new BoundingBoxObjImp( value() ); }
 
 	};

--- a/pol-core/pol/module/partymod.cpp
+++ b/pol-core/pol/module/partymod.cpp
@@ -55,7 +55,7 @@ namespace Pol {
 	public:
 	  EPartyRefObjImp( Core::PartyRef pref );
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual BObjectImp* copy() const POL_OVERRIDE;
 	  virtual bool isTrue() const POL_OVERRIDE;
 	  virtual bool isEqual( const BObjectImp& objimp ) const POL_OVERRIDE;
@@ -73,7 +73,7 @@ namespace Pol {
 	{
 	  return "PartyRef";
 	}
-	int EPartyRefObjImp::typeOfInt() const
+	u8 EPartyRefObjImp::typeOfInt() const
 	{
 	  return OTPartyRef;
 	}

--- a/pol-core/pol/module/polsystemmod.cpp
+++ b/pol-core/pol/module/polsystemmod.cpp
@@ -78,7 +78,7 @@ namespace Pol {
     public:
       explicit PackageObjImp( const PackagePtrHolder& other );
       virtual const char* typeOf() const POL_OVERRIDE;
-      virtual int typeOfInt() const POL_OVERRIDE;
+      virtual u8 typeOfInt() const POL_OVERRIDE;
       virtual Bscript::BObjectImp* copy() const POL_OVERRIDE;
       virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
       virtual Bscript::BObjectRef get_member( const char* membername ) POL_OVERRIDE;
@@ -122,7 +122,7 @@ namespace Pol {
 	{
 	  return "Package";
 	}
-	int PackageObjImp::typeOfInt() const
+	u8 PackageObjImp::typeOfInt() const
 	{
 	  return OTPackage;
 	}

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -182,7 +182,7 @@ namespace Pol {
 	public:
 	  EMenuObjImp( const Menu& m ) : BApplicObj<Menu>( &menu_type, m ) {}
 	  virtual const char* typeOf() const POL_OVERRIDE { return "MenuRef"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTMenuRef; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTMenuRef; }
 	  virtual BObjectImp* copy() const POL_OVERRIDE { return new EMenuObjImp( value() ); }
 	};
 

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -1636,7 +1636,7 @@ namespace Pol {
 	  virtual std::string getStringRep() const POL_OVERRIDE;
 	  virtual size_t sizeEstimate() const POL_OVERRIDE { return sizeof( PolCore ); }
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	private:
 	  // not implemented:
 	  PolCore& operator=( const PolCore& );
@@ -1659,7 +1659,7 @@ namespace Pol {
 	{
 	  return "PolCoreRef";
 	}
-	int PolCore::typeOfInt() const
+	u8 PolCore::typeOfInt() const
 	{
 	  return OTPolCoreRef;
 	}

--- a/pol-core/pol/packetscrobj.h
+++ b/pol-core/pol/packetscrobj.h
@@ -41,7 +41,7 @@ namespace Pol {
 	  Bscript::BObjectImp* SetSize( u16 newsize, bool giveReturn );
       virtual size_t sizeEstimate( ) const POL_OVERRIDE { return sizeof( *this ) + 3 * sizeof(void*) * buffer.capacity( ) * sizeof( unsigned char ); }
 	  virtual const char* typeOf() const POL_OVERRIDE { return "Packet"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTPacket; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTPacket; }
 
 	  bool is_variable_length;
 	};

--- a/pol-core/pol/poldbg.cpp
+++ b/pol-core/pol/poldbg.cpp
@@ -154,7 +154,7 @@ namespace Pol {
 	public:
 	  explicit DebugContextObjImp( ref_ptr<DebugContext> rcdctx );
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual BObjectImp* copy() const POL_OVERRIDE;
 	  virtual BObjectImp* call_method( const char* methodname, Executor& ex ) POL_OVERRIDE;
 	  virtual BObjectRef get_member( const char* membername ) POL_OVERRIDE;
@@ -166,7 +166,7 @@ namespace Pol {
 	{
 	  return "DebugContext";
 	}
-	int DebugContextObjImp::typeOfInt() const
+	u8 DebugContextObjImp::typeOfInt() const
 	{
 	  return OTDebugContext;
 	}

--- a/pol-core/pol/sqlscrobj.h
+++ b/pol-core/pol/sqlscrobj.h
@@ -66,7 +66,7 @@ namespace Pol {
       virtual std::string getStringRep() const POL_OVERRIDE { return "SQLRow"; }
       virtual size_t sizeEstimate( ) const POL_OVERRIDE { return sizeof( *this ) + sizeof(MYSQL_FIELD); }
       virtual const char* typeOf() const POL_OVERRIDE { return "SQLRow"; }
-      virtual int typeOfInt() const POL_OVERRIDE { return OTSQLRow; }
+      virtual u8 typeOfInt() const POL_OVERRIDE { return OTSQLRow; }
       virtual bool isTrue() const POL_OVERRIDE { return _row != 0; };
       virtual Bscript::BObjectRef OperSubscript( const Bscript::BObject& obj ) POL_OVERRIDE;
 
@@ -91,7 +91,7 @@ namespace Pol {
       virtual std::string getStringRep() const POL_OVERRIDE;
       virtual size_t sizeEstimate( ) const POL_OVERRIDE { return sizeof( *this ) + sizeof( MYSQL_FIELD); }
       virtual const char* typeOf() const POL_OVERRIDE { return "SQLResultSet"; }
-      virtual int typeOfInt() const POL_OVERRIDE { return OTSQLResultSet; }
+      virtual u8 typeOfInt() const POL_OVERRIDE { return OTSQLResultSet; }
       virtual bool isTrue() const POL_OVERRIDE;
       // virtual BObjectRef OperSubscript( const BObject& obj );
 
@@ -132,7 +132,7 @@ namespace Pol {
       virtual std::string getStringRep() const POL_OVERRIDE;
       virtual size_t sizeEstimate() const POL_OVERRIDE { return sizeof( *this )+_error.capacity(); }
       virtual const char* typeOf() const POL_OVERRIDE { return "SQLConnection"; }
-      virtual int typeOfInt() const POL_OVERRIDE { return OTSQLConnection; }
+      virtual u8 typeOfInt() const POL_OVERRIDE { return OTSQLConnection; }
       virtual bool isTrue() const POL_OVERRIDE;
       // virtual BObjectRef OperSubscript( const BObject& obj );
 

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -120,7 +120,7 @@ namespace Pol {
 	{
 	  return "MobileRef";
 	}
-	int ECharacterRefObjImp::typeOfInt() const
+	u8 ECharacterRefObjImp::typeOfInt() const
 	{
 	  return OTMobileRef;
 	}
@@ -280,7 +280,7 @@ namespace Pol {
 	{
 	  return "OfflineMobileRef";
 	}
-	int EOfflineCharacterRefObjImp::typeOfInt() const
+	u8 EOfflineCharacterRefObjImp::typeOfInt() const
 	{
 	  return OTOfflineMobileRef;
 	}
@@ -299,7 +299,7 @@ namespace Pol {
 	{
 	  return "ItemRef";
 	}
-	int EItemRefObjImp::typeOfInt() const
+	u8 EItemRefObjImp::typeOfInt() const
 	{
 	  return OTItemRef;
 	}
@@ -459,7 +459,7 @@ namespace Pol {
 	{
 	  return "BoatRef";
 	}
-	int EUBoatRefObjImp::typeOfInt() const
+	u8 EUBoatRefObjImp::typeOfInt() const
 	{
 	  return OTBoatRef;
 	}
@@ -622,7 +622,7 @@ namespace Pol {
 	{
 	  return "MultiRef";
 	}
-	int EMultiRefObjImp::typeOfInt() const
+	u8 EMultiRefObjImp::typeOfInt() const
 	{
 	  return OTMultiRef;
 	}
@@ -3765,7 +3765,7 @@ namespace Pol {
     {
       return "ClientRef";
     }
-    int EClientRefObjImp::typeOfInt() const
+    u8 EClientRefObjImp::typeOfInt() const
     {
       return OTClientRef;
     }

--- a/pol-core/pol/uoscrobj.h
+++ b/pol-core/pol/uoscrobj.h
@@ -61,7 +61,7 @@ namespace Pol {
 	  virtual ~ECharacterRefObjImp( ) { --Core::stateManager.uobjcount.uobj_count_echrref; }
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;
@@ -85,7 +85,7 @@ namespace Pol {
 	  {}
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 
 	  virtual bool isTrue() const POL_OVERRIDE;
@@ -114,7 +114,7 @@ namespace Pol {
 	  {}
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;
@@ -138,7 +138,7 @@ namespace Pol {
 	  {}
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;
@@ -161,7 +161,7 @@ namespace Pol {
 	  {}
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectRef get_member( const char* membername ) POL_OVERRIDE;
 	  virtual Bscript::BObjectRef get_member_id( const int id ) POL_OVERRIDE; //id test
@@ -201,7 +201,7 @@ namespace Pol {
 
 
 	  virtual const char* typeOf() const POL_OVERRIDE;
-	  virtual int typeOfInt() const POL_OVERRIDE;
+	  virtual u8 typeOfInt() const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* copy( ) const POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method( const char* methodname, Bscript::Executor& ex ) POL_OVERRIDE;
 	  virtual Bscript::BObjectImp* call_method_id( const int id, Bscript::Executor& ex, bool forcebuiltin = false ) POL_OVERRIDE;

--- a/pol-core/pol/xmlfilescrobj.h
+++ b/pol-core/pol/xmlfilescrobj.h
@@ -60,7 +60,7 @@ namespace Pol {
 	  virtual std::string getStringRep() const POL_OVERRIDE;
       virtual size_t sizeEstimate( ) const POL_OVERRIDE { return sizeof( *this ) + _filename.capacity(); }
 	  virtual const char* typeOf() const POL_OVERRIDE { return "XMLFile"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTXMLFile; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTXMLFile; }
 	  virtual bool isTrue() const POL_OVERRIDE;
       virtual Bscript::BObjectRef OperSubscript( const Bscript::BObject& obj ) POL_OVERRIDE;
       virtual Bscript::ContIterator* createIterator( Bscript::BObject* pIterVal ) POL_OVERRIDE
@@ -88,7 +88,7 @@ namespace Pol {
 	  virtual std::string getStringRep() const POL_OVERRIDE;
 
 	  virtual const char* typeOf() const POL_OVERRIDE { return "XMLNode"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTXMLNode; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTXMLNode; }
 
 	  virtual size_t sizeEstimate() const POL_OVERRIDE
 	  {
@@ -126,7 +126,7 @@ namespace Pol {
 	  }
 
 	  virtual const char* typeOf() const POL_OVERRIDE { return "XMLAttributes"; }
-	  virtual int typeOfInt() const POL_OVERRIDE { return OTXMLAttributes; }
+	  virtual u8 typeOfInt() const POL_OVERRIDE { return OTXMLAttributes; }
 	  virtual size_t sizeEstimate() const POL_OVERRIDE { return sizeof( *this ); }
 
       virtual Bscript::ContIterator* createIterator( Bscript::BObject* pIterVal ) POL_OVERRIDE


### PR DESCRIPTION
This pull request aims at saving a bit of memory, improving robustness and backward compatibility meanwhile.

This is a very easy mod: apart from changing a lot of lines accordingly, I've just shrinked 3 enums to more fit sizes.

Total memory saving should be 5 bytes for each instruction in the loaded scripts + 3 bytes for each object.

IMPORTANT:
This pull quest is 2 commits only. If it grows, just ignore the rest. Last involved commit is cb4da6e.