### PR TITLE
+Added: _DEFAULT_TEXT_REQUIREDCMD := 0 to uo.em which allows to set a…

### DIFF
--- a/docs/docs.polserver.com/pol099/corechanges.xml
+++ b/docs/docs.polserver.com/pol099/corechanges.xml
@@ -1,21 +1,23 @@
-﻿<?xml version="1.0" ?>
+<?xml version="1.0" ?>
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>05-28-2017</datemodified>
+		<datemodified>07-24-2017</datemodified>
 	</header>
 	<version name="POL099">
 		<entry>
 			<date>07-23-2017</date>
 			<author>DevGIB:</author>
 			<change type="Added">_DEFAULT_TEXT_REQUIREDCMD := 0 to uo.em which allows to set a minimum cmd level that broadcasts will be sent to.</change>
-			<change type="Changed">Changed Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD )<br/>
+			<change type="Changed">Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD )<br/>
 adding requiredcmdlevel argument which allows you to set a minimum cmd level that the broadcast will be sent to.</change>
+			<change type="Changed">No longer require a PID for GetProcess( pid  := &quot;&quot; ), not selecting a PID will use the PID of the parent script.</change>
 		</entry>
 		<entry>
-			<date>07-19-2017</date>
-			<author>DevGIB:</author>
-			<change type="Changed">No longer require a PID for GetProcess( pid  := &quot;&quot; ), not selecting a PID will use the PID of the parent script.</change>
+			<date>07-17-2017</date>
+			<author>Kevin:</author>
+			<change type="Fixed">PrintTextAbove*CL() now behaves similarly to PrintTextAbove*() functions, displaying the<br/>
+object's description instead of &quot;System&quot;.</change>
 		</entry>
 		<entry>
 			<date>05-28-2017</date>

--- a/docs/docs.polserver.com/pol099/corechanges.xml
+++ b/docs/docs.polserver.com/pol099/corechanges.xml
@@ -1,10 +1,22 @@
-<?xml version="1.0" ?>
+﻿<?xml version="1.0" ?>
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
 		<datemodified>05-28-2017</datemodified>
 	</header>
 	<version name="POL099">
+		<entry>
+			<date>07-23-2017</date>
+			<author>DevGIB:</author>
+			<change type="Added">_DEFAULT_TEXT_REQUIREDCMD := 0 to uo.em which allows to set a minimum cmd level that broadcasts will be sent to.</change>
+			<change type="Changed">Changed Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD )<br/>
+adding requiredcmdlevel argument which allows you to set a minimum cmd level that the broadcast will be sent to.</change>
+		</entry>
+		<entry>
+			<date>07-19-2017</date>
+			<author>DevGIB:</author>
+			<change type="Changed">No longer require a PID for GetProcess( pid  := &quot;&quot; ), not selecting a PID will use the PID of the parent script.</change>
+		</entry>
 		<entry>
 			<date>05-28-2017</date>
 			<author>Turley:</author>

--- a/docs/docs.polserver.com/pol099/osem.xml
+++ b/docs/docs.polserver.com/pol099/osem.xml
@@ -14,9 +14,10 @@
   </fileheader>
 
   <function name="GetProcess"> 
-    <prototype>GetProcess(pid)</prototype>
-    <parameter name="pid" value="Integer process ID of a script" />
+    <prototype>GetProcess(pid := 0)</prototype>
+    <parameter name="pid" value="Integer process ID of a script (optional)" />
     <explain>Gets a script process object for the given script's PID.</explain>
+    <explain>If no PID is supplied uses PID of parent script.</explain>
     <return>A Script object</return>
     <error>"Process not found"</error>
     <error>"Invalid parameter type"</error>

--- a/docs/docs.polserver.com/pol099/uoem.xml
+++ b/docs/docs.polserver.com/pol099/uoem.xml
@@ -184,6 +184,7 @@
 <constant>//  (and I don't know what for color)</constant>
 <constant>const _DEFAULT_TEXT_FONT     := 3;</constant>
 <constant>const _DEFAULT_TEXT_COLOR    := 1000;</constant>
+<constant>const _DEFAULT_TEXT_REQUIREDCMD    := 0;</constant>
 <constant> </constant>
 <constant>// Realms</constant>
 <constant>const _DEFAULT_REALM  := "britannia";</constant>
@@ -1159,11 +1160,12 @@ const TE_STYLE_NUMERICAL:= 2;</code></explain>
 </function>
 
 <function name="Broadcast">
-  <prototype>Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR )</prototype>
+  <prototype>Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredCmdLevel := _DEFAULT_TEXT_REQUIREDCMD )</prototype>
   <parameter name="text" value="String" />
   <parameter name="font" value="Integer (optional)" />
   <parameter name="color" value=" Integer (optional)" />
-  <explain>Sends text as a System Message to every online player. </explain>
+  <parameter name="requiredcmdlevel" value=" Integer (optional)" />
+  <explain>Sends text as a System Message to every online player whos cmd level is above requiredcmdlevel. </explain>
   <explain>See client.inc for font and color values.</explain>
   <return>1 on success</return>
   <error>none (returns 0 on invalid parameter) </error>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,10 @@
 ﻿-- POL099 --
+07-23-2017 DevGIB:
+  Added:   _DEFAULT_TEXT_REQUIREDCMD := 0 to uo.em which allows to set a minimum cmd level that broadcasts will be sent to.
+
+  Changed: Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD )
+           adding requiredcmdlevel argument which allows you to set a minimum cmd level that the broadcast will be sent to.
+  Changed: No longer require a PID for GetProcess( pid  := "" ), not selecting a PID will use the PID of the parent script.
 07-17-2017 Kevin:
   Fixed:   PrintTextAbove*CL() now behaves similarly to PrintTextAbove*() functions, displaying the
            object's description instead of "System".

--- a/pol-core/pol/module/osmod.cpp
+++ b/pol-core/pol/module/osmod.cpp
@@ -149,18 +149,15 @@ BObjectImp* OSExecutorModule::mf_debugger()
 BObjectImp* OSExecutorModule::getprocess()
 {
   int pid;
-  if ( getParam( 0, pid ) )
+  if ( !getParam( 0, pid ) )
   {
-    Core::UOExecutor* uoexec;
-    if ( find_uoexec( static_cast<unsigned int>( pid ), &uoexec ) )
-      return new Core::ScriptExObjImp( uoexec );
-    else
-      return new BError( "Process not found" );
+	  pid = pid_;
   }
-  else
-  {
-    return new BError( "Invalid parameter type" );
-  }
+	  Core::UOExecutor* uoexec;
+	  if (find_uoexec(static_cast<unsigned int>(pid), &uoexec))
+		  return new Core::ScriptExObjImp(uoexec);
+	  else
+		  return new BError("Process not found");
 }
 
 BObjectImp* OSExecutorModule::getpid()

--- a/pol-core/pol/module/unimod.cpp
+++ b/pol-core/pol/module/unimod.cpp
@@ -171,9 +171,11 @@ BObjectImp* UnicodeExecutorModule::mf_BroadcastUC()
   const String* lang;
   unsigned short font;
   unsigned short color;
+  unsigned short requiredCmdLevel;
   if ( getObjArrayParam( 0, oText ) && getStringParam( 1, lang ) &&
        getParam( 2, font ) &&  // todo: getFontParam
-       getParam( 3, color ) )  // todo: getColorParam
+       getParam( 3, color ) &&					// todo: getColorParam
+	   getParam( 4, requiredCmdLevel ) )        // todo: getRequiredCmdLevelParam
   {
     size_t textlen = oText->ref_arr.size();
     if ( textlen > SPEECH_MAX_LEN )
@@ -183,7 +185,7 @@ BObjectImp* UnicodeExecutorModule::mf_BroadcastUC()
     // lang->toUpper(); // Language codes are in upper-case :)
     if ( !Core::convertArrayToUC( oText, gwtext, textlen ) )
       return new BError( "Invalid value in Unicode array." );
-    Core::broadcast( gwtext, Clib::strupper( lang->value() ).c_str(), font, color );
+    Core::broadcast( gwtext, Clib::strupper( lang->value() ).c_str(), font, color, requiredCmdLevel );
     return new BLong( 1 );
   }
   else

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -549,11 +549,13 @@ BObjectImp* UOExecutorModule::broadcast()
   const char* text;
   unsigned short font;
   unsigned short color;
+  unsigned short requiredCmdLevel;
   text = exec.paramAsString( 0 );
-  if ( text && getParam( 1, font ) &&  // todo: getFontParam
-       getParam( 2, color ) )          // todo: getColorParam
+  if ( text && getParam( 1, font ) &&			// todo: getFontParam
+       getParam( 2, color ) &&					// todo: getColorParam
+	   getParam(3, requiredCmdLevel))          // todo: getRequiredCmdLevelParam
   {
-    Core::broadcast( text, font, color );
+    Core::broadcast( text, font, color, requiredCmdLevel);
     return new BLong( 1 );
   }
   else

--- a/pol-core/pol/uconst.h
+++ b/pol-core/pol/uconst.h
@@ -95,6 +95,7 @@ enum MOVEMODE : u8
 
 const unsigned short DEFAULT_TEXT_FONT = 3;
 const unsigned short DEFAULT_TEXT_COLOR = 0x3B2;
+const unsigned short DEFAULT_TEXT_REQUIREDCMD = 0;
 }
 }
 #endif /* UCONST_H */

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -1269,22 +1269,22 @@ void send_sysmessage( Network::Client* client, const std::wstring& wtext, const 
   send_sysmessage( client, uctext, lang, font, color );
 }
 
-void broadcast( const char* text, unsigned short font, unsigned short color )
+void broadcast( const char* text, unsigned short font, unsigned short color, unsigned short requiredCmdLevel )
 {
   for ( auto& client : networkManager.clients )
   {
-    if ( !client->ready )
+    if ( !client->ready || client->chr->cmdlevel_ < requiredCmdLevel)
       continue;
 
     send_sysmessage( client, text, font, color );
   }
 }
 
-void broadcast( const u16* wtext, const char lang[4], unsigned short font, unsigned short color )
+void broadcast( const u16* wtext, const char lang[4], unsigned short font, unsigned short color, unsigned short requiredCmdLevel )
 {
   for ( auto& client : networkManager.clients )
   {
-    if ( !client->ready )
+    if ( !client->ready || client->chr->cmdlevel_ < requiredCmdLevel)
       continue;
 
     send_sysmessage( client, wtext, lang, font, color );

--- a/pol-core/pol/ufunc.h
+++ b/pol-core/pol/ufunc.h
@@ -187,9 +187,9 @@ void send_sysmessage( Network::Client* client, const u16* wtext, const char lang
                       unsigned short font = DEFAULT_TEXT_FONT,
                       unsigned short color = DEFAULT_TEXT_COLOR );
 void broadcast( const char* text, unsigned short font = DEFAULT_TEXT_FONT,
-                unsigned short color = DEFAULT_TEXT_COLOR );
+                unsigned short color = DEFAULT_TEXT_COLOR, unsigned short requiredCmdLevel = DEFAULT_TEXT_REQUIREDCMD );
 void broadcast( const u16* wtext, const char lang[4], unsigned short font = DEFAULT_TEXT_FONT,
-                unsigned short color = DEFAULT_TEXT_COLOR );
+                unsigned short color = DEFAULT_TEXT_COLOR, unsigned short requiredCmdLevel = DEFAULT_TEXT_REQUIREDCMD );
 bool say_above( const UObject* obj, const char* text, unsigned short font = DEFAULT_TEXT_FONT,
                 unsigned short color = DEFAULT_TEXT_COLOR,
                 unsigned int journal_print = JOURNAL_PRINT_NAME );

--- a/pol-core/support/scripts/uo.em
+++ b/pol-core/support/scripts/uo.em
@@ -193,6 +193,7 @@ const RACE_GARGOYLE := 2;
 //  (and I don't know what for color)
 const _DEFAULT_TEXT_FONT     := 3;
 const _DEFAULT_TEXT_COLOR    := 1000;
+const _DEFAULT_TEXT_REQUIREDCMD    := 0;
 
 // Realms
 const _DEFAULT_REALM  		:= "britannia";
@@ -239,6 +240,7 @@ ApplyConstraint( objlist, configfile, propertyname, minvalue );
 AssignRectToWeatherRegion( region, xwest, ynorth, xeast, ysouth );
 Attach( character );
 Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR );
+Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD );
 CancelTarget( of_whom );
 CanWalk(movemode, x1, y1, z1, x2_or_dir, y2 := CANWALK_DIR, realm := _DEFAULT_REALM);
 CheckLineOfSight( object1, object2 );


### PR DESCRIPTION
… minimum cmd level that broadcasts will be sent to.

~Changed:Broadcast( text, font := _DEFAULT_TEXT_FONT, color := _DEFAULT_TEXT_COLOR, requiredcmdlevel := _DEFAULT_TEXT_REQUIREDCMD ) adding requiredcmdlevel argument which allows you to set a minimum cmd level that the broadcast will be sent to.
~Changed: No longer require a PID for GetProcess( pid  := &quot;&quot; ), not selecting a PID will use the PID of the parent script.