### PR TITLE
Update prepare_extlibs.bat

### DIFF
--- a/lib/prepare_extlibs.bat
+++ b/lib/prepare_extlibs.bat
@@ -12,6 +12,7 @@ for /f "usebackq delims=" %%i in (`%VCWHERE% -prerelease -latest -legacy -proper
   if exist "%%i\Common7\Tools\vsdevcmd.bat" (
     set VCVARSALL="%%i\Common7\Tools\vsdevcmd.bat"
 	set ARCHPARAM=-arch=%POLARCH%
+	set VSCMD_START_DIR=%CD%
   )
     if exist "%%i\VC\vcvarsall.bat" (
 	  set VCVARSALL="%%i\VC\vcvarsall.bat"


### PR DESCRIPTION
Update prepare_extlibs.bat to force vs2017 dev cmd to use current working directory.