### PR TITLE
Fix table width to display headings correctly.

### DIFF
--- a/docs/docs.polserver.com/pol100/objref.xslt
+++ b/docs/docs.polserver.com/pol100/objref.xslt
@@ -27,7 +27,7 @@
 		<div id="main">
 			<div class="container">
 				<div class="doc-mainbox">
-					<table class="doc-table" width="600px">
+					<table class="doc-table" width="700px">
 						<tr align="center">
 							<td>
 								<strong>


### PR DESCRIPTION
Made the base table 700px wide so that the additional entries don't wrap.