### PR TITLE
Fix overflow for buying from merchants

### DIFF
--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -345,7 +345,7 @@ unsigned int calculate_cost( Character* /*vendor*/, UContainer* for_sale, UConta
         continue;
     }
     // const ItemDesc& id = find_itemdesc(item->objtype_);
-    amt += cfBEu16( msg->items[i].number_bought ) * item->sellprice();
+    amt += cfBEu16( msg->items[i].number_bought ) * static_cast<uint64_t>( item->sellprice() );
 
     if ( amt < prev_amt || amt > INT_MAX )
     {

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -330,7 +330,7 @@ void send_clear_vendorwindow( Client* client, Character* vendor )
 unsigned int calculate_cost( Character* /*vendor*/, UContainer* for_sale, UContainer* bought,
                              PKTBI_3B* msg )
 {
-  unsigned int amt = 0, prev_amt = 0;
+  uint64_t amt = 0, prev_amt = 0;
 
   int nitems = ( cfBEu16( msg->msglen ) - offsetof( PKTBI_3B, items ) ) / sizeof msg->items[0];
 
@@ -347,13 +347,14 @@ unsigned int calculate_cost( Character* /*vendor*/, UContainer* for_sale, UConta
     // const ItemDesc& id = find_itemdesc(item->objtype_);
     amt += cfBEu16( msg->items[i].number_bought ) * item->sellprice();
 
-    if ( amt < prev_amt || amt > INT_MAX ) {
+    if ( amt < prev_amt || amt > INT_MAX )
+    {
       return INT_MAX + 1U;
     }
 
     prev_amt = amt;
   }
-  return amt;
+  return static_cast<uint32_t>( amt );
 }
 
 void oldBuyHandler( Client* client, PKTBI_3B* msg )


### PR DESCRIPTION
Handle overflow for vendor purchases. Will display a warning, and then stop the sale. 

![image](https://user-images.githubusercontent.com/8634912/51313766-aa649300-1a4e-11e9-8674-f965df8d1b99.png)

Solves issue #77 