### PR TITLE
Added:   uoconvert.exe will now surface the AnimID for equippables to…

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,13 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-21-2019</datemodified>
+		<datemodified>02-02-2019</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>02-02-2019</date>
+			<change type="Added">uoconvert.exe will now surface the AnimID for equippables to tiles.cfg. This can be used to look-up the gump pic for wearables that are displayed on the paper doll. Add this number to 50000 for male gumpart or 60000 for female gump art. The resulting number will be the gump art that is displayed in the paper doll.</change>
+		</entry>
 		<entry>
 			<date>01-21-2019</date>
 			<author>Nando:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+02-02-2019
+  Added:   uoconvert.exe will now surface the AnimID for equippables to tiles.cfg. This can be used to look-up the gump pic for wearables that are displayed on the paper doll. Add this number to 50000 for male gumpart or 60000 for female gump art. The resulting number will be the gump art that is displayed in the paper doll.
 01-21-2019 Nando:
   Changed: account.split() will now return an AccountRef to the new account instead of "true".
 01-17-2019 Kevin:

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -967,6 +967,8 @@ void UoConvertMain::create_tiles_cfg()
     fprintf( fp, "    UoFlags 0x%08lx\n", static_cast<unsigned long>( tile.flags ) );
     if ( tile.layer )
       fprintf( fp, "    Layer %u\n", tile.layer );
+    if ( flags & FLAG::EQUIPPABLE )
+      fprintf( fp, "    AnimID %u\n", tile.anim );
     fprintf( fp, "    Height %u\n", tile.height );
     fprintf( fp, "    Weight %u\n", tile.weight );
     write_flags( fp, flags );


### PR DESCRIPTION
… tiles.cfg. This can be used to look-up the gump pic for wearables that are displayed on the paper doll. Add this number to 50000 for male gumpart or 60000 for female gump art. The resulting number will be the gump art that is displayed in the paper doll.