### PR TITLE
Rectify core not clearing mobiles from client during shadow realm shift.

### DIFF
--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -373,6 +373,7 @@ void send_remove_character( Network::Client* client, const Mobile::Character* ch
   /* Don't remove myself */
   if ( client->chr == chr )
     return;
+  pkt.update(chr->serial_ext);
   pkt.Send( client );
 }
 


### PR DESCRIPTION
Added character reference on update when moving from 1 realm to another which appears to effect npc's and players not clearing when going to a shadow realm.