### PR TITLE
Add dummy packet handler for 0xFA and 0xFB

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>12-28-2019</datemodified>
+		<datemodified>12-29-2019</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>12-29-2019</date>
+			<author>Kevin:</author>
+			<change type="Added">Added definitions for packets 0xFA (Open UO Store) and 0xFB (Update View Public House Contents).</change>
+		</entry>
 		<entry>
 			<date>12-28-2019</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+12-29-2019 Kevin:
+  Added:   Added definitions for packets 0xFA (Open UO Store) and 0xFB (Update View Public House Contents).
 12-28-2019 Turley:
   Changed: house.house_parts member returns now when in edit mode the current (possible not yet confirmed)
            list of parts instead of an error.

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -410,6 +410,16 @@ void handle_update_range_change( Client* client, PKTBI_C8* /*msg*/ )
   handle_unknown_packet( client );
 }
 
+void handle_open_uo_store( Client* client, PKTIN_FA* /*msg*/ )
+{
+  handle_unknown_packet( client );
+}
+
+void handle_update_view_public_house_content( Client* client, PKTIN_FB* /*msg*/ )
+{
+  handle_unknown_packet( client );
+}
+
 void handle_allnames( Client* client, PKTBI_98_IN* msg )
 {
   u32 serial = cfBEu32( msg->serial );

--- a/pol-core/pol/network/msghandl.cpp
+++ b/pol-core/pol/network/msghandl.cpp
@@ -183,6 +183,8 @@ void PacketRegistry::initialize_msg_handlers()
   MESSAGE_HANDLER_VARLEN( PKTIN_E4, KR_Verifier_Response );
   MESSAGE_HANDLER( PKTIN_EF, handle_ef_seed );
   MESSAGE_HANDLER( PKTIN_F8, ClientCreateChar70160 );
+  MESSAGE_HANDLER( PKTIN_FA, handle_open_uo_store );
+  MESSAGE_HANDLER( PKTIN_FB, handle_update_view_public_house_content );
 
   initialize_extended_handlers();
 }

--- a/pol-core/pol/network/msghandl.h
+++ b/pol-core/pol/network/msghandl.h
@@ -169,6 +169,8 @@ void handle_action( Network::Client* client, PKTIN_12* cmd );
 void handle_cast_spell( Network::Client* client, PKTIN_12* msg );
 void handle_open_spellbook( Network::Client* client, PKTIN_12* msg );
 void handle_use_skill( Network::Client* client, PKTIN_12* msg );
+void handle_open_uo_store( Network::Client* client, PKTIN_FA* msg );
+void handle_update_view_public_house_content( Network::Client* client, PKTIN_FB* msg );
 }  // namespace Core
 }  // namespace Pol
 #endif

--- a/pol-core/pol/network/pktin.h
+++ b/pol-core/pol/network/pktin.h
@@ -564,6 +564,18 @@ struct PKTIN_F8
 };
 static_assert( sizeof( PKTIN_F8 ) == 106, "size missmatch" );
 
+struct PKTIN_FA
+{
+  u8 msgtype;  // Byte 0
+};
+static_assert( sizeof( PKTIN_FA ) == 1, "size missmatch" );
+
+struct PKTIN_FB
+{
+  u8 msgtype;  // Byte 0
+  u8 show;  // Bytes 1
+};
+static_assert( sizeof( PKTIN_FB ) == 2, "size missmatch" );
 
 #pragma pack( pop )
 }  // namespace Core

--- a/pol-core/pol/network/pktinid.h
+++ b/pol-core/pol/network/pktinid.h
@@ -60,7 +60,9 @@ enum PKTINID
   PKTIN_E1_ID = 0xE1,  // Client Type (UO3D)
   PKTIN_E4_ID = 0xE4,  // KR Encryption Request
   PKTIN_EF_ID = 0xEF,  // Seed Packet, introduced 6.0.5.0
-  PKTIN_F8_ID = 0xF8   // Create Character packet since 7.0.16.0
+  PKTIN_F8_ID = 0xF8,  // Create Character packet since 7.0.16.0
+  PKTIN_FA_ID = 0xFA,  // Open UO Store
+  PKTIN_FB_ID = 0xFB,  // Update View Public House Contents
 
 };
 }


### PR DESCRIPTION
Adds definitions for packets `0xFA` and `0xFB` and use the default `handle_unknown_packet` handler. 

When using the latest 7.0.83.27 client (and turning on `DisplayUnknownPackets`), we now see:

```
Client#2: Unknown packet type 0xFB, 2 bytes (IP: 127.0.0.1, Account: admin)
0000 fb 00                                              ........ ........

Client#2: Unknown packet type 0xFA, 1 bytes (IP: 127.0.0.1, Account: admin)
0000 fa                                                 ........ ........                                            ........ ........
```