### PR TITLE
Default pol.cfg UoDataFileRoot to Ultima Online install location on Windows

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -887,7 +887,7 @@ ItemMenu
     <requiredby>Core</requiredby>
     <purpose>Configures many critical options for the POL server.</purpose>
     <structure>
-UoDataFileRoot=(path to UO MUL files)
+UoDataFileRoot=(path to UO MUL files {see Windows-specific notes})
 WorldDataPath=(path to POL Data files {default data/})
 RealmDataPath=(path to POL Realm files {default realm/})
 PidFilePath=(where POL will write its .pid file {default ./})
@@ -958,6 +958,8 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [ShowWarningItem=(1/0 {default 1})]
 </structure>
     <explain>Your own pol.cfg should give descriptions on most of these. I'll describe them here if people want me to.</explain>
+    <explain>UoDataFileRoot: Directory where Ultima Online client files are located. Used by UOConvert.exe to find map, multi, tiledata, statics, etc. files.
+    On Windows, the setting will default to the directory of the Ultima Online installation found in the Windows Registry.</explain>
     ignition = uorice = none, 2.0.0x and due to autocalculation major.minor.build (no patch)
             e.g. 7.0.4 for latest client 7.0.4.1
             default for both is "none"

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-04-2020</datemodified>
+		<datemodified>01-12-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>01-12-2020</date>
+			<author>Kevin:</author>
+			<change type="Changed">On Windows, the pol.cfg setting UoDataFileRoot will now default to the directory of the Ultima Online installation found in<br/>
+the Windows Registry. This setting MUST be set for servers that do not have Ultima Online installed through the operating<br/>
+system, and MAY be set to use custom a client data files directory.</change>
+		</entry>
 		<entry>
 			<date>01-04-2020</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 ﻿-- POL100 --
+01-12-2020 Kevin:
+  Changed: On Windows, the pol.cfg setting UoDataFileRoot will now default to the directory of the Ultima Online installation found in
+           the Windows Registry. This setting MUST be set for servers that do not have Ultima Online installed through the operating
+           system, and MAY be set to use custom a client data files directory.
 01-04-2020 Turley:
     Fixed: Tabulator and newline chars where disallowed in CChr and the sanitize step of strings. (introduced with unicode support)
 01-03-2020 DevGIB: 

--- a/pol-core/plib/CMakeSources.cmake
+++ b/pol-core/plib/CMakeSources.cmake
@@ -52,6 +52,8 @@ set (plib_sources  # sorted !
   uofile06.cpp
   uofile07.cpp
   uofile08.cpp
+  uoinstallfinder.cpp
+  uoinstallfinder.h
   uopreader/uop.cpp
   uopreader/uop.h
   uopreader/uopfile.ksy

--- a/pol-core/plib/uoinstallfinder.cpp
+++ b/pol-core/plib/uoinstallfinder.cpp
@@ -116,7 +116,6 @@ std::string UOInstallFinder::getInstallDir()
 }
 
 
-
 }  // namespace Plib
 }  // namespace Pol
 

--- a/pol-core/plib/uoinstallfinder.cpp
+++ b/pol-core/plib/uoinstallfinder.cpp
@@ -1,0 +1,128 @@
+
+#include "uoinstallfinder.h"
+#include "../clib/cfgelem.h"
+#include "../clib/logfacility.h"
+#include <stdexcept>
+#include <string>
+
+namespace Pol
+{
+namespace Plib
+{
+std::string UOInstallFinder::remove_elem( Clib::ConfigElem& elem )
+{
+  std::string uodata_root = elem.remove_string( "UoDataFileRoot", "" );
+  if ( uodata_root == "" )
+  {
+    uodata_root = Plib::UOInstallFinder::getInstallDir();
+    if ( uodata_root == "" )
+    {
+      elem.throw_error(
+          "Property 'UoDataFileRoot' was not found, and no Ultima Online installation could be "
+          "found on the system." );
+    }
+
+    INFO_PRINT << "Using Ultima Online data files from installation directory " << uodata_root
+               << "\n";
+  }
+  return uodata_root;
+}
+}  // namespace Plib
+}  // namespace Pol
+
+
+#ifdef _WIN32
+
+#include "../clib/fileutil.h"
+
+#define WIN32_LEAN_AND_MEAN  // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+LONG GetStringRegKey( HKEY hKey, const std::string& strValueName, std::string& strValue )
+{
+  CHAR szBuffer[512];
+  DWORD dwBufferSize = sizeof( szBuffer );
+  ULONG nError;
+  nError = RegQueryValueExA( hKey, strValueName.c_str(), 0, NULL, (LPBYTE)szBuffer, &dwBufferSize );
+  if ( ERROR_SUCCESS == nError )
+  {
+    strValue = szBuffer;
+  }
+  return nError;
+}
+
+const std::vector<std::string> KNOWN_KEYS = {
+    "Electronic Arts\\EA Games\\Ultima Online Classic",
+    "Electronic Arts\\EA Games\\Ultima Online Stygian Abyss Classic",
+    "Origin Worlds Online\\Ultima Online\\KR Legacy Beta",
+    "Origin Worlds Online\\Ultima Online Samurai Empire\\3d\\1.0",
+    "Origin Worlds Online\\Ultima Online Samurai Empire\\2d\\1.0",
+    "Origin Worlds Online\\Ultima Online Samurai Empire BETA\\3d\\1.0",
+    "Origin Worlds Online\\Ultima Online Samurai Empire BETA\\2d\\1.0",
+    "EA Games\\Ultima Online: Mondain's Legacy\\1.0",
+    "EA Games\\Ultima Online: Mondain's Legacy\\1.00.0000",
+    "EA GAMES\\Ultima Online: Samurai Empire\\1.00.0000",
+    "EA Games\\Ultima Online: Mondain's Legacy",
+    "EA GAMES\\Ultima Online Samurai Empire\\1.00.0000",
+    "EA GAMES\\Ultima Online: Samurai Empire\\1.0",
+    "EA GAMES\\Ultima Online Samurai Empire",
+    "EA GAMES\\Ultima Online Samurai Empire\\1.0",
+    "Origin Worlds Online\\Ultima Online\\1.0",
+    "Origin Worlds Online\\Ultima Online Third Dawn\\1.0",
+};
+
+const std::vector<std::string> KNOWN_VALUES = {"ExePath", "Install Dir", "InstallDir"};
+
+#ifdef _WIN64
+const bool is64bit = true;
+#else
+const bool is64bit = false;
+#endif
+
+namespace Pol
+{
+namespace Plib
+{
+std::string UOInstallFinder::getInstallDir()
+{
+  HKEY hKey;
+  LONG lRes;
+  std::string installPath;
+  for ( auto it = KNOWN_KEYS.begin(); it != KNOWN_KEYS.end(); ++it )
+  {
+    auto keyPath = ( is64bit ? "SOFTWARE\\WOW6432Node\\" : "SOFTWARE\\" ) + *it;
+    lRes = RegOpenKeyExA( HKEY_LOCAL_MACHINE, keyPath.c_str(), 0, KEY_READ, &hKey );
+    if ( lRes != ERROR_SUCCESS )
+    {
+      lRes = RegOpenKeyExA( HKEY_CURRENT_USER, keyPath.c_str(), 0, KEY_READ, &hKey );
+      if ( lRes != ERROR_SUCCESS )
+        continue;
+    }
+    for ( auto valueItr = KNOWN_VALUES.begin(); valueItr != KNOWN_VALUES.end(); ++valueItr )
+    {
+      lRes = GetStringRegKey( hKey, *valueItr, installPath );
+      if ( lRes == ERROR_SUCCESS )
+      {
+        if ( Clib::IsDirectory( installPath.c_str() ) )
+        {
+          RegCloseKey( hKey );
+          return installPath;
+        }
+      }
+    }
+    RegCloseKey( hKey );
+  }
+  return "";
+}
+
+#else
+
+std::string UOInstallFinder::getInstallDir()
+{
+  return "";
+}
+
+#endif
+
+}  // namespace Plib
+}  // namespace Pol

--- a/pol-core/plib/uoinstallfinder.cpp
+++ b/pol-core/plib/uoinstallfinder.cpp
@@ -12,10 +12,10 @@ namespace Plib
 std::string UOInstallFinder::remove_elem( Clib::ConfigElem& elem )
 {
   std::string uodata_root = elem.remove_string( "UoDataFileRoot", "" );
-  if ( uodata_root == "" )
+  if ( uodata_root.empty() )
   {
     uodata_root = Plib::UOInstallFinder::getInstallDir();
-    if ( uodata_root == "" )
+    if ( uodata_root.empty() )
     {
       elem.throw_error(
           "Property 'UoDataFileRoot' was not found, and no Ultima Online installation could be "
@@ -115,6 +115,11 @@ std::string UOInstallFinder::getInstallDir()
   return "";
 }
 
+
+
+}  // namespace Plib
+}  // namespace Pol
+
 #else
 
 namespace Pol
@@ -129,6 +134,3 @@ std::string UOInstallFinder::getInstallDir()
 }  // namespace Pol
 
 #endif
-
-}  // namespace Plib
-}  // namespace Pol

--- a/pol-core/plib/uoinstallfinder.cpp
+++ b/pol-core/plib/uoinstallfinder.cpp
@@ -88,9 +88,9 @@ std::string UOInstallFinder::getInstallDir()
   HKEY hKey;
   LONG lRes;
   std::string installPath;
-  for ( auto it = KNOWN_KEYS.begin(); it != KNOWN_KEYS.end(); ++it )
+  for ( const auto& keyItr : KNOWN_KEYS )
   {
-    auto keyPath = ( is64bit ? "SOFTWARE\\WOW6432Node\\" : "SOFTWARE\\" ) + *it;
+    auto keyPath = ( is64bit ? "SOFTWARE\\WOW6432Node\\" : "SOFTWARE\\" ) + keyItr;
     lRes = RegOpenKeyExA( HKEY_LOCAL_MACHINE, keyPath.c_str(), 0, KEY_READ, &hKey );
     if ( lRes != ERROR_SUCCESS )
     {
@@ -98,9 +98,9 @@ std::string UOInstallFinder::getInstallDir()
       if ( lRes != ERROR_SUCCESS )
         continue;
     }
-    for ( auto valueItr = KNOWN_VALUES.begin(); valueItr != KNOWN_VALUES.end(); ++valueItr )
+    for ( const auto& valueItr : KNOWN_VALUES )
     {
-      lRes = GetStringRegKey( hKey, *valueItr, installPath );
+      lRes = GetStringRegKey( hKey, valueItr, installPath );
       if ( lRes == ERROR_SUCCESS )
       {
         if ( Clib::IsDirectory( installPath.c_str() ) )
@@ -117,10 +117,16 @@ std::string UOInstallFinder::getInstallDir()
 
 #else
 
+namespace Pol
+{
+namespace Plib
+{
 std::string UOInstallFinder::getInstallDir()
 {
   return "";
 }
+}  // namespace Plib
+}  // namespace Pol
 
 #endif
 

--- a/pol-core/plib/uoinstallfinder.h
+++ b/pol-core/plib/uoinstallfinder.h
@@ -1,0 +1,23 @@
+#ifndef UOINSTALLFINDER_H
+#define UOINSTALLFINDER_H
+
+#include <string>
+#include <vector>
+
+namespace Pol
+{
+namespace Clib
+{
+class ConfigElem;
+}
+namespace Plib
+{
+class UOInstallFinder
+{
+public:
+  static std::string getInstallDir();
+  static std::string remove_elem( Clib::ConfigElem& elem );
+};
+}  // namespace Plib
+}  // namespace Pol
+#endif

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -30,6 +30,7 @@
 #include "../clib/passert.h"
 #include "../clib/strutil.h"
 #include "../plib/systemstate.h"
+#include "../plib/uoinstallfinder.h"
 // TODO: get rid of the dependencies and move to plib
 #include "core.h"           // todo save_full does not belong here
 #include "globals/state.h"  // todo polsig dependency
@@ -56,7 +57,7 @@ void PolConfig::read_pol_config( bool initial_load )
     stat( "pol.cfg", &pol_cfg_stat );
 
     // these config options can't change after startup.
-    Plib::systemstate.config.uo_datafile_root = elem.remove_string( "UoDataFileRoot" );
+    Plib::systemstate.config.uo_datafile_root = Plib::UOInstallFinder::remove_elem( elem );
     Plib::systemstate.config.uo_datafile_root =
         Clib::normalized_dir_form( Plib::systemstate.config.uo_datafile_root );
 

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -6,6 +6,11 @@
 # UoDataFileRoot: where the UO client files are located.
 # Used by UOConvert.exe to find map, multi, tiledata, statics, etc. files.
 #
+# On Windows, the pol.cfg setting UoDataFileRoot will default to the directory of the Ultima Online
+#  installation found in the Windows Registry. This setting MUST be set for servers that do not have
+#  Ultima Online installed through the operating system, and MAY be set to use custom a client data
+#  files directory.
+#
 UoDataFileRoot=MUL
 
 #

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -10,8 +10,8 @@
 #  installation found in the Windows Registry. This setting MUST be set for servers that do not have
 #  Ultima Online installed through the operating system, and MAY be set to use custom a client data
 #  files directory.
-#
-UoDataFileRoot=MUL
+# On Linux, you MUST set this to the correct Ultima Online client files directory.
+UoDataFileRoot=
 
 #
 # Used to tell POL where to look for the realm data that was made by uoconvert.

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -26,6 +26,7 @@
 #include "../plib/udatfile.h"
 #include "../plib/uofile.h"
 #include "../plib/uofilei.h"
+#include "../plib/uoinstallfinder.h"
 #include "../plib/uopreader/uop.h"
 #include "../plib/uopreader/uophash.h"
 #include "../plib/ustruct.h"
@@ -1224,7 +1225,7 @@ void UoConvertMain::setup_uoconvert()
   std::string uodata_root = programArgsFindEquals( "uodata=", "" );
   unsigned short max_tile =
       static_cast<unsigned short>( programArgsFindEquals( "maxtileid=", 0x0, true ) );
-  
+
   // if any of the two is missing, read from pol.cfg
   if ( uodata_root.empty() || !max_tile )
   {
@@ -1235,15 +1236,15 @@ void UoConvertMain::setup_uoconvert()
     cf.readraw( elem );
 
     if ( uodata_root.empty() )
-      uodata_root = elem.remove_string( "UoDataFileRoot" );
+      uodata_root = Plib::UOInstallFinder::remove_elem( elem );
 
     if ( !max_tile )
       max_tile = elem.remove_ushort( "MaxTileID", 0x0 );
   }
-  
+
   if ( max_tile != UOBJ_DEFAULT_MAX && max_tile != UOBJ_SA_MAX && max_tile != UOBJ_HSA_MAX )
     max_tile = UOBJ_DEFAULT_MAX;
-  
+
   // Save the parameters into this ugly global state we have
   Plib::systemstate.config.max_tile_id = max_tile;
   Plib::systemstate.config.uo_datafile_root = Clib::normalized_dir_form( uodata_root );

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -1225,7 +1225,7 @@ void UoConvertMain::setup_uoconvert()
   std::string uodata_root = programArgsFindEquals( "uodata=", "" );
   unsigned short max_tile =
       static_cast<unsigned short>( programArgsFindEquals( "maxtileid=", 0x0, true ) );
-
+  
   // if any of the two is missing, read from pol.cfg
   if ( uodata_root.empty() || !max_tile )
   {
@@ -1241,10 +1241,10 @@ void UoConvertMain::setup_uoconvert()
     if ( !max_tile )
       max_tile = elem.remove_ushort( "MaxTileID", 0x0 );
   }
-
+  
   if ( max_tile != UOBJ_DEFAULT_MAX && max_tile != UOBJ_SA_MAX && max_tile != UOBJ_HSA_MAX )
     max_tile = UOBJ_DEFAULT_MAX;
-
+  
   // Save the parameters into this ugly global state we have
   Plib::systemstate.config.max_tile_id = max_tile;
   Plib::systemstate.config.uo_datafile_root = Clib::normalized_dir_form( uodata_root );

--- a/pol-core/uotool/UoToolMain.cpp
+++ b/pol-core/uotool/UoToolMain.cpp
@@ -26,6 +26,7 @@
 #include "../plib/udatfile.h"
 #include "../plib/uofile.h"
 #include "../plib/uofilei.h"
+#include "../plib/uoinstallfinder.h"
 #include "../plib/ustruct.h"
 #include "../pol/globals/multidefs.h"
 #include "../pol/multi/multidef.h"
@@ -1219,7 +1220,7 @@ int UoToolMain::main()
 
   cf.readraw( elem );
 
-  Plib::systemstate.config.uo_datafile_root = elem.remove_string( "UoDataFileRoot" );
+  Plib::systemstate.config.uo_datafile_root = Plib::UOInstallFinder::remove_elem( elem );
   Plib::systemstate.config.uo_datafile_root =
       Clib::normalized_dir_form( Plib::systemstate.config.uo_datafile_root );
 


### PR DESCRIPTION
On Windows, if the `UoDataFileRoot` is either empty or not found in `pol.cfg`, attempt to find the Ultima Online installation directory from the Windows Registry. 

If using the registry value, the console will show the directory found from the registry:

```
H:\vs_workspace\Distro (master)
λ pol
POL100 Never Gonna Give You Up - Windows 64bit (Rev. Non-Git)
compiled on Jan 12 2020 19:29:38
Copyright (C) 1993-2018 Eric N. Swanson

Using 2 out of 4 worldsave threads
Reading Configuration.
Using Ultima Online data files from installation directory h:\Games\Electronic Arts\Ultima Online Classic
Loading Realm britannia.
Validating statics files: Completed in 1 ms.
Completed in 729 ms.
```

If not set and no registry found, 

```
Error reading configuration file pol.cfg:
        Property 'UoDataFileRoot' was not found, and no Ultima Online installation could be found on the system.
Server Shutdown: reading pol.cfg
```