### PR TITLE
Add UTF8 checks to String toLower/toUpper

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-12-2020</datemodified>
+		<datemodified>01-17-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>01-17-2020</date>
+			<author>Kevin:</author>
+			<change type="Fixed">On Windows, add UTF8 checks to lowering/uppering of strings.</change>
+		</entry>
 		<entry>
 			<date>01-12-2020</date>
 			<author>Kevin:</author>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-18-2020</datemodified>
+		<datemodified>01-20-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>01-20-2020</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Huge Performance loss in Lower/Upper String functions.</change>
+		</entry>
 		<entry>
 			<date>01-18-2020</date>
 			<author>DevGIB:</author>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,13 +2,13 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-17-2020</datemodified>
+		<datemodified>01-18-2020</datemodified>
 	</header>
 	<version name="POL100">
 		<entry>
-			<date>01-17-2020</date>
+			<date>01-18-2020</date>
 			<author>Kevin:</author>
-			<change type="Fixed">On Windows, add UTF8 checks to lowering/uppering of strings.</change>
+			<change type="Fixed">Add UTF8 checks to lowering/uppering of strings.</change>
 		</entry>
 		<entry>
 			<date>01-12-2020</date>

--- a/pol-core/bscript/str.cpp
+++ b/pol-core/bscript/str.cpp
@@ -412,6 +412,11 @@ void String::toUpper()
     utf8::unchecked::append( std::towupper( c ), std::back_inserter( value_ ) );
   }
 #else
+  if ( !hasUTF8Characters() )
+  {
+    Clib::mkupperASCII( value_ );
+    return;
+  }
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring str = converter.from_bytes( value_ );
 
@@ -446,6 +451,11 @@ void String::toLower()
     utf8::unchecked::append( std::towlower( c ), std::back_inserter( value_ ) );
   }
 #else
+  if ( !hasUTF8Characters() )
+  {
+    Clib::mklowerASCII( value_ );
+    return;
+  }
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring str = converter.from_bytes( value_ );
 

--- a/pol-core/bscript/str.cpp
+++ b/pol-core/bscript/str.cpp
@@ -404,6 +404,11 @@ std::vector<wchar_t> convertutf8( const std::string& value )
 
 void String::toUpper()
 {
+  if ( !hasUTF8Characters() )
+  {
+    Clib::mkupperASCII( value_ );
+    return;
+  }
 #ifndef WINDOWS
   std::vector<wchar_t> codes = convertutf8<wchar_t>( value_ );
   value_.clear();
@@ -412,11 +417,6 @@ void String::toUpper()
     utf8::unchecked::append( std::towupper( c ), std::back_inserter( value_ ) );
   }
 #else
-  if ( !hasUTF8Characters() )
-  {
-    Clib::mkupperASCII( value_ );
-    return;
-  }
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring str = converter.from_bytes( value_ );
 
@@ -443,6 +443,11 @@ void String::toUpper()
 
 void String::toLower()
 {
+  if ( !hasUTF8Characters() )
+  {
+    Clib::mklowerASCII( value_ );
+    return;
+  }
 #ifndef WINDOWS
   std::vector<wchar_t> codes = convertutf8<wchar_t>( value_ );
   value_.clear();
@@ -451,11 +456,6 @@ void String::toLower()
     utf8::unchecked::append( std::towlower( c ), std::back_inserter( value_ ) );
   }
 #else
-  if ( !hasUTF8Characters() )
-  {
-    Clib::mklowerASCII( value_ );
-    return;
-  }
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::wstring str = converter.from_bytes( value_ );
 

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,6 @@
 ﻿-- POL100 --
-01-17-2020 Kevin:
-    Fixed: On Windows, add UTF8 checks to lowering/uppering of strings.
+01-18-2020 Kevin:
+    Fixed: Add UTF8 checks to lowering/uppering of strings.
 01-12-2020 Kevin:
   Changed: On Windows, the pol.cfg setting UoDataFileRoot will now default to the directory of the Ultima Online installation found in
            the Windows Registry. This setting MUST be set for servers that do not have Ultima Online installed through the operating

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+01-20-2020 Kevin:
+    Fixed: Huge Performance loss in Lower/Upper String functions.
 01-18-2020 DevGIB:
   Changed: Return type of XMLFile method .appendxmlnode() now returns the created node on success.
   Changed: Return type of XMLNode method .appendxmlnode() now returns the created node on success.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+01-17-2020 Kevin:
+    Fixed: On Windows, add UTF8 checks to lowering/uppering of strings.
 01-12-2020 Kevin:
   Changed: On Windows, the pol.cfg setting UoDataFileRoot will now default to the directory of the Ultima Online installation found in
            the Windows Registry. This setting MUST be set for servers that do not have Ultima Online installed through the operating


### PR DESCRIPTION
On Windows, fixes major performance loss on `String::toLower`/`toUpper` by checking if the string contains UTF-8 characters.