### PR TITLE
XML method returns.

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-12-2020</datemodified>
+		<datemodified>01-18-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>01-18-2020</date>
+			<author>DevGIB:</author>
+			<change type="Changed">Return type of XMLFile method .appendxmlnode() now returns the created node on success.</change>
+			<change type="Changed">Return type of XMLNode method .appendxmlnode() now returns the created node on success.</change>
+			<change type="Changed">Return type of XMLNode methods .setxmlattribute() and .removexmlattribute() now returns parent node on success.</change>
+		</entry>
 		<entry>
 			<date>01-12-2020</date>
 			<author>Kevin:</author>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -894,7 +894,7 @@ Object can be copied inside the same script, but cannot be stored in cprops or t
 ForEach support: iterates over all child nodes, iterator is XMLNode object _iterator_iter is integer index.</explain>
 <method proto="removexmlnode(integer/string/XMLNode)" returns="1/0" desc="removes node by index, first node with given name or passed one." />
 <method proto="setxmldeclaration(string version, string encoding, string standalone)" returns="1" desc="Sets the xml declaration." />
-<method proto="appendxmlnode(string value, [struct{attributes}])" returns="1" desc="Appends node with name value and given attributes (key=name, value=value)." />
+<method proto="appendxmlnode(string value, [struct{attributes}])" returns="Created node on success." desc="Appends node with name value and given attributes (key=name, value=value)." />
 <method proto="appendxmlcomment(string value)" returns="1" desc="Adds comment." />
 <method proto="savexml(string filename)" returns="1/0" desc="Saves to file." />
 <method proto="xmltostring([string ident])" returns="String" desc="Returns XML as string, identation is by default \t." />
@@ -910,10 +910,10 @@ ForEach support: iterates over all child nodes, iterator is XMLNode object _iter
 <method proto="clonenode()" returns="XMLNode" desc="Create a copy of node which is then valid longer then the file object." />
 <method proto="firstxmlchild([string value])" returns="XMLNode" desc="Returns first children or first with given name." />
 <method proto="nextxmlsibling([string value])" returns="XMLNode" desc="Returns next sibling or first with given name." />
-<method proto="appendxmlnode(string value, [struct{attributes}])" returns="1" desc="Appends node with name value and given attributes (key=name, value=value)." />
+<method proto="appendxmlnode(string value, [struct{attributes}])" returns="Created node on success." desc="Appends node with name value and given attributes (key=name, value=value)." />
 <method proto="appendxmlcomment(string value)" returns="1" desc="Adds comment." />
-<method proto="setxmlattribute(struct{attributes})" returns="1" desc="Sets node attributes (key=name, value=value)." />
-<method proto="removexmlattribute(string key)" returns="1" desc="Removes attribute with given name." />
+<method proto="setxmlattribute(struct{attributes})" returns="Parent node on success." desc="Sets node attributes (key=name, value=value)." />
+<method proto="removexmlattribute(string key)" returns="Parent node on success." desc="Removes attribute with given name." />
 <method proto="appendxmltext(string text)" returns="1" desc="Adds node text." />
 </class>
 

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 ﻿-- POL100 --
+01-18-2020 DevGIB:
+  Changed: Return type of XMLFile method .appendxmlnode() now returns the created node on success.
+  Changed: Return type of XMLNode method .appendxmlnode() now returns the created node on success.
+  Changed: Return type of XMLNode methods .setxmlattribute() and .removexmlattribute() now returns parent node on success.
 01-12-2020 Kevin:
   Changed: On Windows, the pol.cfg setting UoDataFileRoot will now default to the directory of the Ultima Online installation found in
            the Windows Registry. This setting MUST be set for servers that do not have Ultima Online installed through the operating

--- a/pol-core/pol/xmlfilescrobj.cpp
+++ b/pol-core/pol/xmlfilescrobj.cpp
@@ -122,7 +122,6 @@ Bscript::BObjectImp* BXMLfile::call_method_id( const int id, Executor& ex, bool 
       }
       file.LinkEndChild( elem.release() );
       return new BXmlNode(file.LastChild());
-      //return new BLong( 1 );
     }
     break;
   }
@@ -419,7 +418,6 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
       TiXmlElement* nodeelem = node->ToElement();
       nodeelem->LinkEndChild( elem.release() );
       return new BXmlNode(nodeelem->LastChild());
-      //return new BLong( 1 );
     }
     break;
   }
@@ -457,9 +455,8 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
         else
           elem->SetAttribute( name, ref->getStringRep() );
       }
-      // note sure if this should be node or elem
       return new BXmlNode(elem);
-      //return new BLong( 1 );
+     
     }
     break;
   }
@@ -473,7 +470,6 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
       TiXmlElement* elem = node->ToElement();
       elem->RemoveAttribute( pstr->value() );
       return new BXmlNode(elem);
-      //return new BLong( 1 );
     }
     break;
   }
@@ -521,7 +517,6 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
       TiXmlElement* elem = node->ToElement();
       elem->LinkEndChild( new TiXmlText( pstr->value() ) );
       return new BXmlNode(elem->LastChild());
-      //return new BLong( 1 );
     }
     break;
   }

--- a/pol-core/pol/xmlfilescrobj.cpp
+++ b/pol-core/pol/xmlfilescrobj.cpp
@@ -120,9 +120,9 @@ Bscript::BObjectImp* BXMLfile::call_method_id( const int id, Executor& ex, bool 
           }
         }
       }
-
       file.LinkEndChild( elem.release() );
-      return new BLong( 1 );
+      return new BXmlNode(file.LastChild());
+      //return new BLong( 1 );
     }
     break;
   }
@@ -418,7 +418,8 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
 
       TiXmlElement* nodeelem = node->ToElement();
       nodeelem->LinkEndChild( elem.release() );
-      return new BLong( 1 );
+      return new BXmlNode(nodeelem->LastChild());
+      //return new BLong( 1 );
     }
     break;
   }
@@ -456,7 +457,9 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
         else
           elem->SetAttribute( name, ref->getStringRep() );
       }
-      return new BLong( 1 );
+      // note sure if this should be node or elem
+      return new BXmlNode(elem);
+      //return new BLong( 1 );
     }
     break;
   }
@@ -469,7 +472,8 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
     {
       TiXmlElement* elem = node->ToElement();
       elem->RemoveAttribute( pstr->value() );
-      return new BLong( 1 );
+      return new BXmlNode(elem);
+      //return new BLong( 1 );
     }
     break;
   }
@@ -516,7 +520,8 @@ Bscript::BObjectImp* BXmlNode::call_method_id( const int id, Executor& ex, bool 
     {
       TiXmlElement* elem = node->ToElement();
       elem->LinkEndChild( new TiXmlText( pstr->value() ) );
-      return new BLong( 1 );
+      return new BXmlNode(elem->LastChild());
+      //return new BLong( 1 );
     }
     break;
   }


### PR DESCRIPTION
Changed: Return type of XMLFile method .appendxmlnode() now returns the created node on success.
Changed: Return type of XMLNode method .appendxmlnode() now returns the created node on success.
Changed: Return type of XMLNode methods .setxmlattribute() and .removexmlattribute() now returns parent node on success.