### PR TITLE
Remove SmartParser::IP

### DIFF
--- a/pol-core/bscript/parser.cpp
+++ b/pol-core/bscript/parser.cpp
@@ -2382,26 +2382,5 @@ int SmartParser::IIP( Expression& expr, CompilerContext& ctx, unsigned flags )
   return res;
 }
 
-/* not used? 12/10/1998 ens
-int SmartParser::IP(Expression& expr, char *s)
-{
-//  return Parser::IP(s);
-reinit(expr);
-int res = IIP(expr, &s, EXPR_FLAG_SEMICOLON_TERM_ALLOWED);
-if (res < 0 && !quiet)
-{
-cout << "Parse Error: " << ParseErrorStr[err];
-if (ext_err[0]) cout << " " << ext_err;
-cout << endl;
-}
-return res;
-}
-*/
-
-int SmartParser::IP( Expression& expr, CompilerContext& ctx )
-{
-  reinit( expr );
-  return IIP( expr, ctx, EXPR_FLAG_SEMICOLON_TERM_ALLOWED );
-}
 }  // namespace Bscript
 }  // namespace Pol

--- a/pol-core/bscript/parser.h
+++ b/pol-core/bscript/parser.h
@@ -149,8 +149,6 @@ public:
   virtual int getFunctionPArgument( Expression& expr, CompilerContext& ctx, Token* tok ) = 0;
 
   int IIP( Expression& expr, CompilerContext& ctx, unsigned expr_flags );
-  int IP( Expression& expr, char* s );
-  int IP( Expression& expr, CompilerContext& ctx );
 };
 
 inline int SmartParser::isLegal( Token& )


### PR DESCRIPTION
Remove another unused caller of `SmartParser::IIP`, and a 21.5-year-old "not used?" comment