### PR TITLE
Make getUserArgs optimize arguments, rename Expression::eat2 -> consume_tokens

### DIFF
--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -148,7 +148,6 @@ void Scope::addvalue()
 }
 
 
-
 void Compiler::enterblock( eb_label_ok eblabel, eb_break_ok ebbreak, eb_continue_ok ebcontinue )
 {
   program->enterblock();
@@ -900,7 +899,8 @@ int Compiler::getUserArgs( Expression& ex, CompilerContext& ctx, bool inject_jsr
 
     Expression& arg_expr = params_passed[varname];
 
-    res = readexpr( arg_expr, ctx, EXPR_FLAG_COMMA_TERM_ALLOWED | EXPR_FLAG_RIGHTPAREN_TERM_ALLOWED );
+    res =
+        readexpr( arg_expr, ctx, EXPR_FLAG_COMMA_TERM_ALLOWED | EXPR_FLAG_RIGHTPAREN_TERM_ALLOWED );
     if ( res < 0 )
       return res;
 

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -900,7 +900,7 @@ int Compiler::getUserArgs( Expression& ex, CompilerContext& ctx, bool inject_jsr
 
     Expression& arg_expr = params_passed[varname];
 
-    res = IIP( arg_expr, ctx, EXPR_FLAG_COMMA_TERM_ALLOWED | EXPR_FLAG_RIGHTPAREN_TERM_ALLOWED );
+    res = readexpr( arg_expr, ctx, EXPR_FLAG_COMMA_TERM_ALLOWED | EXPR_FLAG_RIGHTPAREN_TERM_ALLOWED );
     if ( res < 0 )
       return res;
 
@@ -942,7 +942,7 @@ int Compiler::getUserArgs( Expression& ex, CompilerContext& ctx, bool inject_jsr
     else
     {
       Expression& arg_expr = params_passed[itr->name];
-      ex.eat( arg_expr );
+      ex.eat2( arg_expr );
       params_passed.erase( itr->name );
     }
   }

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -430,7 +430,7 @@ int Compiler::getArrayElements( Expression& expr, CompilerContext& ctx )
     if ( res < 0 )
       return res;
 
-    expr.eat2( eex );
+    expr.consume_tokens( eex );
 
     expr.CA.push( new Token( TOK_INSERTINTO, TYP_OPERATOR ) );
 
@@ -496,7 +496,7 @@ int Compiler::getNewArrayElements( Expression& expr, CompilerContext& ctx )
     if ( res < 0 )
       return res;
 
-    expr.eat2( eex );
+    expr.consume_tokens( eex );
 
     expr.CA.push( new Token( TOK_INSERTINTO, TYP_OPERATOR ) );
 
@@ -581,7 +581,7 @@ int Compiler::getStructMembers( Expression& expr, CompilerContext& ctx )
         auto addmem = new Token( ident_tkn );
         addmem->id = INS_ADDMEMBER_ASSIGN;
 
-        expr.eat2( eex );
+        expr.consume_tokens( eex );
         expr.CA.push( addmem );
       }
       else if ( token.id == TOK_EQUAL1 )
@@ -676,7 +676,7 @@ int Compiler::getDictionaryMembers( Expression& expr, CompilerContext& ctx )
     if ( res < 0 )
       return res;
 
-    expr.eat2( key_expression );
+    expr.consume_tokens( key_expression );
 
     // if the key is followed by "->", then grab the value
     res = peekToken( ctx, token );
@@ -693,7 +693,7 @@ int Compiler::getDictionaryMembers( Expression& expr, CompilerContext& ctx )
       if ( res < 0 )
         return res;
 
-      expr.eat2( value_expression );
+      expr.consume_tokens( value_expression );
     }
     else
     {
@@ -751,7 +751,7 @@ int Compiler::getMethodArguments( Expression& expr, CompilerContext& ctx, int& n
     if ( res < 0 )
       return res;
 
-    expr.eat2( eex );
+    expr.consume_tokens( eex );
 
     ++nargs;
 
@@ -942,7 +942,7 @@ int Compiler::getUserArgs( Expression& ex, CompilerContext& ctx, bool inject_jsr
     else
     {
       Expression& arg_expr = params_passed[itr->name];
-      ex.eat2( arg_expr );
+      ex.consume_tokens( arg_expr );
       params_passed.erase( itr->name );
     }
   }

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -46,13 +46,12 @@ Expression::~Expression()
   }
 }
 
-void Expression::eat2( Expression& expr )
+void Expression::consume_tokens( Expression& expr )
 {
-  while ( !expr.tokens.empty() )
-  {
-    CA.push( expr.tokens.front() );
-    expr.tokens.erase( expr.tokens.begin() );
+  for( auto& token : expr.tokens ) {
+    CA.push(token);
   }
+  expr.tokens.clear();
 }
 
 Token* optimize_long_operation( Token* left, Token* oper, Token* right )

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -46,15 +46,6 @@ Expression::~Expression()
   }
 }
 
-void Expression::eat( Expression& expr )
-{
-  while ( !expr.CA.empty() )
-  {
-    CA.push( expr.CA.front() );
-    expr.CA.pop();
-  }
-}
-
 void Expression::eat2( Expression& expr )
 {
   while ( !expr.tokens.empty() )

--- a/pol-core/bscript/expression.h
+++ b/pol-core/bscript/expression.h
@@ -23,7 +23,7 @@ class Expression
 public:
   ~Expression();
 
-  void eat2( Expression& expr );
+  void consume_tokens( Expression& expr );
   void optimize();
   void optimize_binary_operations();
   void optimize_unary_operations();

--- a/pol-core/bscript/expression.h
+++ b/pol-core/bscript/expression.h
@@ -23,7 +23,6 @@ class Expression
 public:
   ~Expression();
 
-  void eat( Expression& expr );
   void eat2( Expression& expr );
   void optimize();
   void optimize_binary_operations();


### PR DESCRIPTION
Three commits in this PR (I will squash before merging):
- make `Compiler::getUserArgs` call `Compiler::readexpr` rather than `SmartParser::IIP`
    - this makes it so `Compiler::readexpr` is the only caller of `SmartParser::IIP`
    - it also has the effect of optimizing the arguments immediately, even though they would have been optimized later on with the overall expression.
    - it also has to call `Expression::eat2` (renamed `consume_tokens` later) because `readexpr` moves tokens from `CA` to `tokens`
- delete `Expression::eat` since it is no longer used
- renamed `Expression::eat2` to `Expression::consume_tokens`
- streamlined `Expression::consume_tokens` to use a modern for loop and a single `clear()` call