### PR TITLE
Add Compiler::read_subexpression for DRY

### DIFF
--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -197,6 +197,7 @@ private:
   void convert_variables( Expression& expr ) const;
   int validate( const Expression& expr, CompilerContext& ctx ) const;
   int readexpr( Expression& expr, CompilerContext& ctx, unsigned flags );
+  int read_subexpression( Expression& expr, CompilerContext& ctx, unsigned flags );
   void inject( Expression& expr );
   int insertBreak( const std::string& label );
 


### PR DESCRIPTION
Just a small refactor to reduce some duplicate code.  As a result, there are only two direct callers of `Expression::consume_tokens`.