### PR TITLE
Remove TYP_USERFUNC tokens during expression optimization

### DIFF
--- a/pol-core/bscript/eprog2.cpp
+++ b/pol-core/bscript/eprog2.cpp
@@ -148,9 +148,6 @@ void EScriptProgram::addToken( const Token& token )
   }
   break;
 
-  case TYP_USERFUNC:  // these don't do anything.
-    return;
-
   case TYP_METHOD:
   {
     if ( token.id != INS_CALL_METHOD_ID )

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -657,19 +657,9 @@ void Expression::optimize()
 
 void Expression::remove_non_emitting_tokens()
 {
-  for ( size_t i = 0; i < tokens.size(); )
-  {
-    auto token = tokens[i];
-    if ( token->type == TYP_USERFUNC )
-    {
-      tokens.erase( tokens.begin() + i );
-      delete token;
-    }
-    else
-    {
-      ++i;
-    }
-  }
+  tokens.erase( std::remove_if( tokens.begin(), tokens.end(),
+                                []( const Token* tkn ) { return tkn->type == TYP_USERFUNC; } ),
+                tokens.end() );
 }
 
 }  // namespace Bscript

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -370,12 +370,6 @@ int Expression::get_num_tokens( int idx ) const
   {
     children = 1 + tkn->lval;
   }
-  else if ( tkn->type == TYP_USERFUNC )
-  {
-    // the CTRL_JSR_USERFUNC
-    // FIXME: TODO: what?
-    children = 1;
-  }
   else if ( tkn->id == CTRL_JSR_USERFUNC )
   {
     // the CTRL_MAKELOCAL + the parameters
@@ -647,6 +641,8 @@ void Expression::optimize_assignments()
     */
 void Expression::optimize()
 {
+  remove_non_emitting_tokens();
+
   size_t starting_size;
   do
   {
@@ -658,6 +654,17 @@ void Expression::optimize()
   } while ( tokens.size() != starting_size );
 }
 
+void Expression::remove_non_emitting_tokens() {
+  for( size_t i = 0; i < tokens.size(); ) {
+    auto token = tokens[i];
+    if (token->type == TYP_USERFUNC) {
+      tokens.erase( tokens.begin() + i );
+      delete token;
+    } else {
+      ++i;
+    }
+  }
+}
 
 }  // namespace Bscript
 }  // namespace Pol

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -657,9 +657,19 @@ void Expression::optimize()
 
 void Expression::remove_non_emitting_tokens()
 {
-  tokens.erase( std::remove_if( tokens.begin(), tokens.end(),
-                                []( const Token* tkn ) { return tkn->type == TYP_USERFUNC; } ),
-                tokens.end() );
+  for ( size_t i = 0; i < tokens.size(); )
+  {
+    auto token = tokens[i];
+    if ( token->type == TYP_USERFUNC )
+    {
+      tokens.erase( tokens.begin() + i );
+      delete token;
+    }
+    else
+    {
+      ++i;
+    }
+  }
 }
 
 }  // namespace Bscript

--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -48,8 +48,9 @@ Expression::~Expression()
 
 void Expression::consume_tokens( Expression& expr )
 {
-  for( auto& token : expr.tokens ) {
-    CA.push(token);
+  for ( auto& token : expr.tokens )
+  {
+    CA.push( token );
   }
   expr.tokens.clear();
 }
@@ -170,7 +171,7 @@ Token* optimize_string_operation( Token* left, Token* oper, Token* right )
     combined = std::string( left->tokval() ) + std::string( right->tokval() );
     ntoken->copyStr( combined.c_str() );
   }
-    break;
+  break;
 
   default:
     break;
@@ -654,13 +655,18 @@ void Expression::optimize()
   } while ( tokens.size() != starting_size );
 }
 
-void Expression::remove_non_emitting_tokens() {
-  for( size_t i = 0; i < tokens.size(); ) {
+void Expression::remove_non_emitting_tokens()
+{
+  for ( size_t i = 0; i < tokens.size(); )
+  {
     auto token = tokens[i];
-    if (token->type == TYP_USERFUNC) {
+    if ( token->type == TYP_USERFUNC )
+    {
       tokens.erase( tokens.begin() + i );
       delete token;
-    } else {
+    }
+    else
+    {
       ++i;
     }
   }

--- a/pol-core/bscript/expression.h
+++ b/pol-core/bscript/expression.h
@@ -25,11 +25,7 @@ public:
 
   void consume_tokens( Expression& expr );
   void optimize();
-  void optimize_binary_operations();
-  void optimize_unary_operations();
-  void optimize_assignments();
   int get_num_tokens( int idx ) const;
-  bool optimize_token( int i );
 
   typedef std::vector<Token*> Tokens;
   Tokens tokens;
@@ -37,6 +33,13 @@ public:
 public:
   std::stack<Token*> TX;
   std::queue<Token*> CA;
+
+private:
+  void optimize_binary_operations();
+  void optimize_unary_operations();
+  void optimize_assignments();
+  bool optimize_token( int i );
+  void remove_non_emitting_tokens();
 };
 
 }  // namespace Bscript


### PR DESCRIPTION
...rather than when emitting tokens.

For all tokens other than TYP_USERFUNC, `EScriptProgram::addToken` writes a single "stored token" per Token.

The elvis operator needs to be able to calculate the number of tokens that will be written for an expression, so this change makes it so that (upcoming) code will not have to adjust for that.
