### PR TITLE
Update to pol.example.cfg

### DIFF
--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -397,7 +397,8 @@ WebServerLocalOnly=0
 #WebServerDebug=0
 
 #
-# WebServerPassword: username/password required for access to the web server.
+# WebServerPassword: username:password required for access to the web server.
+#                    username and password must be delimited using a colon ':'.
 #                    If not specified, no password is required.
 # WebServerPassword=username:password
 # Default empty


### PR DESCRIPTION
The delimiter for username and password for the webserver was wrong. Changed from a '/' to a colon ':'.