### PR TITLE
Add bug010 - optimizer bug with if statements

### DIFF
--- a/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.out
+++ b/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.out
@@ -1,0 +1,1 @@
+correct: first pathirst path

--- a/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.src
+++ b/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.src
@@ -1,0 +1,16 @@
+// The optimizer overwrites the offset of a token, under the assumption that the
+// token is a JMP_IF_FALSE instruction.
+//
+// However, due to rolling back an optimized block, the token is actually something else.
+//
+// In this script, the offset of the "!" string literal is overwritten with the address
+// of the instruction following the "if", in this case the PROGEND.
+
+var b := "correct: first path";
+
+if (1)
+    b := b + "!";
+    print(b);
+elseif (b)
+    print("incorrect: second path");
+endif


### PR DESCRIPTION
This PR documents an existing bug in the compiler.  The expected output of the included script is:

```
correct: first path!
```

After this is merged, I will follow up with the PR that fixes this error.