### PR TITLE
Fix optimization error: will sometimes patch an offset of the wrong instruction

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>06-10-2020</datemodified>
+		<datemodified>06-14-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>06-14-2020</date>
+			<author>Syzygy:</author>
+			<change type="Fixed">A compiler optimization bug that could corrupt emitted instructions<br/>
+if branches of an if statement were optimized out.</change>
+		</entry>
 		<entry>
 			<date>06-10-2020</date>
 			<author>Syzygy:</author>

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -1923,6 +1923,8 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
       rollback( *program, checkpt_expr );  // don't need the expression or the jump,
       // even if we're keeping the block
       patch_if_token = false;
+      if_token_posn = -1;
+      last_if_token_posn = -1;
     }
     else
     {
@@ -2007,6 +2009,10 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
         prog_tokens->atGet1( last_if_token_posn, tkn );
         tkn.offset = static_cast<unsigned short>( prog_tokens->next() );
         prog_tokens->atPut1( tkn, last_if_token_posn );
+      }
+      else
+      {
+        last_if_token_posn = -1;
       }
     }
     // dump(cout);

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -1882,7 +1882,6 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
   bool discard_rest = false;
   // bool discarded_all = true;
   bool included_any_tests = false;
-  unsigned last_if_token_posn = static_cast<unsigned>( -1 );
   unsigned if_token_posn = static_cast<unsigned>( -1 );
   StoredTokenContainer* prog_tokens = &program->tokens;
   while ( token.id == RSV_ST_IF || token.id == RSV_ELSEIF )
@@ -1896,7 +1895,7 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
       return res;
     // dump(cout);
     bool patch_if_token = true;
-    last_if_token_posn = if_token_posn;
+    const unsigned last_if_token_posn = if_token_posn;
     if ( ex.tokens.back()->id == TOK_LOG_NOT )
     {
       if_token_posn = prog_tokens->count() - 1;
@@ -1923,8 +1922,7 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
       rollback( *program, checkpt_expr );  // don't need the expression or the jump,
       // even if we're keeping the block
       patch_if_token = false;
-      if_token_posn = -1;
-      last_if_token_posn = -1;
+      if_token_posn = last_if_token_posn;
     }
     else
     {
@@ -2009,10 +2007,6 @@ int Compiler::handleBracketedIf( CompilerContext& ctx, int level )
         prog_tokens->atGet1( last_if_token_posn, tkn );
         tkn.offset = static_cast<unsigned short>( prog_tokens->next() );
         prog_tokens->atPut1( tkn, last_if_token_posn );
-      }
-      else
-      {
-        last_if_token_posn = -1;
       }
     }
     // dump(cout);

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 ﻿-- POL100 --
+06-14-2020 Syzygy:
+    Fixed: A compiler optimization bug that could corrupt emitted instructions
+           if branches of an if statement were optimized out.
 06-10-2020 Syzygy:
   Changed: It is now a compile error if a script requires a terminator (semicolon, etc)
            at its end-of-file.  This fixes bug009 in the escript test suite.

--- a/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.out
+++ b/testsuite/escript/bug/bug010-if-statement-optimization-offset-corruption.out
@@ -1,1 +1,1 @@
-correct: first pathirst path
+correct: first path!


### PR DESCRIPTION
This would happen when rolling back an if statement branch.