### PR TITLE
Improve optimizer: also roll back module function "used" status

### DIFF
--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -4172,6 +4172,16 @@ void Compiler::rollback( EScriptProgram& prog, const EScriptProgramCheckpoint& c
     delete prog.modules.back();
     prog.modules.pop_back();
   }
+  for ( unsigned i = 0; i < checkpoint.module_used_functions.size(); ++i )
+  {
+    FunctionalityModule* fm = prog.modules.at(i);
+    unsigned used_functions = checkpoint.module_used_functions[i];
+    while ( fm->used_functions.size() > used_functions )
+    {
+      fm->used_functions.back()->used = false;
+      fm->used_functions.pop_back();
+    }
+  }
   prog.tokens.setcount( checkpoint.tokens_count );
   prog.symbols.setlength( checkpoint.symbols_length );
   while ( prog.sourcelines.size() > checkpoint.sourcelines_count )

--- a/pol-core/bscript/eprog.h
+++ b/pol-core/bscript/eprog.h
@@ -173,6 +173,7 @@ public:
   void rollback( EScriptProgram& prog ) const;
 
   unsigned module_count;
+  std::vector<unsigned> module_used_functions;
   unsigned tokens_count;
   unsigned symbols_length;
   unsigned sourcelines_count;

--- a/pol-core/bscript/eprog2.cpp
+++ b/pol-core/bscript/eprog2.cpp
@@ -344,6 +344,11 @@ EScriptProgramCheckpoint::EScriptProgramCheckpoint( const EScriptProgram& prog )
 void EScriptProgramCheckpoint::commit( const EScriptProgram& prog )
 {
   module_count = static_cast<unsigned int>( prog.modules.size() );
+  module_used_functions.clear();
+  for( auto mod : prog.modules )
+  {
+    module_used_functions.push_back( mod->used_functions.size() );
+  }
   tokens_count = prog.tokens.count();
   symbols_length = prog.symbols.length();
   sourcelines_count = static_cast<unsigned int>( prog.sourcelines.size() );

--- a/testsuite/escript/opt/opt006-unreferenced-optimized-module-functions.src
+++ b/testsuite/escript/opt/opt006-unreferenced-optimized-module-functions.src
@@ -1,0 +1,12 @@
+// We can't tell from the output, but if we make it so certain
+// tests check against known .ecl output, this would be a good
+// candidate.
+//
+// The call to print() is optimized out, but the OG compiler
+// used to include basicio::print() in the .ecl file, while
+// the new compiler does not.
+
+if (0)
+    print("incorrect, and should not reference print() in the .ecl");
+endif
+


### PR DESCRIPTION
(if they were not used before)

If a module function was referenced in an if branch that was later optimized out,
the compiler would leave the function marked as referenced, and so include
it in the .ecl file even if it was never actually used.

The new compiler doesn't do this.

To test, run `ecompile` against the included test script.

Contents of `.ecl` file before:
```
00000000  43 45 0f 00 00 00 01 00  00 00 00 00 62 61 73 69  |CE..........basi|
00000010  63 00 00 00 00 00 00 00  00 00 00 00 00 00 01 00  |c...............|
00000020  00 00 00 00 62 61 73 69  63 69 6f 00 00 00 00 00  |....basicio.....|
00000030  00 00 01 00 00 00 50 72  69 6e 74 00 00 00 00 00  |......Print.....|
00000040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000050  00 00 00 00 00 00 00 01  02 00 09 00 00 00 05 00  |................|
00000060  00 00 1e 22 00 00 00 03  00 05 00 00 00 01 00 00  |..."............|
```

Contents of `.ecl` file after:
```
00000000  43 45 0f 00 00 00 01 00  00 00 00 00 62 61 73 69  |CE..........basi|
00000010  63 00 00 00 00 00 00 00  00 00 00 00 00 00 01 00  |c...............|
00000020  00 00 00 00 62 61 73 69  63 69 6f 00 00 00 00 00  |....basicio.....|
00000030  00 00 00 00 00 00 02 00  09 00 00 00 05 00 00 00  |................|
00000040  1e 22 00 00 00 03 00 05  00 00 00 01 00 00 00 00  |."..............|
00000050
```