### PR TITLE
Add compiler mode: dual-compile OG / grammar-based (unfinished) compiler

### DIFF
--- a/pol-core/bscript/CMakeLists.txt
+++ b/pol-core/bscript/CMakeLists.txt
@@ -9,8 +9,10 @@ add_library(${lib_name} STATIC
 set_compile_flags(${lib_name} 0)
 warning_suppression(${lib_name})
 enable_pch(${lib_name})
+include_directories("${CMAKE_CURRENT_LIST_DIR}/../../lib/antlr")
 
 target_link_libraries(${lib_name} PUBLIC
+  antlr
   clib
 )
 if (${linux})

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -1,5 +1,15 @@
 set (bscript_sources    # sorted !
-  CMakeSources.cmake 
+  ../../lib/EscriptGrammar/EscriptLexer.cpp
+  ../../lib/EscriptGrammar/EscriptLexer.h
+  ../../lib/EscriptGrammar/EscriptParser.cpp
+  ../../lib/EscriptGrammar/EscriptParser.h
+  ../../lib/EscriptGrammar/EscriptParserBaseListener.cpp
+  ../../lib/EscriptGrammar/EscriptParserBaseListener.h
+  ../../lib/EscriptGrammar/EscriptParserListener.cpp
+  ../../lib/EscriptGrammar/EscriptParserListener.h
+  CMakeSources.cmake
+  EscriptCompiler.cpp
+  EscriptCompiler.h
   StdAfx.h
   berror.cpp 
   berror.h
@@ -25,8 +35,8 @@ set (bscript_sources    # sorted !
   eprog3.cpp
   eprog_read.cpp
   escript.h
-  escript_config.cpp 
-  escriptv.cpp 
+  escript_config.cpp
+  escriptv.cpp
   escriptv.h
   escrutil.cpp
   escrutil.h

--- a/pol-core/bscript/EscriptCompiler.cpp
+++ b/pol-core/bscript/EscriptCompiler.cpp
@@ -1,0 +1,46 @@
+//
+// Created by Eric Swanson on 4/27/20.
+//
+
+#include "EscriptCompiler.h"
+
+#include <iostream>
+
+#include "antlr4-runtime.h"
+
+#include "../clib/fileutil.h"
+#include "../clib/logfacility.h"
+
+#include <EscriptGrammar/EscriptLexer.h>
+#include <EscriptGrammar/EscriptParser.h>
+
+using antlr4::ANTLRInputStream;
+using antlr4::CommonTokenStream;
+using EscriptGrammar::EscriptLexer;
+using EscriptGrammar::EscriptParser;
+
+namespace Pol
+{
+namespace Bscript
+{
+
+int EscriptCompiler::compileFile( const std::string& filename )
+{
+  auto pathname = Clib::FullPath( filename.c_str() );
+  std::ifstream stream( pathname );
+
+  ANTLRInputStream input( stream );
+  EscriptLexer lexer( &input );
+  CommonTokenStream tokens( &lexer );
+  EscriptParser parser( &tokens );
+
+  auto compilationUnit = parser.compilationUnit();
+
+  INFO_PRINT << "compilation unit has " << compilationUnit->topLevelDeclaration().size()
+             << " top-level declarations.\n";
+
+  return 0;
+}
+
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/EscriptCompiler.h
+++ b/pol-core/bscript/EscriptCompiler.h
@@ -1,0 +1,29 @@
+//
+// Created by Eric Swanson on 4/27/20.
+//
+
+#ifndef POLSERVER_ESCRIPTCOMPILER_H
+#define POLSERVER_ESCRIPTCOMPILER_H
+
+#include <string>
+#include <vector>
+
+namespace Pol
+{
+namespace Bscript
+{
+
+class EscriptCompiler
+{
+public:
+  int compileFile( const std::string& fname );
+
+private:
+  std::vector<std::string> referenced_pathnames;
+
+};
+
+} // namespace Bscript
+} // namespace Pol
+
+#endif  // POLSERVER_ESCRIPTCOMPILER_H

--- a/pol-core/bscript/compilercfg.cpp
+++ b/pol-core/bscript/compilercfg.cpp
@@ -57,6 +57,8 @@ void CompilerConfig::Read( const std::string& path )
   ParanoiaWarnings = elem.remove_bool( "ParanoiaWarnings", false );
   ErrorOnFileCaseMissmatch = elem.remove_bool( "ErrorOnFileCaseMissmatch", false );
 
+  DualCompileWithAntlrGrammar = elem.remove_bool( "DualCompileWithAntlrGrammar", false );
+
 // This is where we TRY to validate full paths from what was provided in the
 // ecompile.cfg. Maybe Turley or Shini can find the best way to do this in *nix.
 #ifdef WIN32

--- a/pol-core/bscript/compilercfg.h
+++ b/pol-core/bscript/compilercfg.h
@@ -37,6 +37,7 @@ struct CompilerConfig
   int NumberOfThreads;
   bool ParanoiaWarnings;
   bool ErrorOnFileCaseMissmatch;
+  bool DualCompileWithAntlrGrammar;
 
   void Read( const std::string& path );
   void SetDefaults();

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -9,6 +9,7 @@
 
 #include "../bscript/compiler.h"
 #include "../bscript/compilercfg.h"
+#include "../bscript/EscriptCompiler.h"
 #include "../bscript/escriptv.h"
 #include "../bscript/executor.h"
 #include "../bscript/executortype.h"
@@ -67,6 +68,7 @@ void ECompileMain::showHelp()
 #ifdef WIN32
              << "       -Ecfgpath    set or change the ECOMPILE_CFG_PATH evironment variable\n"
 #endif
+             << "       -g           also run ANTLR-grammar-driven compiler\n"
              << "       -i           include intrusive debug info in .ecl file\n"
              << "       -l           generate listfile\n"
              << "       -m           don't optimize object members\n"
@@ -229,6 +231,14 @@ bool compile_file( const char* path )
     C.setQuiet( !debug );
     int res = C.compileFile( path );
 
+    if ( compilercfg.DualCompileWithAntlrGrammar )
+    {
+      EscriptCompiler compiler;
+      int res2 = compiler.compileFile( path );
+      INFO_PRINT << "ANTLR grammar compile result: " << res2 << "\n";
+    }
+
+
     if ( expect_compile_failure )
     {
       if ( res )  // good, it failed
@@ -383,6 +393,10 @@ int readargs( int argc, char** argv )
       }
       break;
 #endif
+
+      case 'g':
+        compilercfg.DualCompileWithAntlrGrammar = setting_value( arg );
+        break;
 
       case 'q':
         quiet = true;

--- a/testsuite/escript/ecompile.cfg
+++ b/testsuite/escript/ecompile.cfg
@@ -14,3 +14,4 @@ DisplaySummary 0
 GenerateDependencyInfo 0
 DisplayUpToDateScripts 0
 ErrorOnFileCaseMissmatch 1
+DualCompileWithAntlrGrammar 0


### PR DESCRIPTION
- Add `-g`, `DualCompileWithAntlrGrammar` option: dual-compile (just parses right now)

This is just to demonstrate ANTLR compiling and linking on all platforms.  The rest of the work will later change the meaning of the `-g` argument, the name of the compilecfg config option, and replace the EscriptCompiler class entirely.

Because this isn't meant to be user-facing yet, I did not update the docs.
