### PR TITLE
Move compiler class into Legacy namespace

### DIFF
--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -53,10 +53,12 @@ namespace Pol
 {
 namespace Bscript
 {
+extern int include_debug;
+namespace Legacy
+{
 bool Compiler::check_filecase_;
 int Compiler::verbosity_level_;
 
-extern int include_debug;
 
 std::string getpathof( const std::string& fname )
 {
@@ -4364,6 +4366,7 @@ void Compiler::dump( std::ostream& os )
 {
   program->dump( os );
 }
+}  // namespace Legacy
 }  // namespace Bscript
 }  // namespace Pol
    /*

--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -41,6 +41,8 @@ namespace Bscript
 class EScriptProgram;
 class EScriptProgramCheckpoint;
 class FunctionalityModule;
+namespace Legacy
+{
 /*
     ack, this is a misnomer.
     "CanBeLabelled" means "break or continue can happen here."
@@ -224,8 +226,7 @@ public:
   virtual int getStructMembers( Expression& expr, CompilerContext& ctx ) override;
   virtual int getDictionaryMembers( Expression& expr, CompilerContext& ctx ) override;
   virtual int getMethodArguments( Expression& expr, CompilerContext& ctx, int& nargs ) override;
-  virtual int getFunctionPArgument( Expression& expr, CompilerContext& ctx,
-                                    Token* tok ) override;
+  virtual int getFunctionPArgument( Expression& expr, CompilerContext& ctx, Token* tok ) override;
 
   int eatToken( CompilerContext& ctx, BTokenId tokenid );
   int getExpr( CompilerContext& ctx, unsigned expr_flags, size_t* exprlen = nullptr,
@@ -294,6 +295,7 @@ public:
 private:
   std::vector<char*> delete_these_arrays;
 };
-}
-}
+}  // namespace Legacy
+}  // namespace Bscript
+}  // namespace Pol
 #endif  // H_COMPILER_H

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -130,7 +130,7 @@ void compile_inc( const char* path )
   if ( !quiet )
     INFO_PRINT << "Compiling: " << path << "\n";
 
-  Compiler C;
+  Legacy::Compiler C;
 
   C.setQuiet( !debug );
   C.setIncludeCompileMode();
@@ -224,7 +224,7 @@ bool compile_file( const char* path )
     if ( !quiet )
       INFO_PRINT << "Compiling: " << path << "\n";
 
-    Compiler C;
+    Legacy::Compiler C;
 
     C.setQuiet( !debug );
     int res = C.compileFile( path );
@@ -466,7 +466,7 @@ int readargs( int argc, char** argv )
         vlev = atoi( &argv[i][2] );
         if ( !vlev )
           vlev = 1;
-        Compiler::setVerbosityLevel( vlev );
+        Legacy::Compiler::setVerbosityLevel( vlev );
         break;
 
       case 'x':


### PR DESCRIPTION
The new compiler lives in the Pol::Bscript::Compiler namespace.  This change moves the current `Compiler` class into the Pol::Bscript::Legacy namespace, so that these names do not conflict.
