### PR TITLE
Fix a bug in the legacy compiler .ecl output for RSV_LOCAL

### DIFF
--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -2229,7 +2229,6 @@ int Compiler::handleVarDeclare( CompilerContext& ctx, unsigned save_id )
       varindex = localscope.numVariables();
       program->addlocalvar( tk_varname.tokval() );
 
-      varindex = localscope.numVarsInBlock();
       localscope.addvar( tk_varname.tokval(), ctx );
     }
 

--- a/testsuite/escript/bug/bug013-local-variable-index.src
+++ b/testsuite/escript/bug/bug013-local-variable-index.src
@@ -1,0 +1,17 @@
+// The RSV_LOCALVAR instruction used to emit the wrong variable index.
+// Rather than emitting the index of the variable in the overall block,
+// it would emit the index within the innermost block.
+// The executor doesn't use the variable index, which is why this didn't cause problems.
+
+program foo()
+   var a;             // should be 0
+   if ( a )
+       var b;         // should be 1    actually emitted 0
+       var c;         // should be 2    actually emitted 1
+       if ( b )
+           var d;     // should be 3    actually emitted 0
+           print(d);
+       endif
+   endif
+endprogram
+


### PR DESCRIPTION
The RSV_LOCAL offset should be the the index of the local variable, not the index within the block

Notice though, that the executor [doesn't even use it](https://github.com/polserver/polserver/blob/master/pol-core/bscript/executor.cpp#L846).

There is more detail in the attached script.  There's no verified output, but the script output comparison mode will make sure that both compilers output the same thing.

listfile before:
```
/vagrant/testsuite/escript/bug/bug013-local-variable-index.src, Line 7
program foo()
var a;             // should be 0
0: decl local #0
1: #
if ( a )
2: local #0
3: if false goto 17
var b;         // should be 1    actually emitted 0
4: decl local #0
5: #
var c;         // should be 2    actually emitted 1
6: decl local #1
7: #
if ( b )
8: local #1
9: if false goto 16
var d;     // should be 3    actually emitted 0
10: decl local #0
11: #
print(d);
12: local #3
13: Func(1,0): Print
14: #
15: leave block(1)
16: leave block(2)
17: leave block(1)
18: progend
```

listfile after:
```
/vagrant/testsuite/escript/bug/bug013-local-variable-index.src, Line 7
program foo()
var a;             // should be 0
0: decl local #0
1: #
if ( a )
2: local #0
3: if false goto 17
var b;         // should be 1    actually emitted 0
4: decl local #1
5: #
var c;         // should be 2    actually emitted 1
6: decl local #2
7: #
if ( b )
8: local #1
9: if false goto 16
var d;     // should be 3    actually emitted 0
10: decl local #3
11: #
print(d);
12: local #3
13: Func(1,0): Print
14: #
15: leave block(1)
16: leave block(2)
17: leave block(1)
18: progend
```