### PR TITLE
fix optimizer bug: can stop optimizing prematurely if pre- or post-decrement operators are present

### DIFF
--- a/pol-core/bscript/expression.cpp
+++ b/pol-core/bscript/expression.cpp
@@ -524,9 +524,9 @@ bool Expression::optimize_token( int i )
           operand->id = INS_SET_MEMBER_ID_UNMINUSMINUS_POST;
         delete oper;
         tokens.erase( tokens.begin() + i );
+        return true;
       }
     }
-    return true;
   }
   else if ( oper->id == TOK_MEMBER )
   {

--- a/testsuite/escript/opt/opt005-stopped-optimizing-early.src
+++ b/testsuite/escript/opt/opt005-stopped-optimizing-early.src
@@ -1,0 +1,9 @@
+var i := 3;
+var ii;
+
+// The OG optimizer had a bug where would exit early
+// after not optimizing (ii-), and so it would
+// not optimize the global assignment + consume.
+ii := 1 - (--i);
+print(i);
+print(ii);


### PR DESCRIPTION
optimize_token() is meant to return true only if it performs an optimization.

By returning true when it did not, it makes the optimizer stop trying.

A script like this can trigger the condition:

```
var i := 3;
var ii;

ii := 1 - (--i);
print(i);
print(ii);
```

Notice that line 4 does not optimize to an 'assign-consume' and therefore does not optimize to 'assign global`

Listfile before (see instructions 6, 11, and 12):

```
/vagrant/testsuite/escript/opt/opt005-stopped-optimizing-early.src, Line 1
var i := 3;
0: decl global #0
1: 3L
2: :=
3: #
var ii;
4: decl global #1
5: #
ii := 1 - (--i);
6: global #1
7: 1L
8: global #0
9: unary --
10: -
11: :=
12: #
print(i);
13: global #0
14: Func(1,0): Print
15: #
print(ii);
16: global #1
17: Func(1,0): Print
18: #
19: progend
```

Listfile after (see instruction 10):

```
/vagrant/testsuite/escript/opt/opt005-stopped-optimizing-early.src, Line 1
var i := 3;
0: decl global #0
1: 3L
2: :=
3: #
var ii;
4: decl global #1
5: #
ii := 1 - (--i);
6: 1L
7: global #0
8: unary --
9: -
10: global1 :=
print(i);
11: global #0
12: Func(1,0): Print
13: #
print(ii);
14: global #1
15: Func(1,0): Print
16: #
17: progend
```