### PR TITLE
Checkskill attrname

### DIFF
--- a/docs/docs.polserver.com/pol100/attributesem.xml
+++ b/docs/docs.polserver.com/pol100/attributesem.xml
@@ -14,9 +14,9 @@
   </fileheader>
   
 <function name="CheckSkill">
-	<prototype>CheckSkill( character, skillid, difficulty, points )</prototype>
+	<prototype>CheckSkill( character, skillid_or_attrname, difficulty, points )</prototype>
 	<parameter name="character" value="Character Ref" />
-	<parameter name="skillid" value="Integer skill/attribute ID" />
+	<parameter name="skillid_or_attrname" value="Integer (skill/attribute ID) or String (attribute name)" />
 	<parameter name="difficulty" value="Integer skill use difficulty" />
 	<parameter name="points" value="Integer skill gain on success" />
 	<explain>NOTE: Calls the Syshook script CheckSkill. If it doesn't exist, always returns false.</explain>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-31-2020</datemodified>
+		<datemodified>08-01-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-01-2020</date>
+			<author>Turley:</author>
+			<change type="Added">attribute.em CheckSkill() accepts now also the attribute name instead of the skill id.</change>
+		</entry>
 		<entry>
 			<date>07-31-2020</date>
 			<author>Nando:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+08-01-2020 Turley:
+    Added: attribute.em CheckSkill() accepts now also the attribute name instead of the skill id.
 07-31-2020 Nando:
     Fixed: Quality of any item can now be directly assigned from an ItemDescriptor. Before this only worked for Equipment (Armor & Weapons).
     Fixed: Stackable items with different values of 'quality' will no longer stack.

--- a/pol-core/pol/loadunld.cpp
+++ b/pol-core/pol/loadunld.cpp
@@ -23,6 +23,7 @@
 #include "item/equipmnt.h"
 #include "item/itemdesc.h"
 #include "landtile.h"
+#include "mobile/attribute.h"
 #include "objtype.h"
 #include "polcfg.h"
 
@@ -38,7 +39,6 @@ namespace Mobile
 {
 void unload_armor_zones();
 void load_armor_zones();
-void load_attributes_cfg();
 }  // namespace Mobile
 namespace Multi
 {
@@ -204,6 +204,7 @@ void load_data()
 
   checkpoint( "load_uoskills_cfg" );
   load_uoskills_cfg();
+  Mobile::combine_attributes_skillid();
 
   checkpoint( "load_uoclient_cfg" );
   load_uoclient_cfg();

--- a/pol-core/pol/mobile/attribute.cpp
+++ b/pol-core/pol/mobile/attribute.cpp
@@ -14,6 +14,7 @@
 #include "../globals/settings.h"
 #include "../globals/uvars.h"
 #include "../syshook.h"
+#include "../uoskills.h"
 
 namespace Pol
 {
@@ -48,7 +49,8 @@ Attribute::Attribute( const Plib::Package* pkg, Clib::ConfigElem& elem )
       disable_core_checks( elem.remove_bool( "DisableCoreChecks", false ) ),
       default_cap(
           elem.remove_ushort( "DefaultCap", Core::settingsManager.ssopt.default_attribute_cap ) ),
-      script_( elem.remove_string( "SCRIPT", "" ), pkg, "scripts/skills/" )
+      script_( elem.remove_string( "SCRIPT", "" ), pkg, "scripts/skills/" ),
+      skillid( static_cast<Core::USKILLID>( -1 ) )
 {
   aliases.push_back( name );
   std::string tmp;
@@ -126,5 +128,20 @@ void clean_attributes()
   Core::gamestate.attributes.clear();
   Core::gamestate.attributes_byname.clear();
 }
+
+void combine_attributes_skillid()
+{
+  for ( auto& attr : Core::gamestate.attributes )
+  {
+    for ( const auto& skill : Core::gamestate.uo_skills )
+    {
+      if ( skill.pAttr == attr )
+      {
+        attr->skillid = static_cast<Core::USKILLID>( skill.skillid );
+        break;
+      }
+    }
+  }
 }
-}
+}  // namespace Mobile
+}  // namespace Pol

--- a/pol-core/pol/mobile/attribute.h
+++ b/pol-core/pol/mobile/attribute.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../scrdef.h"
+#include "../skillid.h"
 
 namespace Pol
 {
@@ -56,12 +57,16 @@ public:
 
   Core::ScriptDef script_;
 
+  Core::USKILLID skillid;
+
   static Attribute* FindAttribute( const std::string& str );
   static Attribute* FindAttribute( unsigned attrid );
 };
 
 
+void load_attributes_cfg();
 void clean_attributes();
+void combine_attributes_skillid();
 
 const unsigned ATTRIBUTE_MIN_EFFECTIVE = 0;
 const unsigned ATTRIBUTE_MAX_EFFECTIVE = 6000;
@@ -74,6 +79,6 @@ const short ATTRIBUTE_MAX_TEMP_MOD = +30000;
 
 const short ATTRIBUTE_MIN_INTRINSIC_MOD = -30000;
 const short ATTRIBUTE_MAX_INTRINSIC_MOD = +30000;
-}
-}
+}  // namespace Mobile
+}  // namespace Pol
 #endif

--- a/pol-core/pol/uoexec.cpp
+++ b/pol-core/pol/uoexec.cpp
@@ -780,8 +780,21 @@ bool UOExecutor::getSkillIdParam( unsigned param, USKILLID& skillid )
     const Mobile::Attribute* attr;
     if ( !getAttributeParam( param, attr ) )
       return false;
-    skillid = static_cast<USKILLID>( attr->attrid );
-    return true;
+    for ( unsigned short i = 0; i <= networkManager.uoclient_general.maxskills; ++i )
+    {
+      const UOSkill& uoskill = GetUOSkill( i );
+      if ( uoskill.pAttr == attr )
+      {
+        skillid = static_cast<USKILLID>( uoskill.skillid );
+        return true;
+      }
+    }
+    const String* attrname;
+    getStringParam( param, attrname );  // no error check needed
+    std::string report = "Parameter " + Clib::tostring( param ) + " value " + attrname->value() +
+                         " has no skill id defined";
+    setFunctionResult( new BError( report ) );
+    return false;
   }
   std::string report = "Invalid parameter type.  Expected param " + Clib::tostring( param ) +
                        " as " + BObjectImp::typestr( BObjectImp::OTLong ) + " or " +

--- a/pol-core/pol/uoexec.cpp
+++ b/pol-core/pol/uoexec.cpp
@@ -780,15 +780,8 @@ bool UOExecutor::getSkillIdParam( unsigned param, USKILLID& skillid )
     const Mobile::Attribute* attr;
     if ( !getAttributeParam( param, attr ) )
       return false;
-    for ( unsigned short i = 0; i <= networkManager.uoclient_general.maxskills; ++i )
-    {
-      const UOSkill& uoskill = GetUOSkill( i );
-      if ( uoskill.pAttr == attr )
-      {
-        skillid = static_cast<USKILLID>( uoskill.skillid );
-        return true;
-      }
-    }
+    if ( attr->skillid != -1 )
+      return attr->skillid;
     const String* attrname;
     getStringParam( param, attrname );  // no error check needed
     std::string report = "Parameter " + Clib::tostring( param ) + " value " + attrname->value() +

--- a/pol-core/support/scripts/attributes.em
+++ b/pol-core/support/scripts/attributes.em
@@ -11,8 +11,7 @@ const ATTRIBUTE_PRECISION_TENTHS := 1;
 
 const ATTRIBUTE_MAX_BASE := 60000;
 
-// To-Fix: Uses a skillid - should take in an attribute name.
-CheckSkill( character, skillid, difficulty, points );
+CheckSkill( character, skillid_or_attrname, difficulty, points );
 
 AlterAttributeTemporaryMod( character, attrname, delta_tenths );
 


### PR DESCRIPTION
Checkskill accepts now not only the skillid but also as string the attribute name.
It's solved in general but the method is currently only used by CheckSkill.