### PR TITLE
Move Compiler.verbosity_level_ to CompilerConfig.VerbosityLevel

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-01-2020</datemodified>
+		<datemodified>08-03-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-03-2020</date>
+			<author>Syzygy:</author>
+			<change type="Added">ecompile.cfg &quot;VerbosityLevel&quot; option (still also controlled by ecompile -v N)</change>
+		</entry>
 		<entry>
 			<date>08-01-2020</date>
 			<author>Turley:</author>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,7 +8,7 @@
 		<entry>
 			<date>08-03-2020</date>
 			<author>Syzygy:</author>
-			<change type="Added">ecompile.cfg &quot;VerbosityLevel&quot; option (still also controlled by ecompile -v N)</change>
+			<change type="Added">ecompile.cfg &quot;VerbosityLevel&quot; option (setting this is equivalent to ecompile -vN)</change>
 		</entry>
 		<entry>
 			<date>08-01-2020</date>

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -57,7 +57,6 @@ extern int include_debug;
 namespace Legacy
 {
 bool Compiler::check_filecase_;
-int Compiler::verbosity_level_;
 
 
 std::string getpathof( const std::string& fname )
@@ -275,7 +274,7 @@ int Compiler::isLegal( Token& token )
 {
   if ( inExpr && ( token.id == TOK_ASSIGN ) )
   {
-    if ( verbosity_level_ >= 5 )
+    if ( compilercfg.VerbosityLevel >= 5 )
       compiler_warning( nullptr, "Warning! possible incorrect assignment.\n", "Near: ", curLine,
                         "\n" );
   }
@@ -2466,17 +2465,17 @@ int Compiler::useModule( const char* modulename )
 
   std::string filename_full = current_file_path + filename_part;
 
-  if ( verbosity_level_ >= 10 )
+  if ( compilercfg.VerbosityLevel >= 10 )
     INFO_PRINT << "Searching for " << filename_full << "\n";
 
   if ( !Clib::FileExists( filename_full.c_str() ) )
   {
     std::string try_filename_full = compilercfg.ModuleDirectory + filename_part;
-    if ( verbosity_level_ >= 10 )
+    if ( compilercfg.VerbosityLevel >= 10 )
       INFO_PRINT << "Searching for " << try_filename_full << "\n";
     if ( Clib::FileExists( try_filename_full.c_str() ) )
     {
-      if ( verbosity_level_ >= 10 )
+      if ( compilercfg.VerbosityLevel >= 10 )
         INFO_PRINT << "Found " << try_filename_full << "\n";
       // cout << "Using " << try_filename << endl;
       filename_full = try_filename_full;
@@ -2484,7 +2483,7 @@ int Compiler::useModule( const char* modulename )
   }
   else
   {
-    if ( verbosity_level_ >= 10 )
+    if ( compilercfg.VerbosityLevel >= 10 )
       INFO_PRINT << "Found " << filename_full << "\n";
   }
 
@@ -2638,16 +2637,16 @@ int Compiler::includeModule( const std::string& modulename )
         filename_full = pkg->dir() + path;
         std::string try_filename_full = pkg->dir() + "include/" + path;
 
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
           INFO_PRINT << "Searching for " << filename_full << "\n";
 
         if ( !Clib::FileExists( filename_full.c_str() ) )
         {
-          if ( verbosity_level_ >= 10 )
+          if ( compilercfg.VerbosityLevel >= 10 )
             INFO_PRINT << "Searching for " << try_filename_full << "\n";
           if ( Clib::FileExists( try_filename_full.c_str() ) )
           {
-            if ( verbosity_level_ >= 10 )
+            if ( compilercfg.VerbosityLevel >= 10 )
               INFO_PRINT << "Found " << try_filename_full << "\n";
 
             filename_full = try_filename_full;
@@ -2655,7 +2654,7 @@ int Compiler::includeModule( const std::string& modulename )
         }
         else
         {
-          if ( verbosity_level_ >= 10 )
+          if ( compilercfg.VerbosityLevel >= 10 )
             INFO_PRINT << "Found " << filename_full << "\n";
 
           if ( Clib::FileExists( try_filename_full.c_str() ) )
@@ -2667,7 +2666,7 @@ int Compiler::includeModule( const std::string& modulename )
       {
         filename_full = compilercfg.PolScriptRoot + path;
 
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
         {
           INFO_PRINT << "Searching for " << filename_full << "\n";
           if ( Clib::FileExists( filename_full.c_str() ) )
@@ -2683,17 +2682,17 @@ int Compiler::includeModule( const std::string& modulename )
   }
   else
   {
-    if ( verbosity_level_ >= 10 )
+    if ( compilercfg.VerbosityLevel >= 10 )
       INFO_PRINT << "Searching for " << filename_full << "\n";
 
     if ( !Clib::FileExists( filename_full.c_str() ) )
     {
       std::string try_filename_full = compilercfg.IncludeDirectory + filename_part;
-      if ( verbosity_level_ >= 10 )
+      if ( compilercfg.VerbosityLevel >= 10 )
         INFO_PRINT << "Searching for " << try_filename_full << "\n";
       if ( Clib::FileExists( try_filename_full.c_str() ) )
       {
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
           INFO_PRINT << "Found " << try_filename_full << "\n";
 
         // cout << "Using " << try_filename << endl;
@@ -2702,7 +2701,7 @@ int Compiler::includeModule( const std::string& modulename )
     }
     else
     {
-      if ( verbosity_level_ >= 10 )
+      if ( compilercfg.VerbosityLevel >= 10 )
         INFO_PRINT << "Found " << filename_full << "\n";
     }
   }
@@ -2961,7 +2960,7 @@ int Compiler::handleBracketedFor_basic( CompilerContext& ctx )
       and end value.  Only the iterator can be accessed, for now.
       */
   program->addlocalvar( itrvar.tokval() );
-  if ( verbosity_level_ >= 5 )
+  if ( compilercfg.VerbosityLevel >= 5 )
     localscope.addvar( itrvar.tokval(), for_ctx );
   else
     localscope.addvar( itrvar.tokval(), for_ctx, false );
@@ -3925,16 +3924,16 @@ bool Compiler::read_function_declarations_in_included_file( const char* modulena
         filename_full = pkg->dir() + path;
         std::string try_filename_full = pkg->dir() + "include/" + path;
 
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
           INFO_PRINT << "Searching for " << filename_full << "\n";
 
         if ( !Clib::FileExists( filename_full.c_str() ) )
         {
-          if ( verbosity_level_ >= 10 )
+          if ( compilercfg.VerbosityLevel >= 10 )
             INFO_PRINT << "Searching for " << try_filename_full << "\n";
           if ( Clib::FileExists( try_filename_full.c_str() ) )
           {
-            if ( verbosity_level_ >= 10 )
+            if ( compilercfg.VerbosityLevel >= 10 )
               INFO_PRINT << "Found " << try_filename_full << "\n";
 
             filename_full = try_filename_full;
@@ -3942,7 +3941,7 @@ bool Compiler::read_function_declarations_in_included_file( const char* modulena
         }
         else
         {
-          if ( verbosity_level_ >= 10 )
+          if ( compilercfg.VerbosityLevel >= 10 )
             INFO_PRINT << "Found " << filename_full << "\n";
 
           if ( Clib::FileExists( try_filename_full.c_str() ) )
@@ -3954,7 +3953,7 @@ bool Compiler::read_function_declarations_in_included_file( const char* modulena
       {
         filename_full = compilercfg.PolScriptRoot + path;
 
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
         {
           INFO_PRINT << "Searching for " << filename_full << "\n";
           if ( Clib::FileExists( filename_full.c_str() ) )
@@ -3970,17 +3969,17 @@ bool Compiler::read_function_declarations_in_included_file( const char* modulena
   }
   else
   {
-    if ( verbosity_level_ >= 10 )
+    if ( compilercfg.VerbosityLevel >= 10 )
       INFO_PRINT << "Searching for " << filename_full << "\n";
 
     if ( !Clib::FileExists( filename_full.c_str() ) )
     {
       std::string try_filename_full = compilercfg.IncludeDirectory + filename_part;
-      if ( verbosity_level_ >= 10 )
+      if ( compilercfg.VerbosityLevel >= 10 )
         INFO_PRINT << "Searching for " << try_filename_full << "\n";
       if ( Clib::FileExists( try_filename_full.c_str() ) )
       {
-        if ( verbosity_level_ >= 10 )
+        if ( compilercfg.VerbosityLevel >= 10 )
           INFO_PRINT << "Found " << try_filename_full << "\n";
 
         filename_full = try_filename_full;
@@ -3988,7 +3987,7 @@ bool Compiler::read_function_declarations_in_included_file( const char* modulena
     }
     else
     {
-      if ( verbosity_level_ >= 10 )
+      if ( compilercfg.VerbosityLevel >= 10 )
         INFO_PRINT << "Found " << filename_full << "\n";
     }
   }
@@ -4293,7 +4292,7 @@ int Compiler::compileFile( const char* in_file )
     std::string filepath = Clib::FullPath( in_file );
     referencedPathnames.push_back( filepath );
     current_file_path = getpathof( filepath );
-    if ( verbosity_level_ >= 11 )
+    if ( compilercfg.VerbosityLevel >= 11 )
       INFO_PRINT << "cfp: " << current_file_path << "\n";
     Clib::FileContents fc( filepath.c_str() );
 

--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -122,9 +122,7 @@ class Compiler final : public SmartParser
 {
 public:
   static bool check_filecase_;
-  static int verbosity_level_;
   static void setCheckFileCase( bool check ) { check_filecase_ = check; }
-  static void setVerbosityLevel( int vlev ) { verbosity_level_ = vlev; }
 
 private:
   std::string current_file_path;

--- a/pol-core/bscript/compilercfg.cpp
+++ b/pol-core/bscript/compilercfg.cpp
@@ -41,6 +41,8 @@ void CompilerConfig::Read( const std::string& path )
   GenerateListing = elem.remove_bool( "GenerateListing", false );
   GenerateDebugInfo = elem.remove_bool( "GenerateDebugInfo", false );
   GenerateDebugTextInfo = elem.remove_bool( "GenerateDebugTextInfo", false );
+
+  VerbosityLevel = elem.remove_int( "VerbosityLevel", 0 );
   DisplayWarnings = elem.remove_bool( "DisplayWarnings", false );
   CompileAspPages = elem.remove_bool( "CompileAspPages", false );
   AutoCompileByDefault = elem.remove_bool( "AutoCompileByDefault", false );

--- a/pol-core/bscript/compilercfg.h
+++ b/pol-core/bscript/compilercfg.h
@@ -23,6 +23,7 @@ struct CompilerConfig
   bool GenerateListing;
   bool GenerateDebugInfo;
   bool GenerateDebugTextInfo;
+  int VerbosityLevel;
   bool DisplayWarnings;
   bool GenerateDependencyInfo;
   bool CompileAspPages;

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,6 @@
 ﻿-- POL100 --
 08-03-2020 Syzygy:
-    Added: ecompile.cfg "VerbosityLevel" option (still also controlled by ecompile -v N)
+    Added: ecompile.cfg "VerbosityLevel" option (setting this is equivalent to ecompile -vN)
 08-01-2020 Turley:
     Added: attribute.em CheckSkill() accepts now also the attribute name instead of the skill id.
 07-31-2020 Nando:

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100 --
+08-03-2020 Syzygy:
+    Added: ecompile.cfg "VerbosityLevel" option (still also controlled by ecompile -v N)
 08-01-2020 Turley:
     Added: attribute.em CheckSkill() accepts now also the attribute name instead of the skill id.
 07-31-2020 Nando:

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -100,7 +100,6 @@ int debug = 0;
 bool quiet = false;
 bool opt_generate_wordlist = false;
 bool keep_building = false;
-bool verbose = false;
 bool force_update = false;
 bool show_timing_details = false;
 bool timing_quiet_override = false;
@@ -180,7 +179,7 @@ bool compile_file( const char* path )
     unsigned int ecl_timestamp = Clib::GetFileTimestamp( filename_ecl.c_str() );
     if ( Clib::GetFileTimestamp( filename_src.c_str() ) >= ecl_timestamp )
     {
-      if ( verbose )
+      if ( compilercfg.VerbosityLevel > 0 )
         INFO_PRINT << filename_src << " is newer than " << filename_ecl << "\n";
       all_old = false;
     }
@@ -196,7 +195,7 @@ bool compile_file( const char* path )
         {
           if ( Clib::GetFileTimestamp( depname.c_str() ) >= ecl_timestamp )
           {
-            if ( verbose )
+            if ( compilercfg.VerbosityLevel > 0 )
               INFO_PRINT << depname << " is newer than " << filename_ecl << "\n";
             all_old = false;
             break;
@@ -205,7 +204,7 @@ bool compile_file( const char* path )
       }
       else
       {
-        if ( verbose )
+        if ( compilercfg.VerbosityLevel > 0 )
           INFO_PRINT << filename_dep << " does not exist."
                      << "\n";
         all_old = false;
@@ -461,7 +460,6 @@ int readargs( int argc, char** argv )
         break;
 
       case 'v':
-        verbose = true;
         int vlev;
         vlev = atoi( &argv[i][2] );
         if ( !vlev )

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -466,7 +466,7 @@ int readargs( int argc, char** argv )
         vlev = atoi( &argv[i][2] );
         if ( !vlev )
           vlev = 1;
-        Legacy::Compiler::setVerbosityLevel( vlev );
+        compilercfg.VerbosityLevel = vlev;
         break;
 
       case 'x':

--- a/pol-core/support/scripts/ecompile.cfg.example
+++ b/pol-core/support/scripts/ecompile.cfg.example
@@ -52,6 +52,11 @@ GenerateDebugInfo=0
 GenerateDebugTextInfo=0
 
 #
+# VerbosityLevel
+# Enabled logging more information such as locations of include files.
+VerbosityLevel=0
+
+#
 # DisplayWarnings
 # Directs eCompile to display warnings such as 'unused variables'.
 # Default is 1


### PR DESCRIPTION
Now settable through ecompile.cfg `VerbosityLevel`

The new compiler needs access to the variable soon-to-be-formerly-known-as `Compiler::verbosity_level_`, so this PR moves it to CompilerConfig.
