### PR TITLE
Two new members for polcore()

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-03-2020</datemodified>
+		<datemodified>08-04-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-04-2020</date>
+			<author>AsYlum:</author>
+			<change type="Added">polcore().last_character_serial returns last character serial assigned by core<br/>
+polcore().last_item_serial returns last item serial assigned by core</change>
+		</entry>
 		<entry>
 			<date>08-03-2020</date>
 			<author>Kevin:</author>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -547,6 +547,8 @@
 <member mname="queued_iostats" type="Array" access="r/o" mdesc="structure same as iostats, but for queued I/O stats" />
 <member mname="pkt_status" type="Array" access="r/o" mdesc="returns and array of info structures about packets currently in the queue" />
 <member mname="memory_usage" type="Integer" access="r/o" mdesc="current process usage in KB" />
+<member mname="last_character_serial" type="Integer" access="r/o" mdesc="Last character serial number assigned by core" />
+<member mname="last_item_serial" type="Integer" access="r/o" mdesc="Last item serial number assigned by core" />
 
 <method proto="log_profile(bool clear)" returns="true/false" desc="Writes the script profile to the log, optionally clearing it after." />
 <method proto="set_priority_divide(int divide)" returns="true/false" desc="Sets the priority divide to 'divide'" />

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 ﻿-- POL100 --
+08-04-2020 AsYlum:
+    Added: polcore().last_character_serial returns last character serial assigned by core
+           polcore().last_item_serial returns last item serial assigned by core
 08-03-2020 Kevin:
     Added: Optional parameter exit_code to uo::Shutdown() to change the pol process' exit code.
 08-03-2020 Syzygy:

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -1896,6 +1896,9 @@ BObjectImp* GetCoreVariable( const char* corevar )
   LONG_COREVAR( combat_operations_per_min, GET_PROFILEVAR_PER_MIN( combat_operations ) );
   LONG_COREVAR( error_creations_per_min, GET_PROFILEVAR_PER_MIN( error_creations ) );
 
+  LONG_COREVAR( last_character_serial, GetCurrentCharSerialNumber() );
+  LONG_COREVAR( last_item_serial, GetCurrentItemSerialNumber() );
+
   LONG_COREVAR( tasks_ontime_per_min, GET_PROFILEVAR_PER_MIN( tasks_ontime ) );
   LONG_COREVAR( tasks_late_per_min, GET_PROFILEVAR_PER_MIN( tasks_late ) );
   LONG_COREVAR( tasks_late_ticks_per_min, GET_PROFILEVAR_PER_MIN( tasks_late_ticks ) );


### PR DESCRIPTION
- polcore().last_character_serial returns last character serial assigned by core
- polcore().last_item_serial returns last item serial assigned by core

Those two properties are already saved to data/pol.txt but where was no way to read them from escript.

Tell me what do you think. Worth merging?