### PR TITLE
Add ecompile mode: compare old and new compiler output

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -9,6 +9,7 @@ set (bscript_sources    # sorted !
   ../../lib/EscriptGrammar/EscriptParserListener.h
   compiler/Compiler.cpp
   compiler/Compiler.h
+  compiler/LegacyFunctionOrder.h
   CMakeSources.cmake
   StdAfx.h
   StoredToken.cpp

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -36,6 +36,7 @@
 #include "../clib/strutil.h"
 #include "../plib/pkg.h"
 #include "compctx.h"
+#include "compiler/LegacyFunctionOrder.h"
 #include "compilercfg.h"
 #include "eprog.h"
 #include "expression.h"
@@ -4113,6 +4114,7 @@ bool Compiler::read_function_declarations( const CompilerContext& ctx )
 
 int Compiler::emit_function( UserFunction& uf )
 {
+  userfunc_emit_order.push_back( uf.name );
   CompilerContext ctx( uf.ctx );
   // cout << "emitting " << uf.name << ": " << program->tokens.next() << endl;
   int res = handleBracketedFunction3( uf, ctx );
@@ -4389,6 +4391,27 @@ void Compiler::write_dbg( const std::string& pathname, bool include_debug_text )
 void Compiler::write_included_filenames( const std::string& pathname )
 {
   writeIncludedFilenames( pathname.c_str() );
+}
+
+Pol::Bscript::Compiler::LegacyFunctionOrder Compiler::get_legacy_function_order() const
+{
+  std::vector<std::string> modulefunc_emit_order;
+
+  if ( program.get() )
+  {
+    for ( auto module : program->modules )
+    {
+      for ( auto function : module->used_functions )
+      {
+        std::string scoped_name =
+            std::string( module->modulename ) + "::" + std::string( function->name );
+
+        modulefunc_emit_order.push_back( scoped_name );
+      }
+    }
+  }
+
+  return Pol::Bscript::Compiler::LegacyFunctionOrder{ modulefunc_emit_order, userfunc_emit_order };
 }
 
 }  // namespace Legacy

--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -40,6 +40,10 @@ namespace Pol
 {
 namespace Bscript
 {
+namespace Compiler
+{
+  class LegacyFunctionOrder;
+}
 class EScriptProgram;
 class EScriptProgramCheckpoint;
 class FunctionalityModule;
@@ -282,6 +286,8 @@ public:
   void write_dbg( const std::string& pathname, bool include_debug_text ) override;
   void write_included_filenames( const std::string& pathname ) override;
 
+  Pol::Bscript::Compiler::LegacyFunctionOrder get_legacy_function_order() const;
+
   // phase 0: determining bracket syntax
 
   // phase 1: read function declarations, constants (but clear constants)
@@ -298,6 +304,8 @@ public:
   int emit_function( UserFunction& uf );
   int emit_functions();
   void patch_callers( UserFunction& uf );
+
+  std::vector<std::string> userfunc_emit_order;
 
 private:
   std::vector<char*> delete_these_arrays;

--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -42,7 +42,7 @@ namespace Bscript
 {
 namespace Compiler
 {
-  class LegacyFunctionOrder;
+  struct LegacyFunctionOrder;
 }
 class EScriptProgram;
 class EScriptProgramCheckpoint;

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -10,9 +10,9 @@ Compiler::Compiler() = default;
 
 Compiler::~Compiler() = default;
 
-bool Compiler::compile_file( const std::string& /*filename*/ )
+bool Compiler::compile_file( const std::string& filename )
 {
-  return false;
+  return compile_file( filename, nullptr );
 }
 
 bool Compiler::write_ecl( const std::string& /*pathname*/ )
@@ -30,6 +30,12 @@ void Compiler::write_dbg( const std::string& /*pathname*/, bool /*include_debug_
 
 void Compiler::write_included_filenames( const std::string& /*pathname*/ )
 {
+}
+
+bool Compiler::compile_file( const std::string& /*filename*/,
+                             const LegacyFunctionOrder* /*legacy_function_order*/ )
+{
+  return false;
 }
 
 }  // namespace Compiler

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -9,6 +9,7 @@ namespace Bscript
 {
 namespace Compiler
 {
+struct LegacyFunctionOrder;
 
 class Compiler : public Pol::Bscript::Facility::Compiler
 {
@@ -23,6 +24,8 @@ public:
   void write_listing( const std::string& pathname ) override;
   void write_dbg( const std::string& pathname, bool include_debug_text ) override;
   void write_included_filenames( const std::string& pathname ) override;
+
+  bool compile_file( const std::string& filename, const LegacyFunctionOrder* );
 };
 
 }  // namespace Compiler

--- a/pol-core/bscript/compiler/LegacyFunctionOrder.h
+++ b/pol-core/bscript/compiler/LegacyFunctionOrder.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_LEGACYFUNCTIONORDER_H
+#define POLSERVER_LEGACYFUNCTIONORDER_H
+
+#include <string>
+#include <vector>
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+struct LegacyFunctionOrder
+{
+  std::vector<std::string> modulefunc_emit_order;
+  std::vector<std::string> userfunc_emit_order;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_LEGACYFUNCTIONORDER_H

--- a/pol-core/bscript/compilercfg.cpp
+++ b/pol-core/bscript/compilercfg.cpp
@@ -60,6 +60,7 @@ void CompilerConfig::Read( const std::string& path )
   ErrorOnFileCaseMissmatch = elem.remove_bool( "ErrorOnFileCaseMissmatch", false );
 
   UseCompiler2020 = elem.remove_bool( "UseCompiler2020", false );
+  CompareCompilerOutput = elem.remove_bool( "CompareCompilerOutput", false );
 
 // This is where we TRY to validate full paths from what was provided in the
 // ecompile.cfg. Maybe Turley or Shini can find the best way to do this in *nix.

--- a/pol-core/bscript/compilercfg.h
+++ b/pol-core/bscript/compilercfg.h
@@ -39,6 +39,7 @@ struct CompilerConfig
   bool ParanoiaWarnings;
   bool ErrorOnFileCaseMissmatch;
   bool UseCompiler2020;
+  bool CompareCompilerOutput;
 
   void Read( const std::string& path );
   void SetDefaults();


### PR DESCRIPTION
Add -G / CompareCompilerOutput ecompile mode that runs old and new compiler and compares output.

Add `LegacyFunctionOrder` because for parity the new compiler needs to know how the old compiler ordered functions.