### PR TITLE
Add SourceFileIdentifier, SourceLocation, formatfwd

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -7,14 +7,18 @@ set (bscript_sources    # sorted !
   ../../lib/EscriptGrammar/EscriptParserBaseListener.h
   ../../lib/EscriptGrammar/EscriptParserListener.cpp
   ../../lib/EscriptGrammar/EscriptParserListener.h
-  compiler/Compiler.cpp
-  compiler/Compiler.h
-  compiler/LegacyFunctionOrder.h
   CMakeSources.cmake
   StdAfx.h
   StoredToken.cpp
   StoredToken.h
-  berror.cpp 
+  compiler/Compiler.cpp
+  compiler/Compiler.h
+  compiler/LegacyFunctionOrder.h
+  compiler/file/SourceFileIdentifier.cpp
+  compiler/file/SourceFileIdentifier.h
+  compiler/file/SourceLocation.cpp
+  compiler/file/SourceLocation.h
+  berror.cpp
   berror.h
   blong.cpp 
   bobject.h

--- a/pol-core/bscript/compiler/file/SourceFileIdentifier.cpp
+++ b/pol-core/bscript/compiler/file/SourceFileIdentifier.cpp
@@ -1,0 +1,18 @@
+#include "SourceFileIdentifier.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+SourceFileIdentifier::SourceFileIdentifier( unsigned index, std::string pathname )
+  : index( index ), pathname( std::move( pathname ) )
+{
+}
+
+SourceFileIdentifier::~SourceFileIdentifier() = default;
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/file/SourceFileIdentifier.h
+++ b/pol-core/bscript/compiler/file/SourceFileIdentifier.h
@@ -1,0 +1,29 @@
+#ifndef POLSERVER_SOURCEFILEIDENTIFIER_H
+#define POLSERVER_SOURCEFILEIDENTIFIER_H
+
+#include <string>
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class SourceFileIdentifier
+{
+public:
+  SourceFileIdentifier( unsigned index, std::string pathname );
+  ~SourceFileIdentifier();
+
+  const unsigned index;
+  const std::string pathname;
+
+  SourceFileIdentifier( const SourceFileIdentifier& ) = delete;
+  SourceFileIdentifier& operator=( const SourceFileIdentifier& ) = delete;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_SOURCEFILEIDENTIFIER_H

--- a/pol-core/bscript/compiler/file/SourceLocation.cpp
+++ b/pol-core/bscript/compiler/file/SourceLocation.cpp
@@ -1,0 +1,68 @@
+#include "SourceLocation.h"
+
+#include <antlr4-runtime.h>
+
+#include "../clib/logfacility.h"
+
+#include "compiler/file/SourceFileIdentifier.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+SourceLocation::SourceLocation( const SourceFileIdentifier* source_file_identifier,
+                                const unsigned short line_number,
+                                const unsigned short character_column )
+  : source_file_identifier( source_file_identifier ),
+    line_number( line_number ),
+    character_column( character_column )
+{
+}
+
+SourceLocation::SourceLocation( const SourceFileIdentifier* source_file_identifier,
+                                antlr4::ParserRuleContext& ctx )
+  : source_file_identifier( source_file_identifier ),
+    line_number( ctx.getStart()->getLine() ),
+    character_column( ctx.getStart()->getCharPositionInLine()+1 )
+{
+}
+
+SourceLocation::SourceLocation( const SourceFileIdentifier* source_file_identifier,
+                                antlr4::tree::TerminalNode& ctx )
+  : source_file_identifier( source_file_identifier ),
+    line_number( ctx.getSymbol()->getLine() ),
+    character_column( ctx.getSymbol()->getCharPositionInLine()+1 )
+{
+}
+
+void SourceLocation::debug( const std::string& msg ) const
+{
+  ERROR_PRINT << ( *this ) << ": " << msg << "\n";
+}
+
+void SourceLocation::internal_error( const std::string& msg ) const
+{
+  ERROR_PRINT << ( *this ) << ": " << msg << "\n";
+  throw std::runtime_error( msg );
+}
+
+void SourceLocation::internal_error( const std::string& msg, const SourceLocation& related ) const
+{
+  ERROR_PRINT << ( *this ) << ": " << msg << "\n"
+              << "  See also: " << related << "\n";
+  throw std::runtime_error( msg );
+}
+
+fmt::Writer& operator<<( fmt::Writer& w, const SourceLocation& location )
+{
+  w << location.source_file_identifier->pathname;
+  if ( location.line_number || location.character_column )
+    w << ":" << location.line_number << ":" << location.character_column;
+  return w;
+}
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/file/SourceLocation.h
+++ b/pol-core/bscript/compiler/file/SourceLocation.h
@@ -1,0 +1,48 @@
+#ifndef POLSERVER_SOURCELOCATION_H
+#define POLSERVER_SOURCELOCATION_H
+
+#include "../clib/formatfwd.h"
+#include <string>
+
+namespace antlr4
+{
+class ParserRuleContext;
+namespace tree
+{
+class TerminalNode;
+}
+}
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class SourceFileIdentifier;
+
+class SourceLocation
+{
+public:
+  SourceLocation( const SourceFileIdentifier*, unsigned short line_number,
+                  unsigned short character_column );
+  SourceLocation( const SourceFileIdentifier*, antlr4::ParserRuleContext& );
+  SourceLocation( const SourceFileIdentifier*, antlr4::tree::TerminalNode& );
+
+  void debug( const std::string& msg ) const;
+
+  [[noreturn]] void internal_error( const std::string& msg ) const;
+  [[noreturn]] void internal_error( const std::string& msg, const SourceLocation& related ) const;
+
+  const SourceFileIdentifier* const source_file_identifier;
+  const unsigned short line_number;
+  const unsigned short character_column; // 1-based on line, as seen in an editor
+};
+
+fmt::Writer& operator<<( fmt::Writer&, const SourceLocation& );  // pathname:line:column
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_SOURCELOCATION_H

--- a/pol-core/bscript/compiler/file/SourceLocation.h
+++ b/pol-core/bscript/compiler/file/SourceLocation.h
@@ -34,6 +34,10 @@ public:
   [[noreturn]] void internal_error( const std::string& msg ) const;
   [[noreturn]] void internal_error( const std::string& msg, const SourceLocation& related ) const;
 
+  // There is a vector of std::unique_ptr<SourceFileIdentifier> that owns
+  // the SourceFileIdentifier instances for a given script compilation.
+  // If you hold onto a SourceFileIdentifier after that vector goes
+  // out of scope, this will be a dangling pointer.
   const SourceFileIdentifier* const source_file_identifier;
   const unsigned short line_number;
   const unsigned short character_column; // 1-based on line, as seen in an editor

--- a/pol-core/clib/CMakeSources.cmake
+++ b/pol-core/clib/CMakeSources.cmake
@@ -41,6 +41,7 @@ set (clib_sources
   fileutil.cpp 
   fileutil.h
   fixalloc.h
+  formatfwd.h
   iohelp.cpp
   iohelp.h
   kbhit.cpp

--- a/pol-core/clib/formatfwd.h
+++ b/pol-core/clib/formatfwd.h
@@ -1,0 +1,10 @@
+#ifndef POLSERVER_FORMATFWD_H
+#define POLSERVER_FORMATFWD_H
+
+namespace fmt
+{
+template <typename Char> class BasicWriter;
+typedef BasicWriter<char> Writer;
+}
+
+#endif  // POLSERVER_FORMATFWD_H


### PR DESCRIPTION
Adds `SourceFileIdentifier`, which identifies a `.src`, `.inc`, or `.em` file used to compile a script:
- pathname to source file
- an index with respect to all of the source files used to compile a given script
  - We'll use this when writing debug information.
  - File #0 is the `*.src` file
- Every `SourceFileIdentifier` has a lifetime that lasts until the script is compiled
  - There will be few instances of these, but many references to them.
- I suppose I could have used a flyweight.

Adds `SourceFileLocation`, which indicates a specific location in a file:
- a `SourceFileIdentifier`
- `line number`: the line in the file, 1-based, like editors display
- `character_column`: the character column within the line, 1-based, like editors display
- There will be many, many of these (at least one per AST node)
- The `internal_error` methods are convenience methods for reporting internal logic errors.  This is in contrast to script errors. 
 The compiler will use a different mechanism to report those.

Adds clib/formatfwd.h:
- allows forward-declaring a `fmt::Writer`
