### PR TITLE
Add compiler/ Profile and Report

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -19,6 +19,8 @@ set (bscript_sources    # sorted !
   compiler/file/SourceLocation.cpp
   compiler/file/SourceLocation.h
   compiler/Profile.h
+  compiler/Report.cpp
+  compiler/Report.h
   berror.cpp
   berror.h
   blong.cpp 

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -18,6 +18,7 @@ set (bscript_sources    # sorted !
   compiler/file/SourceFileIdentifier.h
   compiler/file/SourceLocation.cpp
   compiler/file/SourceLocation.h
+  compiler/Profile.h
   berror.cpp
   berror.h
   blong.cpp 

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -1,5 +1,11 @@
 #include "Compiler.h"
 
+#include "../clib/fileutil.h"
+#include "../clib/logfacility.h"
+
+#include "Report.h"
+#include "compilercfg.h"
+
 namespace Pol
 {
 namespace Bscript
@@ -35,10 +41,42 @@ void Compiler::write_included_filenames( const std::string& /*pathname*/ )
 {
 }
 
-bool Compiler::compile_file( const std::string& /*filename*/,
-                             const LegacyFunctionOrder* /*legacy_function_order*/ )
+bool Compiler::compile_file( const std::string& filename,
+                             const LegacyFunctionOrder* legacy_function_order )
 {
-  return false;
+  bool success;
+  try
+  {
+    auto pathname = Clib::FullPath( filename.c_str() );
+
+    Report report( compilercfg.DisplayWarnings || compilercfg.ErrorOnWarning );
+
+    compile_file_steps( pathname, legacy_function_order, report );
+    display_outcome( pathname, report );
+
+    bool have_warning_as_error = report.warning_count() && compilercfg.ErrorOnWarning;
+    success = !report.error_count() && !have_warning_as_error;
+  }
+  catch ( std::exception& ex )
+  {
+    ERROR_PRINT << ex.what();
+    success = false;
+  }
+  return success;
+}
+
+void Compiler::compile_file_steps( const std::string& /*pathname*/,
+                                   const LegacyFunctionOrder*,
+                                   Report& )
+{
+}
+
+void Compiler::display_outcome( const std::string& filename, Report& report )
+{
+  INFO_PRINT << filename << ": " << report.error_count() << " errors";
+  if ( compilercfg.DisplayWarnings || compilercfg.ErrorOnWarning )
+    INFO_PRINT << ", " << report.warning_count() << " warnings";
+  INFO_PRINT << ".\n";
 }
 
 }  // namespace Compiler

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -6,7 +6,10 @@ namespace Bscript
 {
 namespace Compiler
 {
-Compiler::Compiler() = default;
+Compiler::Compiler( Profile& profile )
+  : profile( profile )
+{
+}
 
 Compiler::~Compiler() = default;
 

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -59,7 +59,7 @@ bool Compiler::compile_file( const std::string& filename,
   }
   catch ( std::exception& ex )
   {
-    ERROR_PRINT << ex.what();
+    ERROR_PRINT << ex.what() << '\n';
     success = false;
   }
   return success;

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -10,11 +10,12 @@ namespace Bscript
 namespace Compiler
 {
 struct LegacyFunctionOrder;
+class Profile;
 
 class Compiler : public Pol::Bscript::Facility::Compiler
 {
 public:
-  Compiler();
+  explicit Compiler( Profile& );
   ~Compiler() override;
   Compiler( const Compiler& ) = delete;
   Compiler& operator=( const Compiler& ) = delete;
@@ -26,6 +27,9 @@ public:
   void write_included_filenames( const std::string& pathname ) override;
 
   bool compile_file( const std::string& filename, const LegacyFunctionOrder* );
+
+private:
+  Profile& profile;
 };
 
 }  // namespace Compiler

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -11,6 +11,7 @@ namespace Compiler
 {
 struct LegacyFunctionOrder;
 class Profile;
+class Report;
 
 class Compiler : public Pol::Bscript::Facility::Compiler
 {
@@ -27,8 +28,11 @@ public:
   void write_included_filenames( const std::string& pathname ) override;
 
   bool compile_file( const std::string& filename, const LegacyFunctionOrder* );
+  void compile_file_steps( const std::string& pathname, const LegacyFunctionOrder*, Report& );
 
 private:
+  void display_outcome( const std::string& filename, Report& );
+
   Profile& profile;
 };
 

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_PROFILE_H
+#define POLSERVER_PROFILE_H
+
+#include <atomic>
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class Profile
+{
+public:
+  // there will be a number of std::atomic<> fields here.
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_PROFILE_H

--- a/pol-core/bscript/compiler/Report.cpp
+++ b/pol-core/bscript/compiler/Report.cpp
@@ -1,0 +1,42 @@
+#include "Report.h"
+
+#include "../clib/logfacility.h"
+
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+Report::Report( bool display_warnings )
+  : display_warnings( display_warnings ), errors( 0 ), warnings( 0 )
+{
+}
+
+void Report::report_error( const SourceLocation& source_location, const char* msg )
+{
+  ++errors;
+  ERROR_PRINT << source_location << ": error: " << msg;
+}
+
+void Report::report_warning( const SourceLocation& source_location, const char* msg )
+{
+  ++warnings;
+  ERROR_PRINT << source_location << ": warning: " << msg;
+}
+
+unsigned Report::error_count() const
+{
+  return errors;
+}
+
+unsigned Report::warning_count() const
+{
+  return warnings;
+}
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/Report.h
+++ b/pol-core/bscript/compiler/Report.h
@@ -1,0 +1,86 @@
+#ifndef POLSERVER_REPORT_H
+#define POLSERVER_REPORT_H
+
+#include <format/format.h>
+
+#include "compiler/file/SourceFileIdentifier.h"
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class SourceLocation;
+
+class Report
+{
+public:
+  explicit Report( bool display_warnings );
+  Report( const Report& ) = delete;
+  Report& operator=( const Report& ) = delete;
+
+  template <typename... Args>
+  inline void error( const SourceLocation& source_location, Args&&... args )
+  {
+    fmt::Writer w;
+    rec_write( w, std::forward<Args>( args )... );
+    report_error( source_location, w.c_str() );
+  }
+
+  template <typename... Args>
+  inline void error( const SourceFileIdentifier& ident, Args&&... args )
+  {
+    SourceLocation loc( &ident, 0, 0 );
+    error( loc, args... );
+  }
+
+  /*
+   * Report.fatal: use this when it's not possible to continue after a user-facing error.
+   */
+  template <typename... Args>
+  [[noreturn]] inline void fatal( const SourceLocation& source_location, Args&&... args )
+  {
+    fmt::Writer w;
+    rec_write( w, std::forward<Args>( args )... );
+    report_error( source_location, w.c_str() );
+    throw std::runtime_error( w.c_str() );
+  }
+
+  template <typename... Args>
+  inline void warning( const SourceLocation& source_location, Args&&... args )
+  {
+    if ( display_warnings )
+    {
+      fmt::Writer w;
+      rec_write( w, std::forward<Args>( args )... );
+      report_warning( source_location, w.c_str() );
+    }
+  }
+
+  unsigned error_count() const;
+  unsigned warning_count() const;
+
+private:
+  void report_error( const SourceLocation&, const char* msg );
+  void report_warning( const SourceLocation&, const char* msg );
+
+  inline void rec_write( fmt::Writer& /*w*/ ) {}
+  template <typename T, typename... Targs>
+  inline void rec_write( fmt::Writer& w, T&& value, Targs&&... Fargs )
+  {
+    w << value;
+    rec_write( w, std::forward<Targs>( Fargs )... );
+  }
+
+  const bool display_warnings;
+  unsigned errors;
+  unsigned warnings;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_REPORT_H

--- a/pol-core/bscript/compiler/Report.h
+++ b/pol-core/bscript/compiler/Report.h
@@ -21,6 +21,7 @@ public:
   Report( const Report& ) = delete;
   Report& operator=( const Report& ) = delete;
 
+  // Always put a newline at the end of the message.
   template <typename... Args>
   inline void error( const SourceLocation& source_location, Args&&... args )
   {
@@ -29,6 +30,7 @@ public:
     report_error( source_location, w.c_str() );
   }
 
+  // Always put a newline at the end of the message.
   template <typename... Args>
   inline void error( const SourceFileIdentifier& ident, Args&&... args )
   {
@@ -36,9 +38,9 @@ public:
     error( loc, args... );
   }
 
-  /*
-   * Report.fatal: use this when it's not possible to continue after a user-facing error.
-   */
+  // Report.fatal: use this when it's not possible to continue after a user-facing error.
+  //
+  // Always put a newline at the end of the message.
   template <typename... Args>
   [[noreturn]] inline void fatal( const SourceLocation& source_location, Args&&... args )
   {
@@ -48,6 +50,7 @@ public:
     throw std::runtime_error( w.c_str() );
   }
 
+  // Always put a newline at the end of the message.
   template <typename... Args>
   inline void warning( const SourceLocation& source_location, Args&&... args )
   {

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -11,6 +11,7 @@
 #include "../bscript/compiler.h"
 #include "../bscript/compiler/Compiler.h"
 #include "../bscript/compiler/LegacyFunctionOrder.h"
+#include "../bscript/compiler/Profile.h"
 #include "../bscript/compilercfg.h"
 #include "../bscript/escriptv.h"
 #include "../bscript/executor.h"
@@ -122,6 +123,7 @@ struct Summary
   unsigned CompiledScripts = 0;
   unsigned ScriptsWithCompileErrors = 0;
   size_t ThreadCount = 0;
+  Compiler::Profile profile;
 } summary;
 
 struct Comparison
@@ -173,7 +175,7 @@ bool compare_compiler_output( const std::string& path )
   Legacy::Compiler og_compiler;
   og_compiler.setQuiet( !debug );
 
-  Compiler::Compiler new_compiler;//( em_parse_tree_cache, inc_parse_tree_cache, summary.profile );
+  Compiler::Compiler new_compiler( summary.profile );
 
   Pol::Tools::HighPerfTimer og_timer;
   bool og_ok = og_compiler.compile_file( path );
@@ -347,7 +349,7 @@ bool compile_file( const char* path )
 
     if ( compilercfg.UseCompiler2020 )
     {
-      compiler = std::make_unique<Compiler::Compiler>();
+      compiler = std::make_unique<Compiler::Compiler>( summary.profile );
     }
     else
     {


### PR DESCRIPTION
Add `compiler/Profile`:
- will hold a bunch of `atomic<>` for elapsed times, cache hits/misses, and so forth.
- maybe should have called `Metrics`, or something else?

Add `compiler/Report`:
- tracks warning and error count for a given script compilation, and provides methods for displaying them with context.