### PR TITLE
Add CompilerWorkspace, BuilderWorkspace, CompilerWorkspaceBuilder

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -14,12 +14,18 @@ set (bscript_sources    # sorted !
   compiler/Compiler.cpp
   compiler/Compiler.h
   compiler/LegacyFunctionOrder.h
+  compiler/astbuilder/BuilderWorkspace.cpp
+  compiler/astbuilder/BuilderWorkspace.h
+  compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+  compiler/astbuilder/CompilerWorkspaceBuilder.h
   compiler/file/SourceFileIdentifier.cpp
   compiler/file/SourceFileIdentifier.h
   compiler/file/SourceLocation.cpp
   compiler/file/SourceLocation.h
   compiler/format/CompiledScriptSerializer.cpp
   compiler/format/CompiledScriptSerializer.h
+  compiler/model/CompilerWorkspace.cpp
+  compiler/model/CompilerWorkspace.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
   compiler/representation/ExportedFunction.cpp

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -12,6 +12,7 @@ namespace Bscript
 namespace Compiler
 {
 class CompiledScript;
+class CompilerWorkspace;
 struct LegacyFunctionOrder;
 class Profile;
 class Report;
@@ -34,6 +35,9 @@ public:
   void compile_file_steps( const std::string& pathname, const LegacyFunctionOrder*, Report& );
 
 private:
+  std::unique_ptr<CompilerWorkspace> build_workspace( const std::string&,
+                                                      const LegacyFunctionOrder*,
+                                                      Report& );
   void display_outcome( const std::string& filename, Report& );
 
   Profile& profile;

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -12,7 +12,7 @@ namespace Compiler
 class Profile
 {
 public:
-  // there will be a number of std::atomic<> fields here.
+  std::atomic<long long> build_workspace_micros;
 };
 
 }  // namespace Compiler

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
@@ -1,0 +1,19 @@
+#include "BuilderWorkspace.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+BuilderWorkspace::BuilderWorkspace( CompilerWorkspace& compiler_workspace, Profile& profile,
+                                    Report& report )
+  : compiler_workspace( compiler_workspace ), profile( profile ), report( report )
+{
+}
+
+BuilderWorkspace::~BuilderWorkspace() = default;
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
@@ -1,0 +1,30 @@
+#ifndef POLSERVER_BUILDERWORKSPACE_H
+#define POLSERVER_BUILDERWORKSPACE_H
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class CompilerWorkspace;
+class Profile;
+class Report;
+
+class BuilderWorkspace
+{
+public:
+  BuilderWorkspace( CompilerWorkspace&, Profile& profile, Report& report );
+  ~BuilderWorkspace();
+
+  CompilerWorkspace& compiler_workspace;
+
+  Profile& profile;
+  Report& report;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_BUILDERWORKSPACE_H

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -1,0 +1,38 @@
+#include "CompilerWorkspaceBuilder.h"
+
+#include "BuilderWorkspace.h"
+#include "compiler/LegacyFunctionOrder.h"
+#include "compiler/Profile.h"
+#include "compiler/Report.h"
+#include "compiler/file/SourceFileIdentifier.h"
+#include "compiler/file/SourceLocation.h"
+#include "compiler/model/CompilerWorkspace.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( Profile& profile, Report& report )
+    : profile( profile ), report( report )
+{
+}
+
+std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
+    const std::string& pathname,
+    const LegacyFunctionOrder* /*legacy_function_order*/ )
+{
+  auto compiler_workspace = std::make_unique<CompilerWorkspace>();
+  BuilderWorkspace workspace( *compiler_workspace, profile, report );
+
+  auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );
+
+  workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
+
+  return compiler_workspace;
+}
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
@@ -1,0 +1,37 @@
+#ifndef POLSERVER_COMPILERWORKSPACEBUILDER_H
+#define POLSERVER_COMPILERWORKSPACEBUILDER_H
+
+#include <memory>
+#include <string>
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+struct LegacyFunctionOrder;
+class Profile;
+class Report;
+class CompilerWorkspace;
+
+class CompilerWorkspaceBuilder
+{
+public:
+  CompilerWorkspaceBuilder( Profile&, Report& );
+
+  std::unique_ptr<CompilerWorkspace> build(
+      const std::string& pathname,
+      const LegacyFunctionOrder* legacy_function_order );
+
+private:
+
+  Profile& profile;
+  Report& report;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_COMPILERWORKSPACEBUILDER_H

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -1,0 +1,19 @@
+#include "CompilerWorkspace.h"
+
+#include <utility>
+
+#include "compiler/file/SourceFileIdentifier.h"
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+CompilerWorkspace::CompilerWorkspace() = default;
+
+CompilerWorkspace::~CompilerWorkspace() = default;
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -1,0 +1,28 @@
+#ifndef POLSERVER_COMPILERWORKSPACE_H
+#define POLSERVER_COMPILERWORKSPACE_H
+
+#include <memory>
+#include <vector>
+
+namespace Pol
+{
+namespace Bscript
+{
+namespace Compiler
+{
+class SourceFileIdentifier;
+
+class CompilerWorkspace
+{
+public:
+  CompilerWorkspace();
+  ~CompilerWorkspace();
+
+  std::vector<std::unique_ptr<SourceFileIdentifier>> referenced_source_file_identifiers;
+};
+
+}  // namespace Compiler
+}  // namespace Bscript
+}  // namespace Pol
+
+#endif  // POLSERVER_COMPILERWORKSPACE_H

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -936,6 +936,10 @@ bool run( int argc, char** argv, int* res )
     if ( summary.UpToDateScripts )
       tmp << "    " << summary.UpToDateScripts << " script"
           << ( summary.UpToDateScripts == 1 ? " was" : "s were" ) << " already up-to-date.\n";
+
+    tmp << "    build workspace: " << (long long)summary.profile.build_workspace_micros / 1000
+        << "\n";
+
     INFO_PRINT << tmp.str();
   }
 


### PR DESCRIPTION
Add [model/CompilerWorkspace](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/model/CompilerWorkspace.h#L29):
  - Holds AST
  - Holds some intermediate data used by semantic analyzer, optimizer, code generator

Add [astbuilder/CompilerWorkspaceBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h):
  - Builds a CompilerWorkspace for a script

Add [astbuilder/BuilderWorkspace](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h):
  - Temporary workspace used while building the CompilerWorkspace

