### PR TITLE
Add analyzer/Disambiguator stub

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -14,6 +14,8 @@ set (bscript_sources    # sorted !
   compiler/Compiler.cpp
   compiler/Compiler.h
   compiler/LegacyFunctionOrder.h
+  compiler/analyzer/Disambiguator.cpp
+  compiler/analyzer/Disambiguator.h
   compiler/analyzer/SemanticAnalyzer.cpp
   compiler/analyzer/SemanticAnalyzer.h
   compiler/ast/NodeVisitor.cpp

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -4,9 +4,9 @@
 #include "../clib/logfacility.h"
 #include "../clib/timer.h"
 
-#include "Report.h"
 #include "Profile.h"
 #include "Report.h"
+#include "analyzer/Disambiguator.h"
 #include "analyzer/SemanticAnalyzer.h"
 #include "astbuilder/CompilerWorkspaceBuilder.h"
 #include "compilercfg.h"
@@ -95,6 +95,10 @@ void Compiler::compile_file_steps( const std::string& pathname,
   if ( report.error_count() )
     return;
 
+  disambiguate( *workspace, report );
+  if ( report.error_count() )
+    return;
+
   analyze( *workspace, report);
   if ( report.error_count() )
     return;
@@ -124,6 +128,14 @@ void Compiler::optimize( CompilerWorkspace& workspace, Report& report )
   Optimizer optimizer( report );
   optimizer.optimize( workspace );
   profile.optimize_micros += timer.ellapsed().count();
+}
+
+void Compiler::disambiguate( CompilerWorkspace& workspace, Report& report )
+{
+  Pol::Tools::HighPerfTimer timer;
+  Disambiguator disambiguator( report );
+  disambiguator.disambiguate( workspace );
+  profile.disambiguate_micros += timer.ellapsed().count();
 }
 
 void Compiler::analyze( CompilerWorkspace& workspace, Report& report )

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -36,6 +36,7 @@ private:
                                                       Report& );
   void register_constants( CompilerWorkspace& );
   void optimize( CompilerWorkspace&, Report& );
+  void disambiguate( CompilerWorkspace&, Report& );
   void analyze( CompilerWorkspace&, Report& );
 
   void display_outcome( const std::string& filename, Report& );

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -11,6 +11,7 @@ public:
   std::atomic<long long> build_workspace_micros;
   std::atomic<long long> register_const_declarations_micros;
   std::atomic<long long> optimize_micros;
+  std::atomic<long long> disambiguate_micros;
   std::atomic<long long> analyze_micros;
 };
 

--- a/pol-core/bscript/compiler/analyzer/Disambiguator.cpp
+++ b/pol-core/bscript/compiler/analyzer/Disambiguator.cpp
@@ -1,0 +1,16 @@
+#include "Disambiguator.h"
+
+#include "compiler/model/CompilerWorkspace.h"
+
+namespace Pol::Bscript::Compiler
+{
+Disambiguator::Disambiguator( Report& report )
+  : report( report )
+{
+}
+
+void Disambiguator::disambiguate( CompilerWorkspace& )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/Disambiguator.h
+++ b/pol-core/bscript/compiler/analyzer/Disambiguator.h
@@ -1,0 +1,24 @@
+#ifndef POLSERVER_DISAMBIGUATOR_H
+#define POLSERVER_DISAMBIGUATOR_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+class CompilerWorkspace;
+class Report;
+
+class Disambiguator : public NodeVisitor
+{
+public:
+  explicit Disambiguator( Report& );
+
+  void disambiguate( CompilerWorkspace& ast );
+
+private:
+  Report& report;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DISAMBIGUATOR_H

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -943,6 +943,7 @@ bool run( int argc, char** argv, int* res )
         << (long long)summary.profile.register_const_declarations_micros / 1000 << "\n";
     tmp << "            analyze: " << (long long)summary.profile.analyze_micros / 1000 << "\n";
     tmp << "           optimize: " << (long long)summary.profile.optimize_micros / 1000 << "\n";
+    tmp << "       disambiguate: " << (long long)summary.profile.disambiguate_micros / 1000 << "\n";
 
     INFO_PRINT << tmp.str();
   }


### PR DESCRIPTION
The [Disambiguator](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/Disambiguator.cpp#L29) will correct the AST based on context.

At present, it needs to handle ambiguities in the grammar between
case group selectors and named break/continue labels.