### PR TITLE
Cleanup: vector byte, default dtor

### DIFF
--- a/pol-core/bscript/compiler/file/SourceFileIdentifier.cpp
+++ b/pol-core/bscript/compiler/file/SourceFileIdentifier.cpp
@@ -7,6 +7,4 @@ SourceFileIdentifier::SourceFileIdentifier( unsigned index, std::string pathname
 {
 }
 
-SourceFileIdentifier::~SourceFileIdentifier() = default;
-
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/file/SourceFileIdentifier.h
+++ b/pol-core/bscript/compiler/file/SourceFileIdentifier.h
@@ -9,7 +9,6 @@ class SourceFileIdentifier
 {
 public:
   SourceFileIdentifier( unsigned index, std::string pathname );
-  ~SourceFileIdentifier();
 
   const unsigned index;
   const std::string pathname;

--- a/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
+++ b/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
@@ -77,7 +77,7 @@ void CompiledScriptSerializer::write( const std::string& pathname ) const
 
   INFO_PRINT << "data section: offset " << ofs.tellp() << "\n";
 
-  const std::vector<uint8_t>& data = compiled_script.data;
+  const std::vector<std::byte>& data = compiled_script.data;
   u32 data_len = data.size();
   sechdr.type = BSCRIPT_SECTION_SYMBOLS;
   sechdr.length = sizeof data_len + data_len;

--- a/pol-core/bscript/compiler/representation/CompiledScript.h
+++ b/pol-core/bscript/compiler/representation/CompiledScript.h
@@ -18,7 +18,7 @@ class SourceFileIdentifier;
 class ModuleDescriptor;
 
 using CodeSection = std::vector<StoredToken>;
-using DataSection = std::vector<uint8_t>;
+using DataSection = std::vector<std::byte>;
 using ExportedFunctions = std::vector<ExportedFunction>;
 using ModuleDescriptors = std::vector<ModuleDescriptor>;
 using SourceFileIdentifiers = std::vector<std::unique_ptr<SourceFileIdentifier>>;


### PR DESCRIPTION
- Use `std::vector<std::byte>` rather than `std::vector<uint8_t>`
- Remove an unnecessary explicit default destructor