### PR TITLE
Add instruction generator, emitter, emit progend

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -30,6 +30,8 @@ set (bscript_sources    # sorted !
   compiler/codegen/CodeGenerator.h
   compiler/codegen/DataEmitter.cpp
   compiler/codegen/DataEmitter.h
+  compiler/codegen/InstructionEmitter.cpp
+  compiler/codegen/InstructionEmitter.h
   compiler/file/SourceFileIdentifier.cpp
   compiler/file/SourceFileIdentifier.h
   compiler/file/SourceLocation.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -32,6 +32,8 @@ set (bscript_sources    # sorted !
   compiler/codegen/DataEmitter.h
   compiler/codegen/InstructionEmitter.cpp
   compiler/codegen/InstructionEmitter.h
+  compiler/codegen/InstructionGenerator.cpp
+  compiler/codegen/InstructionGenerator.h
   compiler/file/SourceFileIdentifier.cpp
   compiler/file/SourceFileIdentifier.h
   compiler/file/SourceLocation.cpp

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "InstructionEmitter.h"
 #include "StoredToken.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/CompilerWorkspace.h"
@@ -23,7 +24,8 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
   ExportedFunctions exported_functions;
   std::vector<ModuleDescriptor> module_descriptors;
 
-  CodeGenerator generator;
+  InstructionEmitter instruction_emitter( code, data );
+  CodeGenerator generator( instruction_emitter );
 
   generator.generate_instructions( *workspace );
 
@@ -33,7 +35,9 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
       std::move( program_info ), std::move( workspace->referenced_source_file_identifiers ) );
 }
 
-CodeGenerator::CodeGenerator()
+CodeGenerator::CodeGenerator( InstructionEmitter& emitter )
+  : emitter( emitter ),
+    emit( emitter )
 {
 }
 

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "InstructionEmitter.h"
+#include "InstructionGenerator.h"
 #include "StoredToken.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/CompilerWorkspace.h"
@@ -43,6 +44,7 @@ CodeGenerator::CodeGenerator( InstructionEmitter& emitter )
 
 void CodeGenerator::generate_instructions( CompilerWorkspace& )
 {
+  emit.progend();
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -22,6 +22,7 @@ private:
   void generate_instructions( CompilerWorkspace& );
 
 private:
+  // Verb vs noun - see InstructionGenerator for reasoning
   InstructionEmitter& emitter;
   InstructionEmitter& emit;
 };

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -8,7 +8,6 @@ namespace Pol::Bscript::Compiler
 class CompiledScript;
 class InstructionEmitter;
 struct LegacyFunctionOrder;
-class ModuleDeclarationRegistrar;
 class CompilerWorkspace;
 
 class CodeGenerator
@@ -18,9 +17,12 @@ public:
                                                    const LegacyFunctionOrder* );
 
 private:
-  CodeGenerator();
+  explicit CodeGenerator( InstructionEmitter& );
 
   void generate_instructions( CompilerWorkspace& );
+
+  InstructionEmitter& emitter;
+  InstructionEmitter& emit;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -21,6 +21,7 @@ private:
 
   void generate_instructions( CompilerWorkspace& );
 
+private:
   InstructionEmitter& emitter;
   InstructionEmitter& emit;
 };

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -1,0 +1,21 @@
+#include "InstructionEmitter.h"
+
+#include "StoredToken.h"
+#include "compiler/representation/CompiledScript.h"
+
+namespace Pol::Bscript::Compiler
+{
+InstructionEmitter::InstructionEmitter( CodeSection& code, DataSection& data )
+  : code_emitter( code ),
+    data_emitter( data )
+{
+  initialize_data();
+}
+
+void InstructionEmitter::initialize_data()
+{
+  std::byte nul{};
+  data_emitter.store( &nul, sizeof nul );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -2,6 +2,7 @@
 
 #include "StoredToken.h"
 #include "compiler/representation/CompiledScript.h"
+#include "modules.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -16,6 +17,22 @@ void InstructionEmitter::initialize_data()
 {
   std::byte nul{};
   data_emitter.store( &nul, sizeof nul );
+}
+
+void InstructionEmitter::progend()
+{
+  emit_token( CTRL_PROGEND, TYP_CONTROL );
+}
+
+unsigned InstructionEmitter::emit_token( BTokenId id, BTokenType type, unsigned offset )
+{
+  StoredToken token( Mod_Basic, id, type, offset );
+  return append_token( token );
+}
+
+unsigned InstructionEmitter::append_token( StoredToken& token )
+{
+  return code_emitter.append( token );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -33,7 +33,11 @@ public:
 
   void initialize_data();
 
+  void progend();
+
 private:
+  unsigned emit_token( BTokenId id, BTokenType type, unsigned offset = 0 );
+  unsigned append_token( StoredToken& );
 
   CodeEmitter code_emitter;
   DataEmitter data_emitter;

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -1,0 +1,44 @@
+#ifndef POLSERVER_INSTRUCTIONEMITTER_H
+#define POLSERVER_INSTRUCTIONEMITTER_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifndef OBJMEMBERS_H
+#include "objmembers.h"
+#endif
+#ifndef OBJMETHODS_H
+#include "objmethods.h"
+#endif
+#ifndef __TOKENS_H
+#include "tokens.h"
+#endif
+#include "CodeEmitter.h"
+#include "DataEmitter.h"
+#include "compiler/representation/CompiledScript.h"
+
+namespace Pol::Bscript
+{
+class StoredToken;
+}
+
+namespace Pol::Bscript::Compiler
+{
+
+class InstructionEmitter
+{
+public:
+  InstructionEmitter( CodeSection& code, DataSection& data );
+
+  void initialize_data();
+
+private:
+
+  CodeEmitter code_emitter;
+  DataEmitter data_emitter;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_INSTRUCTIONEMITTER_H

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,0 +1,13 @@
+#include "InstructionGenerator.h"
+
+#include "InstructionEmitter.h"
+
+namespace Pol::Bscript::Compiler
+{
+InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
+  : emitter( emitter ),
+    emit( emitter )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -16,6 +16,9 @@ public:
   explicit InstructionGenerator( InstructionEmitter& );
 
 private:
+  // There are two of these because sometimes when calling a method
+  // on InstructionEmitter, the variable name reads better as a noun,
+  // and sometimes it reads better as a verb.
   InstructionEmitter& emitter;
   InstructionEmitter& emit;
 };

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_INSTRUCTIONGENERATOR_H
+#define POLSERVER_INSTRUCTIONGENERATOR_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <map>
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class InstructionEmitter;
+
+class InstructionGenerator : public NodeVisitor
+{
+public:
+  explicit InstructionGenerator( InstructionEmitter& );
+
+private:
+  InstructionEmitter& emitter;
+  InstructionEmitter& emit;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_INSTRUCTIONGENERATOR_H

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -14,6 +14,9 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 {
   switch ( tkn.id )
   {
+  case CTRL_PROGEND:
+    w << "progend";
+    break;
 
   default:
     w << "id=0x" << fmt::hex( tkn.id ) << " type=" << tkn.type << " offset=" << tkn.offset


### PR DESCRIPTION
Adds [InstructionGenerator](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp#L719): knows which instructions to generate for high-level language constructs

Adds [InstructionEmitter](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp#L244): knows how to emit the instructions

Also in this PR: Initialize the data and emit the `PROGEND` instruction.  This means that the compiler can now compile an empty file to valid .ecl.

```
$ touch a.src
$ /home/vagrant/polserver/bin/ecompile -l -g a.src
$ cat a.lst
0: progend
```