### PR TITLE
item.hitscript and item.onhitscript will now return the full spec for the script. Added breaking-changes.txt.

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-09-2020</datemodified>
+		<datemodified>08-13-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-13-2020</date>
+			<author>Nando:</author>
+			<change type="Changed">item.hitscript and item.onhitscript now always return the full path to the script (&quot;:pkgname:scriptname&quot;).<br/>
+Before, if the item was defined on the same package as the script, only &quot;scriptname&quot; was returned.<br/>
+POTENTIAL BREAKING CHANGE!</change>
+		</entry>
 		<entry>
 			<date>08-09-2020</date>
 			<author>Turley:</author>

--- a/pol-core/doc/CMakeLists.txt
+++ b/pol-core/doc/CMakeLists.txt
@@ -4,6 +4,7 @@ message("* (${lib_name})")
 
 #custom target to show it in IDEs
 add_custom_target(${lib_name} SOURCES
+  breaking-changes.txt
   core-changes.txt
   packets.zip
   uoconvert.txt
@@ -11,6 +12,7 @@ add_custom_target(${lib_name} SOURCES
 )
 
 install(FILES
+  breaking-changes.txt
   core-changes.txt
   packets.zip
   uoconvert.txt

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -34,5 +34,11 @@
     - Removed: pol.cfg option "Multithread". POL is now always multithreaded. 
     - Removed: method os::System_RPM(). It was only useful for singlethreaded POL.
 
+# >> Older breaking changes in POL100 might be missing here. Let us know if you find any. <<
+    
+2018-02-11:
+    - UO::Accessible(chr, item, range := ACCESSIBLE_DEFAULT) now checks for the item distance to chr. 
+      The default was always documented as 2 tiles. But due to a bug, it could be up to 18 tiles.
+
 -- POL099 --
 # For 099 and older please read core-changes.txt.

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -1,0 +1,38 @@
+# This is a short summary of breaking changes.
+# Please consult core-changes.txt for more information.
+
+-- POL100 [work-in-progress] --
+2020-08-13:
+    item.hitscript and item.onhitscript now *always* return the full path of their scripts (":pkgname:script")
+    
+2020-01-03:
+    AddAmount() now returns item reference on success instead of 1. Remove any explicit comparisons (AddAmount() == 1).
+    
+2019-09-21:
+    The core is now Unicode aware!
+    - Note: Item/Mobile names still need to be in ASCII format.
+    - If invalid unicode is detected while compiling or reading a file, ISO8859 will be assumed.
+    - Unicode functions now accept a string directly. Arrays are still kept for backwards 
+      compatibility, but that may change in the future.
+    - Non-unicode functions that receive a unicode string will use the unicode version 
+      automatically with langcode "ENU".
+    - party.cfg:
+        OnPublicChat second parameter is now a string object
+        OnPrivateChat third parameter is now a string object
+        ChangePublicChat second parameter is now a string object
+        ChangePrivateChat third parameter is now a string object
+    - unicode.em: RequestInputUC() return value no more contains member uc_text
+    - CharRef.clientinfo struct members 'video_description' and 'langcode' are now strings
+    - PacketObj.getunicodestring()/getunicodestringflipped() return a string
+    - Textcmd arguments are now (CharRef, String, [langcode=String])
+    - SpeechEvent no longer contains uc_text member
+    - scripts/misc/charprofile.ecl fourth parameter is a string
+
+2019-04-26:
+    - POL now requires at least Windows Vista / Server 2008. Let us know if Windows XP was important to you.
+    - Removed: pol.cfg option "ListenPort". You should use a Listener in uoclient.cfg.
+    - Removed: pol.cfg option "Multithread". POL is now always multithreaded. 
+    - Removed: method os::System_RPM(). It was only useful for singlethreaded POL.
+
+-- POL099 --
+# For 099 and older please read core-changes.txt.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 ﻿-- POL100 --
+08-13-2020 Nando:
+  Changed: item.hitscript and item.onhitscript now always return the full path to the script (":pkgname:scriptname").
+           Before, if the item was defined on the same package as the script, only "scriptname" was returned.
+           POTENTIAL BREAKING CHANGE!
+           
 08-09-2020 Turley:
     Added: new argument "outdir" for uoconvert tiles/landtiles/multis this allows to define a different directory then the current workdirectory for the produced cfgs
 08-04-2020 AsYlum:

--- a/pol-core/pol/scrdef.cpp
+++ b/pol-core/pol/scrdef.cpp
@@ -101,7 +101,10 @@ bool ScriptDef::config_nodie( const std::string& iname, const Plib::Package* ipk
 
 std::string ScriptDef::qualifiedname() const
 {
-  return relativename( nullptr );
+  if ( empty() )
+    return "";
+  else
+    return ":" + ( pkg_ ? pkg_->name() : "" ) + ":" + localname_.get();
 }
 
 std::string ScriptDef::relativename( const Plib::Package* pkg ) const
@@ -111,7 +114,7 @@ std::string ScriptDef::relativename( const Plib::Package* pkg ) const
   else if ( pkg == pkg_ )
     return localname_;
   else
-    return ":" + ( pkg_ ? pkg_->name() : "" ) + ":" + localname_.get();
+    return qualifiedname();
 }
 
 void ScriptDef::quickconfig( const Plib::Package* pkg, const std::string& name_ecl )

--- a/pol-core/pol/scrdef.cpp
+++ b/pol-core/pol/scrdef.cpp
@@ -99,9 +99,14 @@ bool ScriptDef::config_nodie( const std::string& iname, const Plib::Package* ipk
   return true;
 }
 
+std::string ScriptDef::qualifiedname() const
+{
+  return relativename( nullptr );
+}
+
 std::string ScriptDef::relativename( const Plib::Package* pkg ) const
 {
-  if ( name_ == "" )
+  if ( empty() )
     return "";
   else if ( pkg == pkg_ )
     return localname_;

--- a/pol-core/pol/scrdef.h
+++ b/pol-core/pol/scrdef.h
@@ -46,23 +46,26 @@ public:
   const Plib::Package* pkg() const { return pkg_; }
   bool exists() const;
 
-  // Script path that can be used from any package ("::scriptname", ":pkg:scriptname"). Empty if script is not defined.
+  // Script path that can be used from any package ("::scriptname", ":pkg:scriptname"). Empty if
+  // script is not defined.
   std::string qualifiedname() const;
   // Script path relative to a given package. Empty if script is not defined.
   std::string relativename( const Plib::Package* pkg = nullptr ) const;
   size_t estimatedSize() const;
 
 private:
-  // localname_ is "scriptname" (whatever is left after ":pkgname:" or "::" is removed, may contain slashes)
+  // localname_ is "scriptname" (whatever is left after ":pkgname:" or "::" is removed, may contain
+  // slashes)
   boost_utils::script_name_flystring localname_;
   // name_ is the physical location on disk relative to the core (always ends in .ecl).
   boost_utils::script_name_flystring name_;
-  // pkg_ points to the package where the script exists. May be a nullptr (e.g., if the script is in "scripts/").
+  // pkg_ points to the package where the script exists. May be a nullptr (e.g., if the script is in
+  // "scripts/").
   const Plib::Package* pkg_;
 
 private:  // not implemented
 };
-}
-}
+}  // namespace Core
+}  // namespace Pol
 
 #endif

--- a/pol-core/pol/scrdef.h
+++ b/pol-core/pol/scrdef.h
@@ -46,12 +46,18 @@ public:
   const Plib::Package* pkg() const { return pkg_; }
   bool exists() const;
 
+  // Script path that can be used from any package ("::scriptname", ":pkg:scriptname"). Empty if script is not defined.
+  std::string qualifiedname() const;
+  // Script path relative to a given package. Empty if script is not defined.
   std::string relativename( const Plib::Package* pkg = nullptr ) const;
   size_t estimatedSize() const;
 
 private:
+  // localname_ is "scriptname" (whatever is left after ":pkgname:" or "::" is removed, may contain slashes)
   boost_utils::script_name_flystring localname_;
+  // name_ is the physical location on disk relative to the core (always ends in .ecl).
   boost_utils::script_name_flystring name_;
+  // pkg_ points to the package where the script exists. May be a nullptr (e.g., if the script is in "scripts/").
   const Plib::Package* pkg_;
 
 private:  // not implemented

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -4396,7 +4396,8 @@ BObjectImp* UWeapon::get_script_member_id( const int id ) const
     return new String( attribute().name );
     break;
   case MBR_HITSCRIPT:
-    return new String( hit_script_.relativename( tmpl->pkg ) );
+    // bad method name? nullptr makes it return the fullpath
+    return new String( hit_script_.relativename( nullptr ) );
     break;
   default:
     return nullptr;
@@ -4503,7 +4504,8 @@ BObjectImp* UArmor::get_script_member_id( const int id ) const
     return new BLong( ar_base() );
     break;
   case MBR_ONHIT_SCRIPT:
-    return new String( onhitscript_.relativename( tmpl->pkg ) );
+    // bad method name? nullptr makes it return the fullpath
+    return new String( onhitscript_.relativename( nullptr ) );
     break;
   default:
     return nullptr;

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -4396,8 +4396,7 @@ BObjectImp* UWeapon::get_script_member_id( const int id ) const
     return new String( attribute().name );
     break;
   case MBR_HITSCRIPT:
-    // bad method name? nullptr makes it return the fullpath
-    return new String( hit_script_.relativename( nullptr ) );
+    return new String( hit_script_.qualifiedname() );
     break;
   default:
     return nullptr;
@@ -4505,7 +4504,7 @@ BObjectImp* UArmor::get_script_member_id( const int id ) const
     break;
   case MBR_ONHIT_SCRIPT:
     // bad method name? nullptr makes it return the fullpath
-    return new String( onhitscript_.relativename( nullptr ) );
+    return new String( onhitscript_.qualifiedname() );
     break;
   default:
     return nullptr;


### PR DESCRIPTION
breaking-changes.txt should be kept short. And we can add more as we find them. 