### PR TITLE
Add file/SourceFile

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -38,6 +38,8 @@ set (bscript_sources    # sorted !
   compiler/file/ConformingCharStream.h
   compiler/file/ErrorListener.cpp
   compiler/file/ErrorListener.h
+  compiler/file/SourceFile.cpp
+  compiler/file/SourceFile.h
   compiler/file/SourceFileIdentifier.cpp
   compiler/file/SourceFileIdentifier.h
   compiler/file/SourceLocation.cpp

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
@@ -1,5 +1,7 @@
 #include "BuilderWorkspace.h"
 
+#include "compiler/file/SourceFile.h"
+
 namespace Pol::Bscript::Compiler
 {
 BuilderWorkspace::BuilderWorkspace( CompilerWorkspace& compiler_workspace, Profile& profile,

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
@@ -1,11 +1,17 @@
 #ifndef POLSERVER_BUILDERWORKSPACE_H
 #define POLSERVER_BUILDERWORKSPACE_H
 
+#include <map>
+#include <memory>
+#include <string>
+
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
 class Profile;
 class Report;
+class SourceFile;
+class SourceFileIdentifier;
 
 class BuilderWorkspace
 {
@@ -17,6 +23,8 @@ public:
 
   Profile& profile;
   Report& report;
+
+  std::map<std::string, std::shared_ptr<SourceFile>> source_files;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -4,6 +4,7 @@
 #include "compiler/LegacyFunctionOrder.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
+#include "compiler/file/SourceFile.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/file/SourceLocation.h"
 #include "compiler/model/CompilerWorkspace.h"
@@ -16,15 +17,31 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( Profile& profile, Report& re
 }
 
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
-    const std::string& pathname,
-    const LegacyFunctionOrder* /*legacy_function_order*/ )
+    const std::string& pathname, const LegacyFunctionOrder* /*legacy_function_order*/ )
 {
   auto compiler_workspace = std::make_unique<CompilerWorkspace>();
   BuilderWorkspace workspace( *compiler_workspace, profile, report );
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );
 
+  SourceLocation source_location( ident.get(), 0, 0 );
+
+  if ( SourceFile::enforced_case_sensitivity_mismatch( source_location, pathname, report ) )
+  {
+    report.error( *ident, "Refusing to load '", pathname, "'.\n" );
+    return {};
+  }
+
+  auto sf = SourceFile::load( *ident, profile, report );
+
+  if ( !sf || report.error_count() )
+  {
+    report.error( *ident, "Unable to load '", pathname, "'.\n" );
+    return {};
+  }
+
   workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
+  workspace.source_files[sf->pathname] = sf;
 
   return compiler_workspace;
 }

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -5,6 +5,7 @@
 
 #include "compiler/Report.h"
 #include "compiler/file/SourceFileIdentifier.h"
+#include "compilercfg.h"
 
 using EscriptGrammar::EscriptLexer;
 using EscriptGrammar::EscriptParser;

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -1,0 +1,133 @@
+#include "SourceFile.h"
+
+#include "clib/fileutil.h"
+#include "clib/strutil.h"
+
+#include "compiler/Report.h"
+#include "compiler/file/SourceFileIdentifier.h"
+
+using EscriptGrammar::EscriptLexer;
+using EscriptGrammar::EscriptParser;
+
+namespace Pol::Bscript::Legacy
+{
+bool is_web_script( const char* filename );
+std::string preprocess_web_script( const std::string& input );
+}
+
+namespace Pol::Bscript::Compiler
+{
+SourceFile::SourceFile( const std::string& pathname, const std::string& contents, Profile& profile )
+    : pathname( pathname ),
+      input( contents ),
+      conformer( &input ),
+      lexer( &conformer ),
+      tokens( &lexer ),
+      parser( &tokens ),
+      error_listener( pathname, profile ),
+      compilation_unit( nullptr ),
+      module_unit( nullptr ),
+      access_count( 0 )
+{
+  input.name = pathname;
+
+  lexer.removeErrorListeners();
+  lexer.addErrorListener( &error_listener );
+  parser.removeErrorListeners();
+  parser.addErrorListener( &error_listener );
+}
+
+SourceFile::~SourceFile() = default;
+
+void SourceFile::propagate_errors_to( Report& report, const SourceFileIdentifier& ident )
+{
+  error_listener.propagate_errors_to( report, ident );
+}
+
+#ifdef _WIN32
+bool SourceFile::enforced_case_sensitivity_mismatch( const SourceLocation& referencing_location,
+                                                     const std::string& pathname, Report& report )
+{
+  std::string truename = Clib::GetTrueName( pathname.c_str() );
+  std::string filepart = Clib::GetFilePart( pathname.c_str() );
+  if ( truename != filepart && Clib::FileExists( pathname ) )
+  {
+    if ( compilercfg.ErrorOnFileCaseMissmatch )
+    {
+      report.error( referencing_location, "Case mismatch: \n", "  Specified:  ", filepart, "\n",
+                    "  Filesystem: ", truename, "\n" );
+      return true;
+    }
+
+    report.warning( referencing_location, "Case mismatch: \n", "  Specified:  ", filepart, "\n",
+                    "  Filesystem: ", truename, "\n" );
+  }
+  return false;
+}
+#else
+bool SourceFile::enforced_case_sensitivity_mismatch( const SourceLocation&, const std::string&,
+                                                     Report& )
+{
+  return false;
+}
+#endif
+
+std::shared_ptr<SourceFile> SourceFile::load( const SourceFileIdentifier& ident, Profile& profile,
+                                              Report& report )
+{
+  const std::string& pathname = ident.pathname;
+  std::ifstream ifs( pathname );
+  if ( !ifs.is_open() )
+  {
+    report.error( ident, "Unable to open file '", pathname, "'.\n" );
+    return {};
+  }
+
+  std::string contents( ( std::istreambuf_iterator<char>( ifs ) ),
+                        std::istreambuf_iterator<char>() );
+
+  if ( ifs.fail() )
+  {
+    report.error( ident, "Unable to read file '", pathname, "'.\n" );
+    return {};
+  }
+
+  Clib::sanitizeUnicodeWithIso( &contents );
+
+  if ( Legacy::is_web_script( pathname.c_str() ) )
+  {
+    contents = Legacy::preprocess_web_script( contents );
+  }
+
+  return std::make_shared<SourceFile>( pathname, contents, profile );
+}
+
+EscriptGrammar::EscriptParser::CompilationUnitContext* SourceFile::get_compilation_unit(
+    Report& report, const SourceFileIdentifier& ident )
+{
+  if ( !compilation_unit )
+  {
+    std::lock_guard<std::mutex> guard( mutex );
+    if ( !compilation_unit )
+      compilation_unit = parser.compilationUnit();
+  }
+  ++access_count;
+  propagate_errors_to( report, ident );
+  return compilation_unit;
+}
+
+EscriptGrammar::EscriptParser::ModuleUnitContext* SourceFile::get_module_unit(
+    Report& report, const SourceFileIdentifier& ident )
+{
+  if ( !module_unit )
+  {
+    std::lock_guard<std::mutex> guard( mutex );
+    if ( !module_unit )
+      module_unit = parser.moduleUnit();
+  }
+  ++access_count;
+  propagate_errors_to( report, ident );
+  return module_unit;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/file/SourceFile.h
+++ b/pol-core/bscript/compiler/file/SourceFile.h
@@ -1,0 +1,56 @@
+#ifndef POLSERVER_SOURCEFILE_H
+#define POLSERVER_SOURCEFILE_H
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <EscriptGrammar/EscriptLexer.h>
+#include <EscriptGrammar/EscriptParser.h>
+#include "compiler/file/ConformingCharStream.h"
+#include "compiler/file/ErrorListener.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Profile;
+class Report;
+class SourceLocation;
+
+class SourceFile
+{
+public:
+  SourceFile( const std::string& pathname, const std::string& contents, Profile& );
+  ~SourceFile();
+
+  static bool enforced_case_sensitivity_mismatch( const SourceLocation& referencing_location,
+                                                  const std::string& pathname, Report& report );
+  static std::shared_ptr<SourceFile> load( const SourceFileIdentifier&, Profile&, Report& );
+
+  void propagate_errors_to( Report&, const SourceFileIdentifier& );
+
+  EscriptGrammar::EscriptParser::CompilationUnitContext* get_compilation_unit(
+      Report&, const SourceFileIdentifier& );
+  EscriptGrammar::EscriptParser::ModuleUnitContext* get_module_unit(
+      Report&, const SourceFileIdentifier& );
+
+  const std::string pathname;
+
+private:
+  antlr4::ANTLRInputStream input;
+  ConformingCharStream conformer;
+  EscriptGrammar::EscriptLexer lexer;
+  antlr4::CommonTokenStream tokens;
+  EscriptGrammar::EscriptParser parser;
+  ErrorListener error_listener;
+
+  std::mutex mutex;
+
+  std::atomic<EscriptGrammar::EscriptParser::CompilationUnitContext*> compilation_unit;
+  std::atomic<EscriptGrammar::EscriptParser::ModuleUnitContext*> module_unit;
+
+  std::atomic<unsigned> access_count;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SOURCEFILE_H

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -7,6 +7,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class SourceFile;
 class SourceFileIdentifier;
 
 class CompilerWorkspace


### PR DESCRIPTION
Adds `SourceFile`, which handles loading source files as well as coordinating thread-safe access to parse trees.  The latter will come into play when loading include files and modules.