### PR TITLE
Improve SourceFileCache::keep_some()

### DIFF
--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -14,6 +14,8 @@ public:
   std::atomic<long long> disambiguate_micros;
   std::atomic<long long> analyze_micros;
   std::atomic<long long> codegen_micros;
+  std::atomic<long long> prune_cache_select_micros;
+  std::atomic<long long> prune_cache_delete_micros;
 
   std::atomic<long> ambiguities;
 

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -962,6 +962,10 @@ bool run( int argc, char** argv, int* res )
     tmp << "           optimize: " << (long long)summary.profile.optimize_micros / 1000 << "\n";
     tmp << "       disambiguate: " << (long long)summary.profile.disambiguate_micros / 1000 << "\n";
     tmp << "      generate code: " << (long long)summary.profile.codegen_micros / 1000 << "\n";
+    tmp << "  prune cache (sel): " << (long long)summary.profile.prune_cache_select_micros / 1000
+        << "\n";
+    tmp << "  prune cache (del): " << (long long)summary.profile.prune_cache_delete_micros / 1000
+        << "\n";
     tmp << "\n";
     tmp << "      - ambiguities: " << (long)summary.profile.ambiguities << "\n";
     tmp << "       - cache hits: " << (long)summary.profile.cache_hits << "\n";


### PR DESCRIPTION
- use `std::nth_element` instead of sort
- no `std::shared_ptr` copying
  - and not replaced with `std::string` copying
- track and log timings