### PR TITLE
Add AST builder stubs

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -36,6 +36,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/CompilerWorkspaceBuilder.h
   compiler/astbuilder/TreeBuilder.cpp
   compiler/astbuilder/TreeBuilder.h
+  compiler/astbuilder/ValueBuilder.cpp
+  compiler/astbuilder/ValueBuilder.h
   compiler/codegen/CodeEmitter.cpp
   compiler/codegen/CodeEmitter.h
   compiler/codegen/CodeGenerator.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -36,6 +36,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/CompilerWorkspaceBuilder.h
   compiler/astbuilder/ExpressionBuilder.cpp
   compiler/astbuilder/ExpressionBuilder.h
+  compiler/astbuilder/SimpleStatementBuilder.cpp
+  compiler/astbuilder/SimpleStatementBuilder.h
   compiler/astbuilder/TreeBuilder.cpp
   compiler/astbuilder/TreeBuilder.h
   compiler/astbuilder/ValueBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -34,6 +34,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp
   compiler/astbuilder/CompilerWorkspaceBuilder.h
+  compiler/astbuilder/CompoundStatementBuilder.cpp
+  compiler/astbuilder/CompoundStatementBuilder.h
   compiler/astbuilder/ExpressionBuilder.cpp
   compiler/astbuilder/ExpressionBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -40,6 +40,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/ExpressionBuilder.h
   compiler/astbuilder/ModuleDeclarationBuilder.cpp
   compiler/astbuilder/ModuleDeclarationBuilder.h
+  compiler/astbuilder/ProgramBuilder.cpp
+  compiler/astbuilder/ProgramBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp
   compiler/astbuilder/SimpleStatementBuilder.h
   compiler/astbuilder/TreeBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -46,6 +46,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/SimpleStatementBuilder.h
   compiler/astbuilder/TreeBuilder.cpp
   compiler/astbuilder/TreeBuilder.h
+  compiler/astbuilder/UserFunctionBuilder.cpp
+  compiler/astbuilder/UserFunctionBuilder.h
   compiler/astbuilder/ValueBuilder.cpp
   compiler/astbuilder/ValueBuilder.h
   compiler/codegen/CodeEmitter.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -38,6 +38,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/CompoundStatementBuilder.h
   compiler/astbuilder/ExpressionBuilder.cpp
   compiler/astbuilder/ExpressionBuilder.h
+  compiler/astbuilder/ModuleDeclarationBuilder.cpp
+  compiler/astbuilder/ModuleDeclarationBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp
   compiler/astbuilder/SimpleStatementBuilder.h
   compiler/astbuilder/TreeBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -34,6 +34,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp
   compiler/astbuilder/CompilerWorkspaceBuilder.h
+  compiler/astbuilder/ExpressionBuilder.cpp
+  compiler/astbuilder/ExpressionBuilder.h
   compiler/astbuilder/TreeBuilder.cpp
   compiler/astbuilder/TreeBuilder.h
   compiler/astbuilder/ValueBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -34,6 +34,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp
   compiler/astbuilder/CompilerWorkspaceBuilder.h
+  compiler/astbuilder/TreeBuilder.cpp
+  compiler/astbuilder/TreeBuilder.h
   compiler/codegen/CodeEmitter.cpp
   compiler/codegen/CodeEmitter.h
   compiler/codegen/CodeGenerator.cpp

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -1,0 +1,11 @@
+#include "CompoundStatementBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+CompoundStatementBuilder::CompoundStatementBuilder(
+    const SourceFileIdentifier& source_file_identifier, BuilderWorkspace& workspace )
+  : SimpleStatementBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_COMPOUNDSTATEMENTBUILDER_H
+#define POLSERVER_COMPOUNDSTATEMENTBUILDER_H
+
+#include "compiler/astbuilder/SimpleStatementBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class CompoundStatementBuilder : public SimpleStatementBuilder
+{
+public:
+  CompoundStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_COMPOUNDSTATEMENTBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -1,0 +1,13 @@
+#include "ExpressionBuilder.h"
+
+#include "compiler/Report.h"
+
+namespace Pol::Bscript::Compiler
+{
+ExpressionBuilder::ExpressionBuilder( const SourceFileIdentifier& source_file_identifier,
+                                      BuilderWorkspace& workspace )
+  : ValueBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_EXPRESSIONBUILDER_H
+#define POLSERVER_EXPRESSIONBUILDER_H
+
+#include "compiler/astbuilder/ValueBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class ExpressionBuilder : public ValueBuilder
+{
+public:
+  ExpressionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_EXPRESSIONBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.cpp
@@ -1,0 +1,11 @@
+#include "ModuleDeclarationBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+ModuleDeclarationBuilder::ModuleDeclarationBuilder(
+    const SourceFileIdentifier& source_file_identifier, BuilderWorkspace& workspace )
+  : SimpleStatementBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_MODULEDECLARATIONBUILDER_H
+#define POLSERVER_MODULEDECLARATIONBUILDER_H
+
+#include "compiler/astbuilder/SimpleStatementBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class ModuleDeclarationBuilder : public SimpleStatementBuilder
+{
+public:
+  ModuleDeclarationBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_MODULEDECLARATIONBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/ProgramBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ProgramBuilder.cpp
@@ -1,0 +1,11 @@
+#include "ProgramBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+ProgramBuilder::ProgramBuilder( const SourceFileIdentifier& source_file_identifier,
+                                BuilderWorkspace& workspace )
+  : CompoundStatementBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ProgramBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ProgramBuilder.h
@@ -1,0 +1,19 @@
+#ifndef POLSERVER_PROGRAMBUILDER_H
+#define POLSERVER_PROGRAMBUILDER_H
+
+#include "compiler/astbuilder/CompoundStatementBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class ProgramBuilder : public CompoundStatementBuilder
+{
+public:
+  ProgramBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+};
+
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_PROGRAMBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -1,0 +1,14 @@
+#include "SimpleStatementBuilder.h"
+
+#include "compiler/Report.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+
+namespace Pol::Bscript::Compiler
+{
+SimpleStatementBuilder::SimpleStatementBuilder( const SourceFileIdentifier& source_file_identifier,
+                                    BuilderWorkspace& workspace )
+  : ExpressionBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_SIMPLESTATEMENTBUILDER_H
+#define POLSERVER_SIMPLESTATEMENTBUILDER_H
+
+#include "compiler/astbuilder/ExpressionBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class SimpleStatementBuilder : public ExpressionBuilder
+{
+public:
+  SimpleStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_STATEMENTBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/TreeBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/TreeBuilder.cpp
@@ -1,0 +1,33 @@
+#include "TreeBuilder.h"
+
+#include <antlr4-runtime.h>
+
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+TreeBuilder::TreeBuilder( const SourceFileIdentifier& source_file_identifier,
+                          BuilderWorkspace& workspace )
+  : report( workspace.report ),
+    source_file_identifier( source_file_identifier ),
+    workspace( workspace )
+{
+}
+
+SourceLocation TreeBuilder::location_for( antlr4::ParserRuleContext& ctx ) const
+{
+  return SourceLocation( &source_file_identifier, ctx );
+}
+
+SourceLocation TreeBuilder::location_for( antlr4::tree::TerminalNode& ctx ) const
+{
+  return SourceLocation( &source_file_identifier, ctx );
+}
+
+std::string TreeBuilder::text( antlr4::tree::TerminalNode* terminal )
+{
+  return terminal->getSymbol()->getText();
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/TreeBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/TreeBuilder.h
@@ -1,0 +1,43 @@
+#ifndef POLSERVER_TREEBUILDER_H
+#define POLSERVER_TREEBUILDER_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace antlr4
+{
+  class ParserRuleContext;
+  namespace tree
+  {
+    class TerminalNode;
+  }
+}
+namespace Pol::Bscript::Compiler
+{
+class Report;
+class SourceLocation;
+class SourceFileIdentifier;
+class BuilderWorkspace;
+
+class TreeBuilder
+{
+public:
+  TreeBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  SourceLocation location_for( antlr4::ParserRuleContext& ) const;
+  SourceLocation location_for( antlr4::tree::TerminalNode& ) const;
+
+  std::string text( antlr4::tree::TerminalNode* );
+protected:
+
+  Report& report;
+
+  const SourceFileIdentifier& source_file_identifier;
+
+  BuilderWorkspace& workspace;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_TREEBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -1,0 +1,11 @@
+#include "UserFunctionBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+UserFunctionBuilder::UserFunctionBuilder( const SourceFileIdentifier& source_file_identifier,
+                                          BuilderWorkspace& workspace )
+  : CompoundStatementBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
@@ -1,0 +1,17 @@
+#ifndef POLSERVER_USERFUNCTIONBUILDER_H
+#define POLSERVER_USERFUNCTIONBUILDER_H
+
+#include "compiler/astbuilder/CompoundStatementBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class UserFunctionBuilder : public CompoundStatementBuilder
+{
+public:
+  UserFunctionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_USERFUNCTIONBUILDER_H

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -1,0 +1,15 @@
+#include "ValueBuilder.h"
+
+#include "compiler/Report.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+ValueBuilder::ValueBuilder( const SourceFileIdentifier& source_file_identifier,
+                            BuilderWorkspace& workspace )
+  : TreeBuilder( source_file_identifier, workspace )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_VALUEBUILDER_H
+#define POLSERVER_VALUEBUILDER_H
+
+#include "compiler/astbuilder/TreeBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+
+class ValueBuilder : public TreeBuilder
+{
+public:
+  ValueBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_VALUEBUILDER_H


### PR DESCRIPTION
Add stubs for classes that create AST nodes from parse trees.  These are split up into smaller classes to avoid a single gigantic builder class.  ExpressionBuilder will still get pretty big, though.

These each derive from the previous in a simple clas hierarchy (links to final versions):
- [TreeBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/TreeBuilder.cpp): base class and convenience functions
- [ValueBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp): builds integers, strings, floats, function references
- [ExpressionBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp): builds expressions
- [SimpleStatementBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp): builds statements that contain expressions, but not other statements
  - example `const`, `var`, `return`, `break` ,`continue`
- [CompoundStatementBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp): builds statements that can contain other statements

Then, three that derive from one of the StatementBuilders:
- [ModuleDeclarationBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.cpp): builds ASTs for *.em files
- [ProgramBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/ProgramBuilder.cpp): builds ASTs for `program` and top-level statements (everything not in user functions)
- [UserFunctionBuilder](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp): builds ASTs for user functions