### PR TITLE
Add maximum cmdlevel to polsys::ListTextCommands()

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-13-2020</datemodified>
+		<datemodified>08-18-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-18-2020</date>
+			<author>Nando:</author>
+			<change type="Added">Parameter &quot;max_cmdlevel&quot; to polsys::ListTextCommands(). Indicates the maximum cmdlevel to include in the list.</change>
+		</entry>
 		<entry>
 			<date>08-13-2020</date>
 			<author>Nando:</author>

--- a/docs/docs.polserver.com/pol100/polsysem.xml
+++ b/docs/docs.polserver.com/pol100/polsysem.xml
@@ -127,9 +127,10 @@ endforeach</code></explain>
   </function>
 
   <function name="ListTextCommands">
-    <prototype>ListTextCommands( )</prototype>
+    <prototype>ListTextCommands(max_cmdlevel:=-1)</prototype>
+    <parameter name="max_cmdlevel" value="Integer" />
     <explain>Returns a dict of a dict of structs.</explain>
-    <explain>Dict 1 - Package names Dict 2 - Command levels Struct - .dir .script</explain>
+    <explain>Dict 1 - Package names; Dict 2 - Command levels; Struct - .dir .script</explain>
     <explain>
     <code>
 	Example:
@@ -147,8 +148,7 @@ endforeach</code></explain>
 	endforeach
     </code>
     </explain>
-    <return>1 on success</return>
-    <error>"Invalid parameter type."</error>
+    <return>Dict of a dict of structs</return>
   </function>
 
   <function name="GetPackageByName">

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 ﻿-- POL100 --
+08-18-2020 Nando:
+    Added: Parameter "max_cmdlevel" to polsys::ListTextCommands(). Indicates the maximum cmdlevel to include in the list.
+           
 08-13-2020 Nando:
   Changed: item.hitscript and item.onhitscript now always return the full path to the script (":pkgname:scriptname").
            Before, if the item was defined on the same package as the script, only "scriptname" was returned.

--- a/pol-core/pol/cmdlevel.cpp
+++ b/pol-core/pol/cmdlevel.cpp
@@ -7,6 +7,7 @@
 
 #include "cmdlevel.h"
 
+#include <memory>
 #include <stddef.h>
 #include <string>
 
@@ -21,6 +22,7 @@
 #include "../clib/strutil.h"
 #include "../plib/pkg.h"
 #include "../plib/systemstate.h"
+#include "bscript/dict.h"
 #include "globals/uvars.h"
 namespace Pol
 {
@@ -101,14 +103,34 @@ CmdLevel* FindCmdLevelByAlias( const std::string& str )
   return nullptr;
 }
 
-Bscript::ObjArray* GetCommandsInPackage( Plib::Package* m_pkg, int cmdlvl_num )
+std::unique_ptr<Bscript::BDictionary> ListAllCommandsInPackage( Plib::Package* m_pkg,
+                                                                int max_cmdlevel /*= -1*/ )
 {
+  auto cmd_lvl_list = std::make_unique<Bscript::BDictionary>();
+
+  if ( max_cmdlevel < 0 )
+    max_cmdlevel = static_cast<int>( Core::gamestate.cmdlevels.size() - 1 );
+
+  for ( unsigned num = 0; num <= max_cmdlevel; ++num )
+  {
+    auto script_list = Core::ListCommandsInPackageAtCmdlevel( m_pkg, num );
+    if ( script_list->ref_arr.empty() )
+      continue;
+    else
+      cmd_lvl_list->addMember( new Bscript::BLong( num ), script_list.release() );
+  }
+  return std::move( cmd_lvl_list );
+}
+
+
+std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg, int cmdlvl_num )
+{
+  auto script_names = std::make_unique<Bscript::ObjArray>();
+
   if ( cmdlvl_num >= static_cast<int>( gamestate.cmdlevels.size() ) )
     cmdlvl_num = static_cast<int>( gamestate.cmdlevels.size() - 1 );
 
   CmdLevel& cmdlevel = gamestate.cmdlevels[cmdlvl_num];
-
-  std::unique_ptr<Bscript::ObjArray> script_names( new Bscript::ObjArray );
 
   for ( unsigned diridx = 0; diridx < cmdlevel.searchlist.size(); ++diridx )
   {
@@ -143,10 +165,8 @@ Bscript::ObjArray* GetCommandsInPackage( Plib::Package* m_pkg, int cmdlvl_num )
       }
     }
   }
-  if ( script_names->ref_arr.size() > 0 )
-    return script_names.release();
-  else
-    return nullptr;
+
+  return std::move( script_names );
 }
 
 void load_cmdlevels()

--- a/pol-core/pol/cmdlevel.cpp
+++ b/pol-core/pol/cmdlevel.cpp
@@ -123,7 +123,8 @@ std::unique_ptr<Bscript::BDictionary> ListAllCommandsInPackage( Plib::Package* m
 }
 
 
-std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg, int cmdlvl_num )
+std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg,
+                                                                    int cmdlvl_num )
 {
   auto script_names = std::make_unique<Bscript::ObjArray>();
 

--- a/pol-core/pol/cmdlevel.h
+++ b/pol-core/pol/cmdlevel.h
@@ -6,9 +6,9 @@
 #ifndef __CMDLEVEL_H
 #define __CMDLEVEL_H
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace Pol
 {
@@ -16,7 +16,7 @@ namespace Bscript
 {
 class ObjArray;
 class BDictionary;
-}
+}  // namespace Bscript
 namespace Clib
 {
 class ConfigElem;
@@ -56,8 +56,10 @@ public:
 CmdLevel* find_cmdlevel( const char* name );
 CmdLevel* FindCmdLevelByAlias( const std::string& str );
 
-std::unique_ptr<Bscript::BDictionary> ListAllCommandsInPackage( Plib::Package* m_pkg, int max_cmdlevel = -1 );
-std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg, int cmdlvl_num );
+std::unique_ptr<Bscript::BDictionary> ListAllCommandsInPackage( Plib::Package* m_pkg,
+                                                                int max_cmdlevel = -1 );
+std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg,
+                                                                    int cmdlvl_num );
 
 }  // namespace Core
 }  // namespace Pol

--- a/pol-core/pol/cmdlevel.h
+++ b/pol-core/pol/cmdlevel.h
@@ -8,12 +8,14 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace Pol
 {
 namespace Bscript
 {
 class ObjArray;
+class BDictionary;
 }
 namespace Clib
 {
@@ -54,7 +56,9 @@ public:
 CmdLevel* find_cmdlevel( const char* name );
 CmdLevel* FindCmdLevelByAlias( const std::string& str );
 
-Bscript::ObjArray* GetCommandsInPackage( Plib::Package* m_pkg, int cmdlvl_num );
-}
-}
+std::unique_ptr<Bscript::BDictionary> ListAllCommandsInPackage( Plib::Package* m_pkg, int max_cmdlevel = -1 );
+std::unique_ptr<Bscript::ObjArray> ListCommandsInPackageAtCmdlevel( Plib::Package* m_pkg, int cmdlvl_num );
+
+}  // namespace Core
+}  // namespace Pol
 #endif

--- a/pol-core/pol/module/polsystemmod.cpp
+++ b/pol-core/pol/module/polsystemmod.cpp
@@ -197,38 +197,28 @@ BObjectImp* PolSystemExecutorModule::mf_GetPackageByName()
 BObjectImp* PolSystemExecutorModule::mf_ListTextCommands()
 {
   std::unique_ptr<BDictionary> pkg_list( new BDictionary );
+
+  int max_cmdlevel;
+  if ( exec.numParams() < 1 || !getParam( 0, max_cmdlevel ) )
+    max_cmdlevel = -1;
+
   // Sets up text commands not in a package.
   {
-    std::unique_ptr<BDictionary> cmd_lvl_list( new BDictionary );
-    for ( unsigned num = 0; num < Core::gamestate.cmdlevels.size(); ++num )
-    {
-      ObjArray* script_list = Core::GetCommandsInPackage( nullptr, num );
-      if ( script_list == nullptr )
-        continue;
-      else if ( !script_list->ref_arr.empty() )
-        cmd_lvl_list->addMember( new BLong( num ), script_list );
-    }
+    auto cmd_lvl_list = Core::ListAllCommandsInPackage( nullptr, max_cmdlevel );
     if ( cmd_lvl_list->contents().size() > 0 )
       pkg_list->addMember( new String( "" ), cmd_lvl_list.release() );
   }
-  //
+
   // Sets up packaged text commands.
   for ( Plib::Packages::iterator itr = Plib::systemstate.packages.begin();
         itr != Plib::systemstate.packages.end(); ++itr )
   {
     Plib::Package* pkg = ( *itr );
-    std::unique_ptr<BDictionary> cmd_lvl_list( new BDictionary );
-    for ( unsigned num = 0; num < Core::gamestate.cmdlevels.size(); ++num )
-    {
-      ObjArray* script_list = Core::GetCommandsInPackage( pkg, num );
-      if ( script_list == nullptr )
-        continue;
-      else if ( !script_list->ref_arr.empty() )
-        cmd_lvl_list->addMember( new BLong( num ), script_list );
-    }
+    auto cmd_lvl_list = Core::ListAllCommandsInPackage( pkg, max_cmdlevel );
     if ( cmd_lvl_list->contents().size() > 0 )
       pkg_list->addMember( new String( pkg->name().c_str() ), cmd_lvl_list.release() );
   }
+
   return pkg_list.release();
 }
 

--- a/pol-core/support/scripts/polsys.em
+++ b/pol-core/support/scripts/polsys.em
@@ -11,7 +11,7 @@ GetItemDescriptor(objtype);
 FormatItemDescription(desc, amount := 1, suffix := "");
 GetPackageByName(name);
 IncRevision(object);
-ListTextCommands();
+ListTextCommands(max_cmdlevel := -1); // the default (-1) returns all
 ListenPoints();
 MD5Encrypt(str);
 Packages();


### PR DESCRIPTION
`ListTextCommands(max_level)` returns all the textcmds up to level `max_level` (inclusive). If the parameter does not make sense (wrong type or negative), it returns textcmds from every level.

Feature requested in #157 