### PR TITLE
Add SourceFileProcessor, ValueConsumer

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -44,6 +44,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/ProgramBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp
   compiler/astbuilder/SimpleStatementBuilder.h
+  compiler/astbuilder/SourceFileProcessor.cpp
+  compiler/astbuilder/SourceFileProcessor.h
   compiler/astbuilder/TreeBuilder.cpp
   compiler/astbuilder/TreeBuilder.h
   compiler/astbuilder/UserFunctionBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -30,6 +30,8 @@ set (bscript_sources    # sorted !
   compiler/ast/TopLevelStatements.h
   compiler/ast/Value.cpp
   compiler/ast/Value.h
+  compiler/ast/ValueConsumer.cpp
+  compiler/ast/ValueConsumer.h
   compiler/astbuilder/BuilderWorkspace.cpp
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -2,11 +2,17 @@
 
 #include "compiler/ast/Node.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/ast/ValueConsumer.h"
 
 namespace Pol::Bscript::Compiler
 {
 
 void NodeVisitor::visit_top_level_statements( TopLevelStatements& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_value_consumer( ValueConsumer& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -5,6 +5,7 @@ namespace Pol::Bscript::Compiler
 {
 class Node;
 class TopLevelStatements;
+class ValueConsumer;
 
 class NodeVisitor
 {
@@ -12,6 +13,7 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_top_level_statements( TopLevelStatements& );
+  virtual void visit_value_consumer( ValueConsumer& );
 
   virtual void visit_children( Node& parent );
 };

--- a/pol-core/bscript/compiler/ast/ValueConsumer.cpp
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.cpp
@@ -1,0 +1,25 @@
+#include "ValueConsumer.h"
+
+#include <format/format.h>
+
+#include "NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ValueConsumer::ValueConsumer( const SourceLocation& source_location,
+                              std::unique_ptr<Statement> child )
+    : Statement( source_location, std::move( child ) )
+{
+}
+
+void ValueConsumer::accept( NodeVisitor& visitor )
+{
+  visitor.visit_value_consumer( *this );
+}
+
+void ValueConsumer::describe_to( fmt::Writer& w ) const
+{
+  w << "value-consumer";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ValueConsumer.cpp
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.cpp
@@ -2,7 +2,7 @@
 
 #include <format/format.h>
 
-#include "NodeVisitor.h"
+#include "compiler/ast/NodeVisitor.h"
 
 namespace Pol::Bscript::Compiler
 {

--- a/pol-core/bscript/compiler/ast/ValueConsumer.h
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_VALUECONSUMER_H
+#define POLSERVER_VALUECONSUMER_H
+
+#include "Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+
+class ValueConsumer : public Statement
+{
+public:
+  ValueConsumer( const SourceLocation&, std::unique_ptr<Statement> child );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_VALUECONSUMER_H

--- a/pol-core/bscript/compiler/ast/ValueConsumer.h
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.h
@@ -1,7 +1,7 @@
 #ifndef POLSERVER_VALUECONSUMER_H
 #define POLSERVER_VALUECONSUMER_H
 
-#include "Statement.h"
+#include "compiler/ast/Statement.h"
 
 namespace Pol::Bscript::Compiler
 {

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -6,6 +6,7 @@
 #include "compiler/ast/Statement.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/astbuilder/SourceFileProcessor.h"
 #include "compiler/file/SourceFile.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/file/SourceLocation.h"
@@ -44,11 +45,15 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
     return {};
   }
 
+  SourceFileProcessor src_processor( *ident, workspace, true );
+
   workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
   workspace.source_files[sf->pathname] = sf;
 
   compiler_workspace->top_level_statements =
       std::make_unique<TopLevelStatements>( source_location );
+
+  src_processor.process_source( *sf );
 
   return compiler_workspace;
 }

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -2,6 +2,9 @@
 
 #include "compiler/Report.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/ast/Expression.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/ast/ValueConsumer.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -9,6 +12,12 @@ SimpleStatementBuilder::SimpleStatementBuilder( const SourceFileIdentifier& sour
                                     BuilderWorkspace& workspace )
   : ExpressionBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<Statement> SimpleStatementBuilder::consume_statement_result(
+    std::unique_ptr<Statement> statement )
+{
+  return std::make_unique<ValueConsumer>( statement->source_location, std::move( statement ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -5,11 +5,15 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Statement;
 
 class SimpleStatementBuilder : public ExpressionBuilder
 {
 public:
   SimpleStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  static std::unique_ptr<Statement> consume_statement_result(
+      std::unique_ptr<Statement> statement );
 
 };
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -2,7 +2,7 @@
 
 #include "../clib/fileutil.h"
 
-#include "BuilderWorkspace.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
 #include "compiler/file/SourceFile.h"

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -1,0 +1,38 @@
+#include "SourceFileProcessor.h"
+
+#include "../clib/fileutil.h"
+
+#include "BuilderWorkspace.h"
+#include "compiler/Profile.h"
+#include "compiler/Report.h"
+#include "compiler/file/SourceFile.h"
+#include "compiler/file/SourceFileCache.h"
+#include "compiler/file/SourceFileIdentifier.h"
+#include "compiler/model/CompilerWorkspace.h"
+
+using EscriptGrammar::EscriptParser;
+
+namespace Pol::Bscript::Compiler
+{
+SourceFileProcessor::SourceFileProcessor( const SourceFileIdentifier& source_file_identifier,
+                                          BuilderWorkspace& workspace, bool is_src )
+  : profile( workspace.profile ),
+    report( workspace.report ),
+    source_file_identifier( source_file_identifier ),
+    workspace( workspace ),
+    tree_builder( source_file_identifier, workspace ),
+    is_src( is_src )
+{
+}
+
+void SourceFileProcessor::process_source( SourceFile& )
+{
+}
+
+SourceLocation SourceFileProcessor::location_for( antlr4::ParserRuleContext& ctx ) const
+{
+  return { &source_file_identifier, ctx };
+}
+
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -1,0 +1,41 @@
+#ifndef POLSERVER_SOURCEFILEPROCESSOR_H
+#define POLSERVER_SOURCEFILEPROCESSOR_H
+
+#include <EscriptGrammar/EscriptParserBaseVisitor.h>
+
+#include <boost/optional.hpp>
+#include <memory>
+#include <string>
+
+#include "ProgramBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Profile;
+class SourceFile;
+
+class SourceFileProcessor : public EscriptGrammar::EscriptParserBaseVisitor
+{
+public:
+  SourceFileProcessor( const SourceFileIdentifier&, BuilderWorkspace&, bool is_src );
+
+public:
+  void process_source( SourceFile& );
+
+  SourceLocation location_for( antlr4::ParserRuleContext& ) const;
+
+protected:
+  Profile& profile;
+  Report& report;
+  const SourceFileIdentifier& source_file_identifier;
+  BuilderWorkspace& workspace;
+
+  ProgramBuilder tree_builder;
+
+private:
+  const bool is_src;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SOURCEFILEPROCESSOR_H

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 
-#include "ProgramBuilder.h"
+#include "compiler/astbuilder/ProgramBuilder.h"
 
 namespace Pol::Bscript::Compiler
 {

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -19,6 +19,11 @@ void InstructionEmitter::initialize_data()
   data_emitter.store( &nul, sizeof nul );
 }
 
+void InstructionEmitter::consume()
+{
+  emit_token( TOK_CONSUMER, TYP_UNARY_OPERATOR );
+}
+
 void InstructionEmitter::progend()
 {
   emit_token( CTRL_PROGEND, TYP_CONTROL );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -33,6 +33,7 @@ public:
 
   void initialize_data();
 
+  void consume();
   void progend();
 
 private:

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,6 +1,8 @@
 #include "InstructionGenerator.h"
 
+#include "compiler/ast/ValueConsumer.h"
 #include "compiler/codegen/InstructionEmitter.h"
+#include "compiler/file/SourceFileIdentifier.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -8,6 +10,13 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
   : emitter( emitter ),
     emit( emitter )
 {
+}
+
+void InstructionGenerator::visit_value_consumer( ValueConsumer& node )
+{
+  visit_children( node );
+
+  emit.consume();
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -14,6 +14,7 @@ class InstructionGenerator : public NodeVisitor
 {
 public:
   explicit InstructionGenerator( InstructionEmitter& );
+  void visit_value_consumer( ValueConsumer& ) override;
 
 private:
   // There are two of these because sometimes when calling a method

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -14,6 +14,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 {
   switch ( tkn.id )
   {
+  case TOK_CONSUMER:
+    w << "# (consume)";
+    break;
+
   case CTRL_PROGEND:
     w << "progend";
     break;


### PR DESCRIPTION
Add [SourceFileProcessor](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp) stub: visits a SourceFile, as well as any included .em or .inc files
Add ValueConsumer: An AST node that consumes the result of the evaluation of its child nodes
  - this is used for expression statements and for `var` statements
