### PR TITLE
New compiler: Add FloatValue

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -20,6 +20,8 @@ set (bscript_sources    # sorted !
   compiler/analyzer/SemanticAnalyzer.h
   compiler/ast/Expression.cpp
   compiler/ast/Expression.h
+  compiler/ast/FloatValue.cpp
+  compiler/ast/FloatValue.h
   compiler/ast/Node.cpp
   compiler/ast/Node.h
   compiler/ast/NodeVisitor.cpp

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -19,6 +19,11 @@ public:
 
   std::atomic<long> ambiguities;
 
+  std::atomic<long> parse_src_count;
+
+  std::atomic<long long> parse_src_micros;
+  std::atomic<long long> ast_src_micros;
+
   std::atomic<long> cache_hits;
   std::atomic<long> cache_misses;
 };

--- a/pol-core/bscript/compiler/ast/FloatValue.cpp
+++ b/pol-core/bscript/compiler/ast/FloatValue.cpp
@@ -1,0 +1,24 @@
+#include "FloatValue.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+FloatValue::FloatValue( const SourceLocation& source_location, double value )
+    : Value( source_location ), value( value )
+{
+}
+
+void FloatValue::accept( NodeVisitor& visitor )
+{
+  visitor.visit_float_value( *this );
+}
+
+void FloatValue::describe_to( fmt::Writer& w ) const
+{
+  w << "float-value(" << value << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FloatValue.h
+++ b/pol-core/bscript/compiler/ast/FloatValue.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_FLOATVALUE_H
+#define POLSERVER_FLOATVALUE_H
+
+#include "compiler/ast/Value.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+
+class FloatValue : public Value
+{
+public:
+  FloatValue( const SourceLocation&, double value );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const double value;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FLOATVALUE_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,11 +1,17 @@
 #include "NodeVisitor.h"
 
+#include "compiler/ast/FloatValue.h"
 #include "compiler/ast/Node.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/ValueConsumer.h"
 
 namespace Pol::Bscript::Compiler
 {
+
+void NodeVisitor::visit_float_value( FloatValue& node )
+{
+  visit_children( node );
+}
 
 void NodeVisitor::visit_top_level_statements( TopLevelStatements& node )
 {

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -3,6 +3,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class FloatValue;
 class Node;
 class TopLevelStatements;
 class ValueConsumer;
@@ -12,6 +13,7 @@ class NodeVisitor
 public:
   virtual ~NodeVisitor() = default;
 
+  virtual void visit_float_value( FloatValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_value_consumer( ValueConsumer& );
 

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -1,11 +1,28 @@
 #include "CompoundStatementBuilder.h"
 
+#include "compiler/ast/Expression.h"
+
+using EscriptGrammar::EscriptParser;
+
 namespace Pol::Bscript::Compiler
 {
 CompoundStatementBuilder::CompoundStatementBuilder(
     const SourceFileIdentifier& source_file_identifier, BuilderWorkspace& workspace )
   : SimpleStatementBuilder( source_file_identifier, workspace )
 {
+}
+
+void CompoundStatementBuilder::add_statements(
+    EscriptParser::StatementContext* ctx, std::vector<std::unique_ptr<Statement>>& statements )
+{
+  if ( auto expr_ctx = ctx->expression() )
+  {
+    statements.push_back( consume_statement_result( expression( expr_ctx ) ) );
+  }
+  else
+  {
+    location_for( *ctx ).internal_error( "unhandled statement" );
+  }
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -11,6 +11,9 @@ class CompoundStatementBuilder : public SimpleStatementBuilder
 public:
   CompoundStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  void add_statements( EscriptGrammar::EscriptParser::StatementContext*,
+                       std::vector<std::unique_ptr<Statement>>& );
+
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -1,6 +1,9 @@
 #include "ExpressionBuilder.h"
 
 #include "compiler/Report.h"
+#include "compiler/ast/Value.h"
+
+using EscriptGrammar::EscriptParser;
 
 namespace Pol::Bscript::Compiler
 {
@@ -8,6 +11,22 @@ ExpressionBuilder::ExpressionBuilder( const SourceFileIdentifier& source_file_id
                                       BuilderWorkspace& workspace )
   : ValueBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<Expression> ExpressionBuilder::expression( EscriptParser::ExpressionContext* ctx )
+{
+  if ( auto prim = ctx->primary() )
+    return primary( prim );
+
+  location_for( *ctx ).internal_error( "unhandled expression" );
+}
+
+std::unique_ptr<Expression> ExpressionBuilder::primary( EscriptParser::PrimaryContext* ctx )
+{
+  if ( auto literal = ctx->literal() )
+    return value( literal );
+
+  location_for( *ctx ).internal_error( "unhandled primary expression" );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -5,11 +5,16 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Expression;
 
 class ExpressionBuilder : public ValueBuilder
 {
 public:
   ExpressionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
+
+  std::unique_ptr<Expression> primary( EscriptGrammar::EscriptParser::PrimaryContext* );
 
 };
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -1,10 +1,12 @@
 #include "SourceFileProcessor.h"
 
-#include "../clib/fileutil.h"
-
+#include "clib/fileutil.h"
+#include "clib/timer.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
+#include "compiler/ast/Statement.h"
+#include "compiler/ast/TopLevelStatements.h"
 #include "compiler/file/SourceFile.h"
 #include "compiler/file/SourceFileCache.h"
 #include "compiler/file/SourceFileIdentifier.h"
@@ -25,14 +27,46 @@ SourceFileProcessor::SourceFileProcessor( const SourceFileIdentifier& source_fil
 {
 }
 
-void SourceFileProcessor::process_source( SourceFile& )
+void SourceFileProcessor::process_source( SourceFile& sf )
 {
+  Pol::Tools::HighPerfTimer parse_timer;
+  auto compilation_unit = sf.get_compilation_unit( report, source_file_identifier );
+  long long parse_us_counted = parse_timer.ellapsed().count();
+
+  profile.parse_src_micros.fetch_add( parse_us_counted );
+  profile.parse_src_count++;
+
+  if ( report.error_count() == 0 )
+  {
+    Pol::Tools::HighPerfTimer ast_timer;
+    compilation_unit->accept( this );
+    long long ast_us_elapsed = ast_timer.ellapsed().count();
+
+    profile.ast_src_micros.fetch_add( ast_us_elapsed );
+  }
+}
+
+antlrcpp::Any SourceFileProcessor::visitStatement( EscriptParser::StatementContext* ctx )
+{
+  if ( auto constStatement = ctx->constStatement() )
+  {
+  }
+  else
+  {
+    std::vector<std::unique_ptr<Statement>> statements;
+    tree_builder.add_statements( ctx, statements );
+    for ( auto& statement : statements )
+    {
+      workspace.compiler_workspace.top_level_statements->children.push_back(
+          std::move( statement ) );
+    }
+  }
+  return antlrcpp::Any();
 }
 
 SourceLocation SourceFileProcessor::location_for( antlr4::ParserRuleContext& ctx ) const
 {
   return { &source_file_identifier, ctx };
 }
-
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -22,6 +22,8 @@ public:
 public:
   void process_source( SourceFile& );
 
+  antlrcpp::Any visitStatement( EscriptGrammar::EscriptParser::StatementContext* ) override;
+
   SourceLocation location_for( antlr4::ParserRuleContext& ) const;
 
 protected:

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -1,8 +1,11 @@
 #include "ValueBuilder.h"
 
 #include "compiler/Report.h"
+#include "compiler/ast/FloatValue.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/file/SourceLocation.h"
+
+using EscriptGrammar::EscriptParser;
 
 namespace Pol::Bscript::Compiler
 {
@@ -10,6 +13,27 @@ ValueBuilder::ValueBuilder( const SourceFileIdentifier& source_file_identifier,
                             BuilderWorkspace& workspace )
   : TreeBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<FloatValue> ValueBuilder::float_value(
+    EscriptGrammar::EscriptParser::FloatLiteralContext* ctx )
+{
+  auto loc = location_for( *ctx );
+  double value = std::stod( text( ctx->FLOAT_LITERAL() ) );
+  return std::make_unique<FloatValue>( loc, value );
+}
+
+
+std::unique_ptr<Value> ValueBuilder::value( EscriptParser::LiteralContext* ctx )
+{
+  if ( auto float_literal = ctx->floatLiteral() )
+  {
+    return float_value( float_literal );
+  }
+  else
+  {
+    location_for( *ctx ).internal_error( "unhandled literal" );
+  }
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
@@ -3,13 +3,22 @@
 
 #include "compiler/astbuilder/TreeBuilder.h"
 
+#include <EscriptGrammar/EscriptParser.h>
+
 namespace Pol::Bscript::Compiler
 {
+class FloatValue;
+class Value;
 
 class ValueBuilder : public TreeBuilder
 {
 public:
   ValueBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  std::unique_ptr<FloatValue> float_value(
+      EscriptGrammar::EscriptParser::FloatLiteralContext* );
+
+  std::unique_ptr<Value> value( EscriptGrammar::EscriptParser::LiteralContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -29,6 +29,13 @@ void InstructionEmitter::progend()
   emit_token( CTRL_PROGEND, TYP_CONTROL );
 }
 
+void InstructionEmitter::value( double v )
+{
+  unsigned offset = data_emitter.append( v );
+  emit_token( TOK_DOUBLE, TYP_OPERAND, offset );
+}
+
+
 unsigned InstructionEmitter::emit_token( BTokenId id, BTokenType type, unsigned offset )
 {
   StoredToken token( Mod_Basic, id, type, offset );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -35,6 +35,7 @@ public:
 
   void consume();
   void progend();
+  void value( double );
 
 private:
   unsigned emit_token( BTokenId id, BTokenType type, unsigned offset = 0 );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,5 +1,6 @@
 #include "InstructionGenerator.h"
 
+#include "compiler/ast/FloatValue.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
@@ -10,6 +11,11 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
   : emitter( emitter ),
     emit( emitter )
 {
+}
+
+void InstructionGenerator::visit_float_value( FloatValue& node )
+{
+  emit.value( node.value );
 }
 
 void InstructionGenerator::visit_value_consumer( ValueConsumer& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -14,6 +14,8 @@ class InstructionGenerator : public NodeVisitor
 {
 public:
   explicit InstructionGenerator( InstructionEmitter& );
+
+  void visit_float_value( FloatValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
 
 private:

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -14,6 +14,11 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 {
   switch ( tkn.id )
   {
+  case TOK_DOUBLE:
+    w << double_at( tkn.offset ) << " (float)"
+      << " offset=0x" << fmt::hex( tkn.offset );
+    break;
+
   case TOK_CONSUMER:
     w << "# (consume)";
     break;
@@ -26,6 +31,15 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "id=0x" << fmt::hex( tkn.id ) << " type=" << tkn.type << " offset=" << tkn.offset
       << " module=" << tkn.module;
   }
+}
+
+double StoredTokenDecoder::double_at( unsigned offset ) const
+{
+  if ( offset > data.size() - sizeof( double ) )
+    throw std::runtime_error( "data overflow reading double at offset " + std::to_string( offset ) +
+                              ".  Data size is " + std::to_string( data.size() ) );
+
+  return *reinterpret_cast<const double*>( &data[offset] );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.h
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.h
@@ -22,6 +22,7 @@ public:
   void decode_to( const StoredToken&, fmt::Writer& );
 
 private:
+  double double_at( unsigned offset ) const;
 
   const std::vector<ModuleDescriptor>& module_descriptors;
   const std::vector<std::byte>& data;

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -956,6 +956,9 @@ bool run( int argc, char** argv, int* res )
 
     tmp << "    build workspace: " << (long long)summary.profile.build_workspace_micros / 1000
         << "\n";
+    tmp << "      - parse *.src:   " << (long long)summary.profile.parse_src_micros / 1000 << " ("
+        << (long)summary.profile.parse_src_count << ")\n";
+    tmp << "        - ast *.src:   " << (long long)summary.profile.ast_src_micros / 1000 << "\n";
     tmp << " register constants: "
         << (long long)summary.profile.register_const_declarations_micros / 1000 << "\n";
     tmp << "            analyze: " << (long long)summary.profile.analyze_micros / 1000 << "\n";


### PR DESCRIPTION
Adds handling for float literals.

I'm adding floats before strings because parsing float values is simplest (`std::stod`) among all the value types, and this affords an opportunity to add some more of the plumbing so it will be ready when adding the slightly-more-complex string and int value builders.

```
$ cat a.src
2.5;

$ /home/vagrant/polserver/bin/ecompile -f -l -g a.src

$ cat a.lst
0: 2.5 (float) offset=0x1
1: # (consume)
2: progend
```