### PR TITLE
New compiler: Add StringValue

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -28,6 +28,8 @@ set (bscript_sources    # sorted !
   compiler/ast/NodeVisitor.h
   compiler/ast/Statement.cpp
   compiler/ast/Statement.h
+  compiler/ast/StringValue.cpp
+  compiler/ast/StringValue.h
   compiler/ast/TopLevelStatements.cpp
   compiler/ast/TopLevelStatements.h
   compiler/ast/Value.cpp

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -2,6 +2,7 @@
 
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/Node.h"
+#include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/ValueConsumer.h"
 
@@ -9,6 +10,11 @@ namespace Pol::Bscript::Compiler
 {
 
 void NodeVisitor::visit_float_value( FloatValue& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_string_value( StringValue& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -5,6 +5,7 @@ namespace Pol::Bscript::Compiler
 {
 class FloatValue;
 class Node;
+class StringValue;
 class TopLevelStatements;
 class ValueConsumer;
 
@@ -14,6 +15,7 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_float_value( FloatValue& );
+  virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_value_consumer( ValueConsumer& );
 

--- a/pol-core/bscript/compiler/ast/StringValue.cpp
+++ b/pol-core/bscript/compiler/ast/StringValue.cpp
@@ -1,0 +1,25 @@
+#include "StringValue.h"
+
+#include <format/format.h>
+
+#include "clib/strutil.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+StringValue::StringValue( const SourceLocation& source_location, std::string value )
+    : Value( source_location ), value( std::move( value ) )
+{
+}
+
+void StringValue::accept( NodeVisitor& visitor )
+{
+  visitor.visit_string_value( *this );
+}
+
+void StringValue::describe_to( fmt::Writer& w ) const
+{
+  w << "string-value(" << Clib::getencodedquotedstring( value ) << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/StringValue.h
+++ b/pol-core/bscript/compiler/ast/StringValue.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_STRINGVALUE_H
+#define POLSERVER_STRINGVALUE_H
+
+#include "compiler/ast/Value.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+
+class StringValue : public Value
+{
+public:
+  StringValue( const SourceLocation& source_location, std::string value );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string value;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_STRINGVALUE_H

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -1,5 +1,7 @@
 #include "ValueBuilder.h"
 
+#include <cstring>
+
 #include "clib/strutil.h"
 #include "compiler/Report.h"
 #include "compiler/ast/FloatValue.h"

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -43,6 +43,7 @@ std::string ValueBuilder::unquote( antlr4::tree::TerminalNode* string_literal )
 
   const char* end = s + 1;
   std::string lit;
+  lit.reserve(input.length());
   bool escnext = false;  // true when waiting for 2nd char in an escape sequence
   u8 hexnext = 0;        // tells how many more chars in a \xNN escape sequence
   char hexstr[3];        // will contain the \x escape chars to be processed

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -1,7 +1,9 @@
 #include "ValueBuilder.h"
 
+#include "clib/strutil.h"
 #include "compiler/Report.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/StringValue.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/file/SourceLocation.h"
 
@@ -23,10 +25,97 @@ std::unique_ptr<FloatValue> ValueBuilder::float_value(
   return std::make_unique<FloatValue>( loc, value );
 }
 
+std::unique_ptr<StringValue> ValueBuilder::string_value(
+    antlr4::tree::TerminalNode* string_literal )
+{
+  auto loc = location_for( *string_literal );
+  return std::make_unique<StringValue>( loc, unquote( string_literal ) );
+}
+
+std::string ValueBuilder::unquote( antlr4::tree::TerminalNode* string_literal )
+{
+  std::string input = string_literal->getSymbol()->getText();
+  const char* s = input.c_str();
+  if ( *s != '\"' )
+    location_for( *string_literal ).internal_error( "string does not begin with a quote?" );
+
+  const char* end = s + 1;
+  std::string lit;
+  bool escnext = false;  // true when waiting for 2nd char in an escape sequence
+  u8 hexnext = 0;        // tells how many more chars in a \xNN escape sequence
+  char hexstr[3];        // will contain the \x escape chars to be processed
+  memset( hexstr, 0, 3 );
+
+  for ( ;; )
+  {
+    if ( !*end )
+    {
+      // parser should catch this.
+      location_for( *string_literal ).internal_error( "unterminated string" );
+    }
+
+    if ( escnext && hexnext )
+      location_for( *string_literal )
+          .internal_error( "Bug in the compiler. Please report this on the forums." );
+
+    if ( escnext )
+    {
+      // waiting for 2nd character after a backslash
+      escnext = false;
+      if ( *end == 'n' )
+        lit += '\n';
+      else if ( *end == 't' )
+        lit += '\t';
+      else if ( *end == 'x' )
+        hexnext = 2;
+      else
+        lit += *end;
+    }
+    else if ( hexnext )
+    {
+      // waiting for next (two) chars in hex escape sequence (eg. \xFF)
+      hexstr[2 - hexnext] = *end;
+      if ( !--hexnext )
+      {
+        char* endptr;
+        char ord = static_cast<char>( strtol( hexstr, &endptr, 16 ) );
+        if ( *endptr != '\0' )
+        {
+          report.error( location_for( *string_literal ), "Invalid hex escape sequence '", hexstr,
+                        "'.\n" );
+          return lit;
+        }
+        lit += ord;
+      }
+    }
+    else
+    {
+      if ( *end == '\\' )
+        escnext = true;
+      else if ( *end == '\"' )
+        break;
+      else
+        lit += *end;
+    }
+    ++end;
+  }
+  if ( !Clib::isValidUnicode( lit ) )
+  {
+    report.warning( location_for( *string_literal ),
+                    "Warning: invalid unicode character detected. Assuming ISO8859.\n" );
+
+    Clib::sanitizeUnicodeWithIso( &lit );
+  }
+  return lit;
+}
 
 std::unique_ptr<Value> ValueBuilder::value( EscriptParser::LiteralContext* ctx )
 {
-  if ( auto float_literal = ctx->floatLiteral() )
+  if ( auto string_literal = ctx->STRING_LITERAL() )
+  {
+    return string_value( string_literal );
+  }
+  else if ( auto float_literal = ctx->floatLiteral() )
   {
     return float_value( float_literal );
   }

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
@@ -8,6 +8,7 @@
 namespace Pol::Bscript::Compiler
 {
 class FloatValue;
+class StringValue;
 class Value;
 
 class ValueBuilder : public TreeBuilder
@@ -17,6 +18,10 @@ public:
 
   std::unique_ptr<FloatValue> float_value(
       EscriptGrammar::EscriptParser::FloatLiteralContext* );
+
+  std::unique_ptr<StringValue> string_value( antlr4::tree::TerminalNode* string_literal );
+
+  std::string unquote( antlr4::tree::TerminalNode* string_literal );
 
   std::unique_ptr<Value> value( EscriptGrammar::EscriptParser::LiteralContext* );
 };

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -35,6 +35,16 @@ void InstructionEmitter::value( double v )
   emit_token( TOK_DOUBLE, TYP_OPERAND, offset );
 }
 
+void InstructionEmitter::value( const std::string& v )
+{
+  unsigned data_offset = emit_data( v );
+  emit_token( TOK_STRING, TYP_OPERAND, data_offset );
+}
+
+unsigned InstructionEmitter::emit_data( const std::string& s )
+{
+  return data_emitter.store( s );
+}
 
 unsigned InstructionEmitter::emit_token( BTokenId id, BTokenType type, unsigned offset )
 {

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -36,8 +36,10 @@ public:
   void consume();
   void progend();
   void value( double );
+  void value( const std::string& );
 
 private:
+  unsigned emit_data( const std::string& );
   unsigned emit_token( BTokenId id, BTokenType type, unsigned offset = 0 );
   unsigned append_token( StoredToken& );
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,6 +1,7 @@
 #include "InstructionGenerator.h"
 
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
@@ -16,6 +17,11 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
 void InstructionGenerator::visit_float_value( FloatValue& node )
 {
   emit.value( node.value );
+}
+
+void InstructionGenerator::visit_string_value( StringValue& lit )
+{
+  emit.value( lit.value );
 }
 
 void InstructionGenerator::visit_value_consumer( ValueConsumer& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -16,6 +16,7 @@ public:
   explicit InstructionGenerator( InstructionEmitter& );
 
   void visit_float_value( FloatValue& ) override;
+  void visit_string_value( StringValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
 
 private:

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -19,6 +19,14 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
       << " offset=0x" << fmt::hex( tkn.offset );
     break;
 
+  case TOK_STRING:
+  {
+    auto s = string_at( tkn.offset );
+    w << Clib::getencodedquotedstring( s ) << " (string)"
+      << " len=" << s.length() << " offset=0x" << fmt::hex( tkn.offset );
+    break;
+  }
+
   case TOK_CONSUMER:
     w << "# (consume)";
     break;
@@ -41,5 +49,24 @@ double StoredTokenDecoder::double_at( unsigned offset ) const
 
   return *reinterpret_cast<const double*>( &data[offset] );
 }
+
+std::string StoredTokenDecoder::string_at( unsigned offset ) const
+{
+  if ( offset > data.size() )
+    throw std::runtime_error( "data overflow reading string starting at offset " +
+                              std::to_string( offset ) + ".  Data size is " +
+                              std::to_string( data.size() ) );
+
+  const char* s_begin = reinterpret_cast<const char*>( data.data() + offset );
+  const char* data_end = reinterpret_cast<const char*>( data.data() + data.size() );
+
+  auto s_end = std::find( s_begin, data_end, '\0' );
+  if ( s_end == data_end )
+    throw std::runtime_error( "No null terminator for string at offset " +
+                              std::to_string( offset ) );
+
+  return std::string( s_begin, s_end );
+}
+
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.h
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.h
@@ -1,6 +1,7 @@
 #ifndef POLSERVER_STOREDTOKENDECODER_H
 #define POLSERVER_STOREDTOKENDECODER_H
 
+#include <string>
 #include <vector>
 
 #include "clib/formatfwd.h"

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.h
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.h
@@ -23,6 +23,7 @@ public:
 
 private:
   double double_at( unsigned offset ) const;
+  std::string string_at( unsigned offset ) const;
 
   const std::vector<ModuleDescriptor>& module_descriptors;
   const std::vector<std::byte>& data;


### PR DESCRIPTION
The meat of ValueBuilder::unquote is adapted (but mostly copied) from [Parser::tryLiteral](https://github.com/polserver/polserver/blob/master/pol-core/bscript/parser.cpp#L1251).

```
$ cat a.src
"xyz";
$ /home/vagrant/polserver/bin/ecompile -l -g a.src
$ cat a.lst
0: "xyz" (string) len=3 offset=0x1
1: # (consume)
2: progend
```