### PR TITLE
Upgrade Vagrant setup to Ubuntu 20.04 (focal64)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,17 +5,18 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
-  
+  config.vm.box = "ubuntu/focal64"
+
   config.vm.provision :shell, :path => "./devmachine/prepareMachine.sh"
+  config.vm.boot_timeout = 600
 
   # Forwards port 5003 from the VM to port 5004 at host (useful for testing)
   config.vm.network :forwarded_port, guest: 5003, host: 5004
   
   config.vm.provider "virtualbox" do |v|
     v.memory = 3024
-	v.cpus = 2
-	v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+    v.cpus = 2
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
 	
   end
 end

--- a/devmachine/prepareMachine.sh
+++ b/devmachine/prepareMachine.sh
@@ -5,7 +5,17 @@
 
 # Updates the system and install needed packages
 # uses non-interactive mode (http://askubuntu.com/questions/146921/how-do-i-apt-get-y-dist-upgrade-without-a-grub-config-prompt)
-sudo apt-get update
+
+echo
+echo -------------------------------------------------------------------------------
+echo apt-get update
+echo -------------------------------------------------------------------------------
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+
+echo
+echo -------------------------------------------------------------------------------
+echo apt-get upgrade
+echo -------------------------------------------------------------------------------
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 
 echo
@@ -13,7 +23,8 @@ echo ---------------------------------------------------------------------------
 echo Compiler support and libraries
 echo -------------------------------------------------------------------------------
 echo
-sudo apt-get install make g++ libc-dev g++-multilib libgomp1 --install-suggests -y
+sudo apt-get install g++-9 g++-multilib zlib1g-dev gcc-9-locales gcc-9-doc libstdc++6-9-dbg -y
+sudo apt-get install g++ -y
 
 echo
 echo -------------------------------------------------------------------------------
@@ -36,7 +47,6 @@ echo ---------------------------------------------------------------------------
 echo
 sudo apt-get install mysql-client libmysqlclient-dev -y
 
-
 echo
 echo -------------------------------------------------------------------------------
 echo OpenSSL
@@ -46,69 +56,37 @@ sudo apt-get install libssl-dev -y
 
 echo
 echo -------------------------------------------------------------------------------
-echo  add-apt-repository
-echo -------------------------------------------------------------------------------
-echo
-sudo apt-get install python-software-properties -y
-
-echo
-echo -------------------------------------------------------------------------------
-echo add gcc repro
-echo -------------------------------------------------------------------------------
-echo
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-
-echo
-echo -------------------------------------------------------------------------------
-echo add llvm repro
-echo -------------------------------------------------------------------------------
-echo
-sudo add-apt-repository 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-7 main'
-sudo wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-
-echo
-echo -------------------------------------------------------------------------------
-echo update
-echo -------------------------------------------------------------------------------
-echo
-sudo apt-get update
-
-echo
-echo -------------------------------------------------------------------------------
 echo install clang
 echo -------------------------------------------------------------------------------
 echo
-sudo apt-get install clang-7 clang-7-doc libclang-common-7-dev libclang-7-dev libclang1-7 libllvm-7-ocaml-dev libllvm7 lldb-7 llvm-7 llvm-7-dev llvm-7-doc llvm-7-examples llvm-7-runtime clang-tidy-7 clang-format-7 llvm-toolchain-7 -y
-#sudo apt-get install libiomp5 -y
+sudo apt-get install clang-7 libclang-7-dev libllvm-7-ocaml-dev lldb-7 llvm-7-examples clang-tidy-7 clang-format-7 -y
 echo
-echo -------------------------------------------------------------------------------
-echo install gcc 9
-echo -------------------------------------------------------------------------------
-echo
-sudo apt-get install g++-9 cpp-9 gcc-9  gcc-9-locales g++-9-multilib gcc-9-doc libstdc++6-9-dbg gcc-9-multilib libcloog-isl4 libisl10 libgomp1-dbg libitm1-dbg libatomic1-dbg libasan0-dbg libtsan0-dbg libquadmath0-dbg binutils -y
-
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1 --force
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1 --force
 
 echo
 echo -------------------------------------------------------------------------------
 echo install cmake
 echo -------------------------------------------------------------------------------
 echo
-wget http://www.cmake.org/files/v3.17/cmake-3.17.1.tar.gz
-tar -xvzf cmake-3.17.1.tar.gz
-(cd cmake-3.17.1 && ./configure && make && sudo make install)
-rm -rf cmake-3.17.1 cmake-3.17.1.tar.gz
+sudo apt-get install cmake -y
 
 echo
 echo -------------------------------------------------------------------------------
 echo needed for antlr
 echo -------------------------------------------------------------------------------
 echo
-sudo apt-get install pkg-config uuid-dev
+sudo apt-get install pkgconf uuid-dev -y
 
+echo
+echo -------------------------------------------------------------------------------
+echo ninja
+echo -------------------------------------------------------------------------------
+sudo apt-get install ninja-build -y
 
-sudo apt-get upgrade
+echo
+echo -------------------------------------------------------------------------------
+echo debugging
+echo -------------------------------------------------------------------------------
+sudo apt-get install gdb valgrind -y
 
 # Creates a link to /vagrant (which, if you run this file, will contain the SVN repository)
 if [ ! -d "/home/vagrant/polserver" ]; then

--- a/devmachine/prepareMachine.sh
+++ b/devmachine/prepareMachine.sh
@@ -95,8 +95,7 @@ echo debugging
 echo -------------------------------------------------------------------------------
 sudo apt-get install gdb valgrind -y
 
-# Creates a link to /vagrant (which, if you run this file, will contain the SVN repository)
+# Creates a link to /vagrant (which, if you run this file, will contain the git repository)
 if [ ! -d "/home/vagrant/polserver" ]; then
 	ln -s /vagrant /home/vagrant/polserver
 fi
-

--- a/devmachine/prepareMachine.sh
+++ b/devmachine/prepareMachine.sh
@@ -60,6 +60,7 @@ echo install clang
 echo -------------------------------------------------------------------------------
 echo
 sudo apt-get install clang-7 libclang-7-dev libllvm-7-ocaml-dev lldb-7 llvm-7-examples clang-tidy-7 clang-format-7 -y
+sudo apt-get install clang -y
 echo
 
 echo
@@ -81,6 +82,12 @@ echo ---------------------------------------------------------------------------
 echo ninja
 echo -------------------------------------------------------------------------------
 sudo apt-get install ninja-build -y
+
+echo
+echo -------------------------------------------------------------------------------
+echo formatting
+echo -------------------------------------------------------------------------------
+sudo apt-get install clang-format -y
 
 echo
 echo -------------------------------------------------------------------------------


### PR DESCRIPTION
Another note: with this setup, if you increase the cpu count and memory, it builds much faster.  Example: with cpus = 10, memory = 16384, for me it buildtin ~2.5 minutes rather than 18-20.

Verified on a new clone:
```
$ vagrant up
$ vagrant ssh
$ cd polserver/bin-build
$ ./build_linux.sh
```

On an existing clone, you'll need to clean, as well as track down and wipe out any already-built external libraries.