### PR TITLE
Built AST for module function declarations

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -54,6 +54,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/ExpressionBuilder.h
   compiler/astbuilder/ModuleDeclarationBuilder.cpp
   compiler/astbuilder/ModuleDeclarationBuilder.h
+  compiler/astbuilder/ModuleProcessor.cpp
+  compiler/astbuilder/ModuleProcessor.h
   compiler/astbuilder/ProgramBuilder.cpp
   compiler/astbuilder/ProgramBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -22,6 +22,14 @@ set (bscript_sources    # sorted !
   compiler/ast/Expression.h
   compiler/ast/FloatValue.cpp
   compiler/ast/FloatValue.h
+  compiler/ast/Function.cpp
+  compiler/ast/Function.h
+  compiler/ast/FunctionParameterDeclaration.cpp
+  compiler/ast/FunctionParameterDeclaration.h
+  compiler/ast/FunctionParameterList.cpp
+  compiler/ast/FunctionParameterList.h
+  compiler/ast/ModuleFunctionDeclaration.cpp
+  compiler/ast/ModuleFunctionDeclaration.h
   compiler/ast/Node.cpp
   compiler/ast/Node.h
   compiler/ast/NodeVisitor.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -52,6 +52,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/CompoundStatementBuilder.h
   compiler/astbuilder/ExpressionBuilder.cpp
   compiler/astbuilder/ExpressionBuilder.h
+  compiler/astbuilder/FunctionResolver.cpp
+  compiler/astbuilder/FunctionResolver.h
   compiler/astbuilder/ModuleDeclarationBuilder.cpp
   compiler/astbuilder/ModuleDeclarationBuilder.h
   compiler/astbuilder/ModuleProcessor.cpp

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -19,7 +19,12 @@ public:
 
   std::atomic<long> ambiguities;
 
+  std::atomic<long> parse_em_count;
   std::atomic<long> parse_src_count;
+
+  std::atomic<long long> load_em_micros;
+  std::atomic<long long> parse_em_micros;
+  std::atomic<long long> ast_em_micros;
 
   std::atomic<long long> parse_src_micros;
   std::atomic<long long> ast_src_micros;

--- a/pol-core/bscript/compiler/ast/Function.cpp
+++ b/pol-core/bscript/compiler/ast/Function.cpp
@@ -1,0 +1,30 @@
+#include "Function.h"
+
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+
+namespace Pol::Bscript::Compiler
+{
+Function::Function( const SourceLocation& source_location, std::string name,
+                    std::unique_ptr<FunctionParameterList> parameter_list )
+    : Node( source_location, std::move( parameter_list ) ), name( std::move( name ) )
+{
+}
+
+unsigned Function::parameter_count() const
+{
+  return static_cast<unsigned>(children.at( 0 )->children.size());
+}
+
+std::vector<std::reference_wrapper<FunctionParameterDeclaration>> Function::parameters()
+{
+  std::vector<std::reference_wrapper<FunctionParameterDeclaration>> params;
+  auto& param_list = child<FunctionParameterList>( 0 );
+  for ( auto& param : param_list.children )
+  {
+    params.emplace_back( *static_cast<FunctionParameterDeclaration*>( param.get() ) );
+  }
+  return params;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Function.h
+++ b/pol-core/bscript/compiler/ast/Function.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_FUNCTION_H
+#define POLSERVER_FUNCTION_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class FunctionParameterDeclaration;
+class FunctionParameterList;
+class FunctionBody;
+
+class Function : public Node
+{
+public:
+  Function( const SourceLocation&, std::string name, std::unique_ptr<FunctionParameterList> );
+
+  unsigned parameter_count() const;
+  std::vector<std::reference_wrapper<FunctionParameterDeclaration>> parameters();
+
+  const std::string name;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_FUNCTION_H

--- a/pol-core/bscript/compiler/ast/FunctionParameterDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionParameterDeclaration.cpp
@@ -1,0 +1,48 @@
+#include "FunctionParameterDeclaration.h"
+
+#include <utility>
+
+#include "clib/logfacility.h"
+#include "compiler/ast/NodeVisitor.h"
+#include "compiler/ast/Expression.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionParameterDeclaration::FunctionParameterDeclaration(
+    const SourceLocation& source_location, std::string name, bool byref, bool unused,
+    std::unique_ptr<Expression> default_value )
+  : Node( source_location, std::move( default_value ) ),
+    name( std::move( name ) ),
+    byref( byref ),
+    unused( unused )
+{
+}
+
+FunctionParameterDeclaration::FunctionParameterDeclaration( const SourceLocation& source_location,
+                                                            std::string name, bool byref,
+                                                            bool unused )
+    : Node( source_location ), name( std::move( name ) ), byref( byref ), unused( unused )
+{
+}
+
+void FunctionParameterDeclaration::accept( NodeVisitor& visitor )
+{
+  visitor.visit_function_parameter_declaration( *this );
+}
+
+void FunctionParameterDeclaration::describe_to( fmt::Writer& w ) const
+{
+  w << "function-parameter-declaration(" << name;
+  if ( byref )
+    w << ", byref";
+  if ( unused )
+    w << ", unused";
+  w << ")";
+}
+
+Expression* FunctionParameterDeclaration::default_value()
+{
+  return children.empty() ? nullptr : &child<Expression>( 0 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionParameterDeclaration.h
+++ b/pol-core/bscript/compiler/ast/FunctionParameterDeclaration.h
@@ -1,0 +1,32 @@
+#ifndef POLSERVER_FUNCTIONPARAMETERDECLARATION_H
+#define POLSERVER_FUNCTIONPARAMETERDECLARATION_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class Expression;
+
+class FunctionParameterDeclaration : public Node
+{
+public:
+  FunctionParameterDeclaration( const SourceLocation& source_location, std::string name, bool byref,
+                        bool unused, std::unique_ptr<Expression> default_value );
+  FunctionParameterDeclaration( const SourceLocation& source_location, std::string name, bool byref,
+                        bool unused );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Expression* default_value();
+
+  const std::string name;
+  const bool byref;
+  const bool unused;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_FUNCTIONPARAMETERDECLARATION_H

--- a/pol-core/bscript/compiler/ast/FunctionParameterList.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionParameterList.cpp
@@ -1,0 +1,27 @@
+#include "FunctionParameterList.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionParameterList::FunctionParameterList(
+    const SourceLocation& source_location,
+    std::vector<std::unique_ptr<FunctionParameterDeclaration>> parameters )
+  : Node( source_location, std::move( parameters ) )
+{
+}
+
+void FunctionParameterList::accept( NodeVisitor& visitor )
+{
+  return visitor.visit_function_parameter_list( *this );
+}
+
+void FunctionParameterList::describe_to( fmt::Writer& w ) const
+{
+  w << "function-parameter-list";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionParameterList.h
+++ b/pol-core/bscript/compiler/ast/FunctionParameterList.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_FUNCTIONPARAMETERLIST_H
+#define POLSERVER_FUNCTIONPARAMETERLIST_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class FunctionParameterDeclaration;
+
+class FunctionParameterList : public Node
+{
+public:
+  FunctionParameterList( const SourceLocation&,
+                 std::vector<std::unique_ptr<FunctionParameterDeclaration>> parameters );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_FUNCTIONPARAMETERLIST_H

--- a/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp
@@ -1,0 +1,30 @@
+#include "ModuleFunctionDeclaration.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ModuleFunctionDeclaration::ModuleFunctionDeclaration(
+    const SourceLocation& source_location, std::string module_name, std::string name,
+    std::unique_ptr<FunctionParameterList> parameter_list )
+    : Function( source_location, std::move( name ), std::move( parameter_list ) ),
+      module_name( std::move( module_name ) )
+{
+}
+
+void ModuleFunctionDeclaration::accept( NodeVisitor& visitor )
+{
+  visitor.visit_module_function_declaration( *this );
+}
+
+void ModuleFunctionDeclaration::describe_to( fmt::Writer& w ) const
+{
+  w << "module-function-declaration(" << module_name << "::" << name << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.h
@@ -1,0 +1,27 @@
+#ifndef POLSERVER_MODULEFUNCTIONDECLARATION_H
+#define POLSERVER_MODULEFUNCTIONDECLARATION_H
+
+#include "compiler/ast/Function.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class FunctionParameterDeclaration;
+class FunctionParameterList;
+
+class ModuleFunctionDeclaration : public Function
+{
+public:
+  ModuleFunctionDeclaration( const SourceLocation& source_location, std::string module_name,
+                             std::string name,
+                             std::unique_ptr<FunctionParameterList> parameter_list );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string module_name;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_MODULEFUNCTIONDECLARATION_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,6 +1,9 @@
 #include "NodeVisitor.h"
 
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Node.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
@@ -10,6 +13,21 @@ namespace Pol::Bscript::Compiler
 {
 
 void NodeVisitor::visit_float_value( FloatValue& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_function_parameter_declaration( FunctionParameterDeclaration& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_function_parameter_list( FunctionParameterList& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_module_function_declaration( ModuleFunctionDeclaration& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -4,6 +4,9 @@
 namespace Pol::Bscript::Compiler
 {
 class FloatValue;
+class FunctionParameterDeclaration;
+class FunctionParameterList;
+class ModuleFunctionDeclaration;
 class Node;
 class StringValue;
 class TopLevelStatements;
@@ -15,6 +18,9 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_float_value( FloatValue& );
+  virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
+  virtual void visit_function_parameter_list( FunctionParameterList& );
+  virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_value_consumer( ValueConsumer& );

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
@@ -14,7 +14,8 @@ BuilderWorkspace::BuilderWorkspace( CompilerWorkspace& compiler_workspace,
     em_cache( em_cache ),
     inc_cache( inc_cache ),
     profile( profile ),
-    report( report )
+    report( report ),
+    function_resolver( report )
 {
 }
 

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <string>
 
+#include "compiler/astbuilder/FunctionResolver.h"
+
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
@@ -31,6 +33,7 @@ public:
   Report& report;
 
   std::map<std::string, std::shared_ptr<SourceFile>> source_files;
+  FunctionResolver function_resolver;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -53,6 +53,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   compiler_workspace->top_level_statements =
       std::make_unique<TopLevelStatements>( source_location );
 
+  src_processor.use_module( "basicio", source_location );
   src_processor.process_source( *sf );
 
   return compiler_workspace;

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -1,0 +1,28 @@
+#include "FunctionResolver.h"
+
+#include "compiler/Report.h"
+#include "compiler/ast/Function.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionResolver::FunctionResolver( Report& report ) : report( report ) {}
+
+const Function* FunctionResolver::find( const std::string& scoped_name )
+{
+  auto itr = resolved_functions_by_name.find( scoped_name );
+  if ( itr != resolved_functions_by_name.end() )
+    return ( *itr ).second;
+  else
+    return nullptr;
+}
+
+void FunctionResolver::register_module_function( ModuleFunctionDeclaration* mf )
+{
+  resolved_functions_by_name[mf->name] = mf;
+  auto scoped_name = mf->module_name + "::" + mf->name;
+  resolved_functions_by_name[scoped_name] = mf;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -1,0 +1,47 @@
+#ifndef POLSERVER_FUNCTIONRESOLVER_H
+#define POLSERVER_FUNCTIONRESOLVER_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <EscriptGrammar/EscriptParser.h>
+
+#include "clib/maputil.h"
+
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Function;
+class ModuleFunctionDeclaration;
+class Report;
+
+class FunctionResolver
+{
+public:
+  explicit FunctionResolver( Report& );
+
+  const Function* find( const std::string& scoped_name );
+
+  void register_module_function( ModuleFunctionDeclaration* );
+
+private:
+
+  Report& report;
+
+  //// what about this? (ci_map in Clib)
+  // template<typename T>
+  // using ci_map = std::map<std::string, T, Clib::ci_cmp_pred>;
+  //
+  // using AmbiguousUserFunctionMap =
+  //    ci_map<EscriptGrammar::EscriptParser::FunctionDeclarationContext*>;
+
+  using FunctionMap = std::map<std::string, Function*, Clib::ci_cmp_pred>;
+
+  FunctionMap resolved_functions_by_name;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FUNCTIONRESOLVER_H

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -30,13 +30,6 @@ private:
 
   Report& report;
 
-  //// what about this? (ci_map in Clib)
-  // template<typename T>
-  // using ci_map = std::map<std::string, T, Clib::ci_cmp_pred>;
-  //
-  // using AmbiguousUserFunctionMap =
-  //    ci_map<EscriptGrammar::EscriptParser::FunctionDeclarationContext*>;
-
   using FunctionMap = std::map<std::string, Function*, Clib::ci_cmp_pred>;
 
   FunctionMap resolved_functions_by_name;

--- a/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.cpp
@@ -1,11 +1,56 @@
 #include "ModuleDeclarationBuilder.h"
 
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+
+using EscriptGrammar::EscriptParser;
+
 namespace Pol::Bscript::Compiler
 {
 ModuleDeclarationBuilder::ModuleDeclarationBuilder(
     const SourceFileIdentifier& source_file_identifier, BuilderWorkspace& workspace )
   : SimpleStatementBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<ModuleFunctionDeclaration> ModuleDeclarationBuilder::module_function_declaration(
+    EscriptParser::ModuleFunctionDeclarationContext* ctx, std::string module_name )
+{
+  std::string name = text( ctx->IDENTIFIER() );
+  std::vector<std::unique_ptr<FunctionParameterDeclaration>> parameters;
+
+  if ( auto param_list = ctx->moduleFunctionParameterList() )
+  {
+    for ( auto param : param_list->moduleFunctionParameter() )
+    {
+      std::string parameter_name = text( param->IDENTIFIER() );
+      std::unique_ptr<FunctionParameterDeclaration> parameter_declaration;
+      bool byref = false;
+      bool unused = false;
+
+      if ( auto expr_ctx = param->expression() )
+      {
+        auto default_value = expression( expr_ctx );
+        parameter_declaration = std::make_unique<FunctionParameterDeclaration>(
+            location_for( *param ), std::move( parameter_name ), byref, unused,
+            std::move( default_value ) );
+      }
+      else
+      {
+        parameter_declaration = std::make_unique<FunctionParameterDeclaration>(
+            location_for( *param ), std::move( parameter_name ), byref, unused );
+      }
+      parameters.push_back( std::move( parameter_declaration ) );
+    }
+  }
+
+  auto source_location = location_for( *ctx );
+  auto parameter_list =
+      std::make_unique<FunctionParameterList>( source_location, std::move( parameters ) );
+  return std::make_unique<ModuleFunctionDeclaration>(
+      source_location, std::move( module_name ), std::move( name ), std::move( parameter_list ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ModuleDeclarationBuilder.h
@@ -5,12 +5,15 @@
 
 namespace Pol::Bscript::Compiler
 {
+class ModuleFunctionDeclaration;
 
 class ModuleDeclarationBuilder : public SimpleStatementBuilder
 {
 public:
   ModuleDeclarationBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  std::unique_ptr<ModuleFunctionDeclaration> module_function_declaration(
+      EscriptGrammar::EscriptParser::ModuleFunctionDeclarationContext*, std::string module_name );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
@@ -1,0 +1,37 @@
+#include "ModuleProcessor.h"
+
+#include "compiler/Profile.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/file/SourceFile.h"
+#include "compiler/model/CompilerWorkspace.h"
+
+namespace Pol::Bscript::Compiler
+{
+ModuleProcessor::ModuleProcessor( const SourceFileIdentifier& source_file_identifier,
+                                  BuilderWorkspace& workspace, std::string modulename )
+  : profile( workspace.profile ),
+    report( workspace.report ),
+    source_file_identifier( source_file_identifier ),
+    workspace( workspace ),
+    tree_builder( source_file_identifier, workspace ),
+    modulename( std::move( modulename ) )
+{
+}
+
+antlrcpp::Any ModuleProcessor::visitModuleDeclarationStatement(
+    EscriptGrammar::EscriptParser::ModuleDeclarationStatementContext* ctx )
+{
+  if ( auto moduleFunctionDeclaration = ctx->moduleFunctionDeclaration() )
+  {
+    auto ast =
+        tree_builder.module_function_declaration( moduleFunctionDeclaration, modulename );
+
+    workspace.function_resolver.register_module_function( ast.get() );
+
+    workspace.compiler_workspace.module_function_declarations.push_back( std::move( ast ) );
+  }
+  return antlrcpp::Any();
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.h
@@ -1,0 +1,38 @@
+#ifndef POLSERVER_MODULEPROCESSOR_H
+#define POLSERVER_MODULEPROCESSOR_H
+
+#include <EscriptGrammar/EscriptParserBaseVisitor.h>
+
+#include <memory>
+#include <string>
+
+#include "ModuleDeclarationBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Profile;
+class Report;
+class SourceFile;
+class SourceFileIdentifier;
+class BuilderWorkspace;
+
+class ModuleProcessor : public EscriptGrammar::EscriptParserBaseVisitor
+{
+public:
+  ModuleProcessor( const SourceFileIdentifier&, BuilderWorkspace&, std::string modulename );
+
+  antlrcpp::Any visitModuleDeclarationStatement(
+      EscriptGrammar::EscriptParser::ModuleDeclarationStatementContext* ) override;
+
+private:
+  Profile& profile;
+  Report& report;
+  const SourceFileIdentifier& source_file_identifier;
+  BuilderWorkspace& workspace;
+
+  ModuleDeclarationBuilder tree_builder;
+  const std::string modulename;
+};
+
+}  // namespace Pol::Bscript::Compiler
+#endif  // POLSERVER_MODULEPROCESSOR_HModP

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -2,15 +2,17 @@
 
 #include "clib/fileutil.h"
 #include "clib/timer.h"
-#include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
 #include "compiler/ast/Statement.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/astbuilder/ModuleProcessor.h"
 #include "compiler/file/SourceFile.h"
 #include "compiler/file/SourceFileCache.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/CompilerWorkspace.h"
+#include "compilercfg.h"
 
 using EscriptGrammar::EscriptParser;
 
@@ -25,6 +27,50 @@ SourceFileProcessor::SourceFileProcessor( const SourceFileIdentifier& source_fil
     tree_builder( source_file_identifier, workspace ),
     is_src( is_src )
 {
+}
+
+void SourceFileProcessor::use_module( const std::string& module_name,
+                                      SourceLocation& including_location,
+                                      long long* micros_counted )
+{
+  std::string pathname = compilercfg.ModuleDirectory + module_name + ".em";
+
+  if ( workspace.source_files.find( pathname ) != workspace.source_files.end() )
+    return;
+
+
+
+  auto ident = std::make_unique<SourceFileIdentifier>(
+      workspace.compiler_workspace.referenced_source_file_identifiers.size(), pathname );
+
+  Pol::Tools::HighPerfTimer load_timer;
+  auto sf = workspace.em_cache.load( *ident, report );
+  long long load_elapsed = load_timer.ellapsed().count();
+  profile.load_em_micros += load_elapsed;
+  if ( !sf )
+  {
+    // This is fatal because if we keep going, we'll likely report a bunch of errors
+    // that would just be noise, like missing module function declarations or constants.
+    report.fatal( including_location, "Unable to use module '", module_name, "'.\n" );
+  }
+  workspace.source_files[ pathname ] = sf;
+
+  ModuleProcessor module_processor( *ident, workspace, module_name );
+  workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
+
+  Pol::Tools::HighPerfTimer get_module_unit_timer;
+  auto module_unit_context = sf->get_module_unit( report, source_file_identifier );
+  long long parse_elapsed = get_module_unit_timer.ellapsed().count();
+  profile.parse_em_micros += parse_elapsed;
+  profile.parse_em_count++;
+
+  Pol::Tools::HighPerfTimer visit_module_unit_timer;
+  module_unit_context->accept( &module_processor );
+  long long ast_elapsed = visit_module_unit_timer.ellapsed().count();
+  profile.ast_em_micros.fetch_add( ast_elapsed );
+
+  if ( micros_counted )
+    *micros_counted = load_elapsed + parse_elapsed + ast_elapsed;
 }
 
 void SourceFileProcessor::process_source( SourceFile& sf )

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -20,6 +20,8 @@ public:
   SourceFileProcessor( const SourceFileIdentifier&, BuilderWorkspace&, bool is_src );
 
 public:
+  void use_module( const std::string& name, SourceLocation& including_location,
+                   long long* micros_counted = nullptr );
   void process_source( SourceFile& );
 
   antlrcpp::Any visitStatement( EscriptGrammar::EscriptParser::StatementContext* ) override;

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -1,5 +1,6 @@
 #include "CompilerWorkspace.h"
 
+#include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/file/SourceFileIdentifier.h"
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -8,7 +8,6 @@
 namespace Pol::Bscript::Compiler
 {
 class Block;
-//class ConstDeclaration;
 class ModuleFunctionDeclaration;
 class SourceFile;
 class SourceFileIdentifier;
@@ -22,12 +21,6 @@ public:
 
   std::unique_ptr<TopLevelStatements> top_level_statements;
   std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;
-//  std::vector<std::unique_ptr<UserFunction>> user_functions;
-//  std::unique_ptr<Program> program;
-
-//  // These reference ModuleFunctionDeclaration objects that are in module_functions
-//  std::vector<ModuleFunctionDeclaration*> referenced_module_function_declarations;
-//  std::vector<const ModuleFunctionDeclaration*> module_functions_in_legacy_order;
 
   std::vector<std::unique_ptr<SourceFileIdentifier>> referenced_source_file_identifiers;
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -7,6 +7,9 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Block;
+//class ConstDeclaration;
+class ModuleFunctionDeclaration;
 class SourceFile;
 class SourceFileIdentifier;
 class TopLevelStatements;
@@ -18,6 +21,13 @@ public:
   ~CompilerWorkspace();
 
   std::unique_ptr<TopLevelStatements> top_level_statements;
+  std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;
+//  std::vector<std::unique_ptr<UserFunction>> user_functions;
+//  std::unique_ptr<Program> program;
+
+//  // These reference ModuleFunctionDeclaration objects that are in module_functions
+//  std::vector<ModuleFunctionDeclaration*> referenced_module_function_declarations;
+//  std::vector<const ModuleFunctionDeclaration*> module_functions_in_legacy_order;
 
   std::vector<std::unique_ptr<SourceFileIdentifier>> referenced_source_file_identifiers;
 

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -956,6 +956,10 @@ bool run( int argc, char** argv, int* res )
 
     tmp << "    build workspace: " << (long long)summary.profile.build_workspace_micros / 1000
         << "\n";
+    tmp << "        - load *.em:   " << (long long)summary.profile.load_em_micros / 1000 << "\n";
+    tmp << "       - parse *.em:   " << (long long)summary.profile.parse_em_micros / 1000 << " ("
+        << (long)summary.profile.parse_em_count << ")\n";
+    tmp << "         - ast *.em:   " << (long long)summary.profile.ast_em_micros / 1000 << "\n";
     tmp << "      - parse *.src:   " << (long long)summary.profile.parse_src_micros / 1000 << " ("
         << (long)summary.profile.parse_src_count << ")\n";
     tmp << "        - ast *.src:   " << (long long)summary.profile.ast_src_micros / 1000 << "\n";


### PR DESCRIPTION
It turns out there are a lot of pieces involved in reading a module function declaration and calling a function.  This PR adds enough to build the AST for the module function declarations in a .em file.

Adds:
- [Function](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/Function.cpp): base class for [module function declarations](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp) and [user functions](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp)
- [FunctionParameterDeclaration](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionParameterDeclaration.cpp): declaration for a function parameter, as well as its default value  if any 
- [FunctionParameterList](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionParameterList.cpp): just a holder for function parameter declarations
- [ModuleFunctionDeclaration](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp): for function declarations in .em files
- [FunctionResolver](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp): hooks up function calls to module functions or user functions
- [ModuleProcessor](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp): a visitor for processing `const` declarations and module function declarations (const declarations  are yet to come from the main branch)