### PR TITLE
New compiler: Add AST nodes for function calls.  Can compile hello world.

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -110,6 +110,8 @@ set (bscript_sources    # sorted !
   compiler/model/FunctionLink.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
+  compiler/optimizer/ReferencedFunctionGatherer.cpp
+  compiler/optimizer/ReferencedFunctionGatherer.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
   compiler/representation/ExportedFunction.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -18,12 +18,16 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Disambiguator.h
   compiler/analyzer/SemanticAnalyzer.cpp
   compiler/analyzer/SemanticAnalyzer.h
+  compiler/ast/Argument.cpp
+  compiler/ast/Argument.h
   compiler/ast/Expression.cpp
   compiler/ast/Expression.h
   compiler/ast/FloatValue.cpp
   compiler/ast/FloatValue.h
   compiler/ast/Function.cpp
   compiler/ast/Function.h
+  compiler/ast/FunctionCall.cpp
+  compiler/ast/FunctionCall.h
   compiler/ast/FunctionParameterDeclaration.cpp
   compiler/ast/FunctionParameterDeclaration.h
   compiler/ast/FunctionParameterList.cpp
@@ -80,6 +84,8 @@ set (bscript_sources    # sorted !
   compiler/codegen/InstructionEmitter.h
   compiler/codegen/InstructionGenerator.cpp
   compiler/codegen/InstructionGenerator.h
+  compiler/codegen/ModuleDeclarationRegistrar.cpp
+  compiler/codegen/ModuleDeclarationRegistrar.h
   compiler/file/ConformingCharStream.cpp
   compiler/file/ConformingCharStream.h
   compiler/file/ErrorListener.cpp
@@ -100,6 +106,8 @@ set (bscript_sources    # sorted !
   compiler/format/StoredTokenDecoder.h
   compiler/model/CompilerWorkspace.cpp
   compiler/model/CompilerWorkspace.h
+  compiler/model/FunctionLink.cpp
+  compiler/model/FunctionLink.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
   compiler/representation/CompiledScript.cpp

--- a/pol-core/bscript/compiler/ast/Argument.cpp
+++ b/pol-core/bscript/compiler/ast/Argument.cpp
@@ -1,0 +1,31 @@
+#include "Argument.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+Argument::Argument( const SourceLocation& source_location, std::string identifier,
+                    std::unique_ptr<Expression> expression )
+    : Node( source_location, std::move( expression ) ), identifier( std::move( identifier ) )
+{
+}
+
+void Argument::accept( NodeVisitor& visitor )
+{
+  visitor.visit_argument( *this );
+}
+
+void Argument::describe_to( fmt::Writer& w ) const
+{
+  w << "argument(" << identifier << ")";
+}
+
+std::unique_ptr<Expression> Argument::take_expression()
+{
+  return take_child<Expression>( 0 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Argument.h
+++ b/pol-core/bscript/compiler/ast/Argument.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_ARGUMENT_H
+#define POLSERVER_ARGUMENT_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class Expression;
+
+class Argument : public Node
+{
+public:
+  Argument( const SourceLocation&, std::string identifier, std::unique_ptr<Expression> );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string identifier;  // can be empty if not specified
+
+  std::unique_ptr<Expression> take_expression();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_ARGUMENT_H

--- a/pol-core/bscript/compiler/ast/FunctionCall.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionCall.cpp
@@ -1,0 +1,54 @@
+#include "FunctionCall.h"
+
+#include <format/format.h>
+#include <map>
+#include <utility>
+
+#include "compiler/ast/Argument.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/NodeVisitor.h"
+#include "compiler/file/SourceLocation.h"
+#include "compiler/model/FunctionLink.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionCall::FunctionCall( const SourceLocation& source_location, std::string scope,
+                            std::string name, std::vector<std::unique_ptr<Argument>> children )
+    : Expression( source_location, std::move( children ) ),
+      function_link( std::make_shared<FunctionLink>( source_location ) ),
+      scope( std::move( scope ) ),
+      method_name( std::move( name ) )
+{
+}
+
+void FunctionCall::accept( NodeVisitor& visitor )
+{
+  visitor.visit_function_call( *this );
+}
+
+void FunctionCall::describe_to( fmt::Writer& w ) const
+{
+  w << "function-call(" << method_name << ")";
+}
+
+std::vector<std::unique_ptr<Argument>> FunctionCall::take_arguments()
+{
+  std::vector<std::unique_ptr<Argument>> args;
+  args.reserve( children.size() );
+  for ( auto& child : children )
+  {
+    args.emplace_back( static_unique_pointer_cast<Argument, Node>( std::move( child ) ) );
+  }
+  return args;
+}
+
+std::vector<std::reference_wrapper<FunctionParameterDeclaration>> FunctionCall::parameters() const
+{
+  if ( auto fn = function_link->function() )
+    return fn->parameters();
+  else
+    internal_error( "function has not been resolved" );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionCall.h
+++ b/pol-core/bscript/compiler/ast/FunctionCall.h
@@ -1,0 +1,36 @@
+#ifndef POLSERVER_FUNCTIONCALL_H
+#define POLSERVER_FUNCTIONCALL_H
+
+#include "compiler/ast/Expression.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Argument;
+class FunctionLink;
+class ModuleFunctionDeclaration;
+class FunctionParameterDeclaration;
+class UserFunction;
+
+class FunctionCall : public Expression
+{
+public:
+  FunctionCall( const SourceLocation&, std::string scope, std::string name,
+                std::vector<std::unique_ptr<Argument>> arguments );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  std::vector<std::unique_ptr<Argument>> take_arguments();
+  [[nodiscard]] std::vector<std::reference_wrapper<FunctionParameterDeclaration>> parameters()
+      const;
+
+  const std::shared_ptr<FunctionLink> function_link;
+
+  const std::string scope;
+  const std::string method_name;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_FUNCTIONCALL_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,6 +1,8 @@
 #include "NodeVisitor.h"
 
+#include "compiler/ast/Argument.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
@@ -11,8 +13,17 @@
 
 namespace Pol::Bscript::Compiler
 {
+void NodeVisitor::visit_argument( Argument& node )
+{
+  visit_children( node );
+}
 
 void NodeVisitor::visit_float_value( FloatValue& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_function_call( FunctionCall& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -3,7 +3,9 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Argument;
 class FloatValue;
+class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
 class ModuleFunctionDeclaration;
@@ -17,7 +19,9 @@ class NodeVisitor
 public:
   virtual ~NodeVisitor() = default;
 
+  virtual void visit_argument( Argument& );
   virtual void visit_float_value( FloatValue& );
+  virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -1,6 +1,12 @@
 #include "ExpressionBuilder.h"
 
 #include "compiler/Report.h"
+
+#include "compiler/ast/BuilderWorkspace.h"
+#include "compiler/ast/Argument.h"
+#include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/Value.h"
 
 using EscriptGrammar::EscriptParser;
@@ -21,12 +27,70 @@ std::unique_ptr<Expression> ExpressionBuilder::expression( EscriptParser::Expres
   location_for( *ctx ).internal_error( "unhandled expression" );
 }
 
+std::unique_ptr<FunctionCall> ExpressionBuilder::function_call(
+    EscriptParser::FunctionCallContext* ctx, const std::string& scope )
+{
+  auto method_name = text( ctx->IDENTIFIER() );
+
+  auto arguments = value_arguments( ctx->expressionList() );
+
+  auto function_call = std::make_unique<FunctionCall>( location_for( *ctx ), scope, method_name,
+                                                       std::move( arguments ) );
+
+  std::string key = scope.empty() ? method_name : ( scope + "::" + method_name );
+  workspace.function_resolver.register_function_link( key, function_call->function_link );
+
+  return function_call;
+}
+
 std::unique_ptr<Expression> ExpressionBuilder::primary( EscriptParser::PrimaryContext* ctx )
 {
   if ( auto literal = ctx->literal() )
+  {
     return value( literal );
+  }
+  else if ( auto par_expression = ctx->parExpression() )
+  {
+    return expression( par_expression->expression() );
+  }
+  else if ( auto f_call = ctx->functionCall() )
+  {
+    return function_call( f_call, "" );
+  }
+  else if ( auto scoped_f_call = ctx->scopedFunctionCall() )
+  {
+    return scoped_function_call( scoped_f_call );
+  }
 
   location_for( *ctx ).internal_error( "unhandled primary expression" );
+}
+
+std::unique_ptr<FunctionCall> ExpressionBuilder::scoped_function_call(
+    EscriptParser::ScopedFunctionCallContext* ctx )
+{
+  return function_call( ctx->functionCall(), text( ctx->IDENTIFIER() ) );
+}
+
+std::vector<std::unique_ptr<Argument>> ExpressionBuilder::value_arguments(
+    EscriptGrammar::EscriptParser::ExpressionListContext* ctx )
+{
+  std::vector<std::unique_ptr<Argument>> arguments;
+
+  if ( ctx )
+  {
+    for ( auto argument_context : ctx->expression() )
+    {
+      auto loc = location_for( *argument_context );
+
+      std::string name;
+      auto value = expression( argument_context );
+
+      auto argument = std::make_unique<Argument>( loc, std::move( name ), std::move( value ) );
+      arguments.push_back( std::move( argument ) );
+    }
+  }
+
+  return arguments;
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -2,12 +2,12 @@
 
 #include "compiler/Report.h"
 
-#include "compiler/ast/BuilderWorkspace.h"
 #include "compiler/ast/Argument.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/Value.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
 
 using EscriptGrammar::EscriptParser;
 

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -5,7 +5,9 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Argument;
 class Expression;
+class FunctionCall;
 
 class ExpressionBuilder : public ValueBuilder
 {
@@ -14,8 +16,16 @@ public:
 
   std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
 
+  std::unique_ptr<FunctionCall> function_call( EscriptGrammar::EscriptParser::FunctionCallContext*,
+                                               const std::string& scope );
+
   std::unique_ptr<Expression> primary( EscriptGrammar::EscriptParser::PrimaryContext* );
 
+  std::unique_ptr<FunctionCall> scoped_function_call(
+      EscriptGrammar::EscriptParser::ScopedFunctionCallContext* );
+
+  std::vector<std::unique_ptr<Argument>> value_arguments(
+      EscriptGrammar::EscriptParser::ExpressionListContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -4,6 +4,7 @@
 #include "compiler/ast/Function.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/file/SourceLocation.h"
+#include "compiler/model/FunctionLink.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -16,6 +17,20 @@ const Function* FunctionResolver::find( const std::string& scoped_name )
     return ( *itr ).second;
   else
     return nullptr;
+}
+
+void FunctionResolver::register_function_link( const std::string& name,
+                                               std::shared_ptr<FunctionLink> function_link )
+{
+  auto already_resolved_itr = resolved_functions_by_name.find( name );
+  if ( already_resolved_itr != resolved_functions_by_name.end() )
+  {
+    function_link->link_to( ( *already_resolved_itr ).second );
+  }
+  else
+  {
+    unresolved_function_links_by_name[name].push_back( std::move( function_link ) );
+  }
 }
 
 void FunctionResolver::register_module_function( ModuleFunctionDeclaration* mf )

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -14,6 +14,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Function;
+class FunctionLink;
 class ModuleFunctionDeclaration;
 class Report;
 
@@ -24,6 +25,8 @@ public:
 
   const Function* find( const std::string& scoped_name );
 
+  void register_function_link( const std::string& name,
+                               std::shared_ptr<FunctionLink> function_link );
   void register_module_function( ModuleFunctionDeclaration* );
 
 private:
@@ -32,7 +35,11 @@ private:
 
   using FunctionMap = std::map<std::string, Function*, Clib::ci_cmp_pred>;
 
+  using FunctionReferenceMap =
+      std::map<std::string, std::vector<std::shared_ptr<FunctionLink>>, Clib::ci_cmp_pred>;
+
   FunctionMap resolved_functions_by_name;
+  FunctionReferenceMap unresolved_function_links_by_name;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -3,9 +3,12 @@
 #include <memory>
 
 #include "StoredToken.h"
+#include "compiler/LegacyFunctionOrder.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/codegen/InstructionGenerator.h"
+#include "compiler/codegen/ModuleDeclarationRegistrar.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/CompilerWorkspace.h"
 #include "compiler/representation/CompiledScript.h"
@@ -16,7 +19,7 @@
 namespace Pol::Bscript::Compiler
 {
 std::unique_ptr<CompiledScript> CodeGenerator::generate(
-    std::unique_ptr<CompilerWorkspace> workspace, const LegacyFunctionOrder* )
+    std::unique_ptr<CompilerWorkspace> workspace, const LegacyFunctionOrder* legacy_function_order )
 {
   auto program_info = std::unique_ptr<CompiledScript::ProgramInfo>();
 
@@ -24,12 +27,19 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
   DataSection data;
 
   ExportedFunctions exported_functions;
-  std::vector<ModuleDescriptor> module_descriptors;
 
-  InstructionEmitter instruction_emitter( code, data );
-  CodeGenerator generator( instruction_emitter );
+  ModuleDeclarationRegistrar module_declaration_registrar;
+
+  InstructionEmitter instruction_emitter( code, data,
+                                          module_declaration_registrar );
+  CodeGenerator generator( instruction_emitter, module_declaration_registrar );
+
+  generator.register_module_functions( *workspace, legacy_function_order );
 
   generator.generate_instructions( *workspace );
+
+  std::vector<ModuleDescriptor> module_descriptors =
+      module_declaration_registrar.take_module_descriptors();
 
   return std::make_unique<CompiledScript>(
       std::move( code ), std::move( data ), std::move( exported_functions ),
@@ -37,18 +47,84 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
       std::move( program_info ), std::move( workspace->referenced_source_file_identifiers ) );
 }
 
-CodeGenerator::CodeGenerator( InstructionEmitter& emitter )
-  : emitter( emitter ),
+CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
+    ModuleDeclarationRegistrar& module_declaration_registrar )
+  : module_declaration_registrar( module_declaration_registrar ),
+    emitter( emitter ),
     emit( emitter )
 {
 }
 
 void CodeGenerator::generate_instructions( CompilerWorkspace& workspace )
 {
-  InstructionGenerator top_level_instruction_generator( emitter );
-  workspace.top_level_statements->accept( top_level_instruction_generator );
+   InstructionGenerator top_level_instruction_generator( emitter );
+   workspace.top_level_statements->accept( top_level_instruction_generator );
 
   emit.progend();
+}
+
+void CodeGenerator::register_module_functions( CompilerWorkspace& workspace,
+                                               const LegacyFunctionOrder* legacy_function_order )
+{
+  if ( legacy_function_order )
+  {
+    register_module_functions_as_legacy( workspace );
+  }
+  else
+  {
+    register_module_functions_alphabetically( workspace );
+  }
+}
+
+void CodeGenerator::register_module_functions_as_legacy( CompilerWorkspace& workspace )
+{
+  for ( auto& module_function : workspace.module_function_declarations )
+  {
+    // we might assign IDs to more modules that we actually use,
+    // but this will help us compare output with the original compiler.
+    module_declaration_registrar.register_module( *module_function );
+  }
+  for ( const auto& decl : workspace.module_functions_in_legacy_order )
+  {
+    module_declaration_registrar.register_modulefunc( *decl );
+  }
+}
+
+void CodeGenerator::register_module_functions_alphabetically( CompilerWorkspace& workspace )
+{
+  sort_module_functions_by_module_name( workspace );
+  for ( auto& module_function : workspace.referenced_module_function_declarations )
+  {
+    module_declaration_registrar.register_module( *module_function );
+  }
+
+  sort_module_functions_alphabetically( workspace );
+  for ( const auto& decl : workspace.referenced_module_function_declarations )
+  {
+    module_declaration_registrar.register_modulefunc( *decl );
+  }
+}
+
+void CodeGenerator::sort_module_functions_by_module_name( CompilerWorkspace& workspace )
+{
+  auto sortByModuleName = []( ModuleFunctionDeclaration* d1,
+                              ModuleFunctionDeclaration* d2 ) -> bool {
+    return d1->module_name < d2->module_name;
+  };
+
+  std::sort( workspace.referenced_module_function_declarations.begin(),
+             workspace.referenced_module_function_declarations.end(), sortByModuleName );
+}
+
+void CodeGenerator::sort_module_functions_alphabetically( CompilerWorkspace& workspace )
+{
+  auto sortByModuleFunctionName = []( ModuleFunctionDeclaration* d1,
+                                      ModuleFunctionDeclaration* d2 ) -> bool {
+    return d1->name < d2->name;
+  };
+
+  std::sort( workspace.referenced_module_function_declarations.begin(),
+             workspace.referenced_module_function_declarations.end(), sortByModuleFunctionName );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -57,8 +57,8 @@ CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
 
 void CodeGenerator::generate_instructions( CompilerWorkspace& workspace )
 {
-   InstructionGenerator top_level_instruction_generator( emitter );
-   workspace.top_level_statements->accept( top_level_instruction_generator );
+  InstructionGenerator top_level_instruction_generator( emitter );
+  workspace.top_level_statements->accept( top_level_instruction_generator );
 
   emit.progend();
 }

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -6,9 +6,10 @@
 namespace Pol::Bscript::Compiler
 {
 class CompiledScript;
+class CompilerWorkspace;
 class InstructionEmitter;
 struct LegacyFunctionOrder;
-class CompilerWorkspace;
+class ModuleDeclarationRegistrar;
 
 class CodeGenerator
 {
@@ -17,11 +18,20 @@ public:
                                                    const LegacyFunctionOrder* );
 
 private:
-  explicit CodeGenerator( InstructionEmitter& );
+  CodeGenerator( InstructionEmitter& , ModuleDeclarationRegistrar& );
 
   void generate_instructions( CompilerWorkspace& );
 
+  void register_module_functions( CompilerWorkspace&, const LegacyFunctionOrder* );
+  void register_module_functions_as_legacy( CompilerWorkspace& );
+  void register_module_functions_alphabetically( CompilerWorkspace& );
+
+  static void sort_module_functions_by_module_name( CompilerWorkspace& );
+  static void sort_module_functions_alphabetically( CompilerWorkspace& );
+
 private:
+  ModuleDeclarationRegistrar& module_declaration_registrar;
+
   // Verb vs noun - see InstructionGenerator for reasoning
   InstructionEmitter& emitter;
   InstructionEmitter& emit;

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -6,9 +6,11 @@
 
 namespace Pol::Bscript::Compiler
 {
-InstructionEmitter::InstructionEmitter( CodeSection& code, DataSection& data )
+InstructionEmitter::InstructionEmitter( CodeSection& code, DataSection& data,
+                                        ModuleDeclarationRegistrar& module_declaration_registrar )
   : code_emitter( code ),
-    data_emitter( data )
+    data_emitter( data ),
+    module_declaration_registrar( module_declaration_registrar )
 {
   initialize_data();
 }

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -1,7 +1,10 @@
 #include "InstructionEmitter.h"
 
 #include "StoredToken.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/codegen/ModuleDeclarationRegistrar.h"
 #include "compiler/representation/CompiledScript.h"
+#include "escriptv.h"
 #include "modules.h"
 
 namespace Pol::Bscript::Compiler
@@ -19,6 +22,21 @@ void InstructionEmitter::initialize_data()
 {
   std::byte nul{};
   data_emitter.store( &nul, sizeof nul );
+}
+
+void InstructionEmitter::call_modulefunc(
+    const ModuleFunctionDeclaration& module_function_declaration )
+{
+  unsigned module_id, function_index;
+  module_declaration_registrar.lookup_or_register_module_function( module_function_declaration,
+                                                                   module_id, function_index );
+  unsigned sympos = include_debug ? emit_data( module_function_declaration.name ) : 0;
+  StoredToken token(
+      module_id, TOK_FUNC,
+      static_cast<BTokenType>(
+          function_index ),  // function index, stored in Token.lval, saved in StoredToken.type
+      sympos );
+  append_token( token );
 }
 
 void InstructionEmitter::consume()

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -26,6 +26,7 @@ class StoredToken;
 namespace Pol::Bscript::Compiler
 {
 class ModuleDeclarationRegistrar;
+class ModuleFunctionDeclaration;
 
 class InstructionEmitter
 {
@@ -35,6 +36,7 @@ public:
 
   void initialize_data();
 
+  void call_modulefunc( const ModuleFunctionDeclaration& );
   void consume();
   void progend();
   void value( double );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -25,11 +25,13 @@ class StoredToken;
 
 namespace Pol::Bscript::Compiler
 {
+class ModuleDeclarationRegistrar;
 
 class InstructionEmitter
 {
 public:
-  InstructionEmitter( CodeSection& code, DataSection& data );
+  InstructionEmitter( CodeSection& code, DataSection& data,
+                      ModuleDeclarationRegistrar& );
 
   void initialize_data();
 
@@ -45,6 +47,7 @@ private:
 
   CodeEmitter code_emitter;
   DataEmitter data_emitter;
+  ModuleDeclarationRegistrar& module_declaration_registrar;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,10 +1,12 @@
 #include "InstructionGenerator.h"
 
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
+#include "compiler/model/FunctionLink.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -17,6 +19,20 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
 void InstructionGenerator::visit_float_value( FloatValue& node )
 {
   emit.value( node.value );
+}
+
+void InstructionGenerator::visit_function_call( FunctionCall& call )
+{
+  visit_children( call );
+
+  if ( auto mf = call.function_link->module_function_declaration() )
+  {
+    emit.call_modulefunc( *mf );
+  }
+  else
+  {
+    call.internal_error( "neither a module function nor a user function?" );
+  }
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -16,6 +16,7 @@ public:
   explicit InstructionGenerator( InstructionEmitter& );
 
   void visit_float_value( FloatValue& ) override;
+  void visit_function_call( FunctionCall& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
 

--- a/pol-core/bscript/compiler/codegen/ModuleDeclarationRegistrar.cpp
+++ b/pol-core/bscript/compiler/codegen/ModuleDeclarationRegistrar.cpp
@@ -1,0 +1,87 @@
+#include "ModuleDeclarationRegistrar.h"
+
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/representation/ModuleDescriptor.h"
+#include "compiler/representation/ModuleFunctionDescriptor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ModuleDeclarationRegistrar::ModuleDeclarationRegistrar() = default;
+
+void ModuleDeclarationRegistrar::register_modulefunc(
+    const ModuleFunctionDeclaration& module_function_declaration )
+{
+  unsigned module_id, function_index;
+  lookup_or_register_module_function( module_function_declaration, module_id, function_index );
+}
+
+void ModuleDeclarationRegistrar::register_module( const ModuleFunctionDeclaration& node )
+{
+  auto& module_name = node.module_name;
+  auto module_itr = registered_modules.find( module_name );
+  if ( module_itr == registered_modules.end() )
+  {
+    unsigned module_index = registered_modules.size();
+
+    registered_modules[module_name] = std::make_unique<EmittedModule>( module_index );
+    module_names_in_order.push_back( module_name );
+  }
+}
+
+void ModuleDeclarationRegistrar::lookup_or_register_module_function(
+    const ModuleFunctionDeclaration& node, unsigned& module_index, unsigned& function_index )
+{
+  auto& module_name = node.module_name;
+  auto& function_name = node.name;
+  auto argument_count = node.parameter_count();
+
+  auto module_itr = registered_modules.find( module_name );
+  if ( module_itr != registered_modules.end() )
+  {
+    EmittedModule& em = *( ( *module_itr ).second );
+    module_index = em.module_index;
+
+    auto function_itr = em.function_name_to_index.find( function_name );
+    if ( function_itr != em.function_name_to_index.end() )
+    {
+      function_index = ( *function_itr ).second;
+    }
+    else
+    {
+      function_index = em.function_name_to_index.size();
+      em.function_name_to_index[function_name] = function_index;
+      em.function_declarations.emplace_back( function_name, argument_count );
+    }
+  }
+  else
+  {
+    module_index = registered_modules.size();
+    function_index = 0;
+
+    auto mod = std::make_unique<EmittedModule>( module_index );
+    mod->function_name_to_index.emplace( function_name, function_index );
+    mod->function_declarations.emplace_back( function_name, argument_count );
+    registered_modules[module_name] = std::move( mod );
+    module_names_in_order.push_back( module_name );
+  }
+}
+
+std::vector<ModuleDescriptor> ModuleDeclarationRegistrar::take_module_descriptors()
+{
+  std::vector<ModuleDescriptor> module_descriptors;
+  for ( auto& module_name : module_names_in_order )
+  {
+    EmittedModule& emitted_module = *registered_modules[module_name];
+    module_descriptors.emplace_back( module_name,
+                                     std::move( emitted_module.function_declarations ) );
+  }
+  return module_descriptors;
+}
+
+ModuleDeclarationRegistrar::EmittedModule::EmittedModule( unsigned module_index )
+    : module_index( module_index )
+{
+}
+ModuleDeclarationRegistrar::EmittedModule::~EmittedModule() = default;
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/ModuleDeclarationRegistrar.h
+++ b/pol-core/bscript/compiler/codegen/ModuleDeclarationRegistrar.h
@@ -1,0 +1,44 @@
+#ifndef POLSERVER_MODULEDECLARATIONREGISTRAR_H
+#define POLSERVER_MODULEDECLARATIONREGISTRAR_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class ModuleDescriptor;
+class ModuleFunctionDeclaration;
+class ModuleFunctionDescriptor;
+
+class ModuleDeclarationRegistrar
+{
+public:
+  ModuleDeclarationRegistrar();
+
+  void register_module( const ModuleFunctionDeclaration& node );
+  void register_modulefunc( const ModuleFunctionDeclaration& );
+
+  std::vector<ModuleDescriptor> take_module_descriptors();
+
+  void lookup_or_register_module_function( const ModuleFunctionDeclaration& node,
+                                           unsigned& module_index, unsigned& function_index );
+
+private:
+  struct EmittedModule
+  {
+    explicit EmittedModule(unsigned module_index);
+    ~EmittedModule();
+
+    const unsigned module_index;
+    std::map<std::string, unsigned> function_name_to_index;
+    std::vector<ModuleFunctionDescriptor> function_declarations;
+  };
+  std::map<std::string, std::unique_ptr<EmittedModule>> registered_modules;
+  std::vector<std::string> module_names_in_order;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_MODULEDECLARATIONREGISTRAR_H

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -1,6 +1,8 @@
 #include "StoredTokenDecoder.h"
 
 #include "StoredToken.h"
+#include "compiler/representation/ModuleDescriptor.h"
+#include "compiler/representation/ModuleFunctionDescriptor.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -34,6 +36,29 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
   case CTRL_PROGEND:
     w << "progend";
     break;
+
+  case TOK_FUNC:
+  {
+    unsigned module_id = tkn.module;
+    unsigned function_index = tkn.type;
+    w << "call module function (" << module_id << ", " << function_index << "): ";
+    if ( module_id >= module_descriptors.size() )
+    {
+      w << "module index " << module_id << " exceeds module_descriptors size "
+        << module_descriptors.size();
+      break;
+    }
+    auto& module = module_descriptors.at( module_id );
+    if ( function_index >= module.functions.size() )
+    {
+      w << "function index " << function_index << " exceeds module.functions size "
+        << module.functions.size();
+      break;
+    }
+    auto& defn = module.functions.at( function_index );
+    w << defn.name;
+    break;
+  }
 
   default:
     w << "id=0x" << fmt::hex( tkn.id ) << " type=" << tkn.type << " offset=" << tkn.offset

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -22,6 +22,10 @@ public:
   std::unique_ptr<TopLevelStatements> top_level_statements;
   std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;
 
+  // These reference ModuleFunctionDeclaration objects that are in module_functions
+  std::vector<ModuleFunctionDeclaration*> referenced_module_function_declarations;
+  std::vector<const ModuleFunctionDeclaration*> module_functions_in_legacy_order;
+
   std::vector<std::unique_ptr<SourceFileIdentifier>> referenced_source_file_identifiers;
 
   std::vector<std::string> global_variable_names;

--- a/pol-core/bscript/compiler/model/FunctionLink.cpp
+++ b/pol-core/bscript/compiler/model/FunctionLink.cpp
@@ -1,0 +1,30 @@
+#include "FunctionLink.h"
+
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionLink::FunctionLink( const SourceLocation& source_location )
+    : source_location( source_location ), linked_function( nullptr )
+{
+}
+
+Function* FunctionLink::function() const
+{
+  return linked_function;
+}
+
+ModuleFunctionDeclaration* FunctionLink::module_function_declaration() const
+{
+  return dynamic_cast<ModuleFunctionDeclaration*>( linked_function );
+}
+
+void FunctionLink::link_to( Function* f )
+{
+  if ( linked_function )
+    source_location.internal_error( "function already linked" );
+  linked_function = f;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/FunctionLink.h
+++ b/pol-core/bscript/compiler/model/FunctionLink.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_FUNCTIONLINK_H
+#define POLSERVER_FUNCTIONLINK_H
+
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Function;
+class ModuleFunctionDeclaration;
+
+class FunctionLink
+{
+public:
+  explicit FunctionLink( const SourceLocation& );
+  FunctionLink( const FunctionLink& ) = delete;
+  FunctionLink& operator=( const FunctionLink& ) = delete;
+
+  [[nodiscard]] Function* function() const;
+  [[nodiscard]] ModuleFunctionDeclaration* module_function_declaration() const;
+
+  void link_to( Function* );
+
+  const SourceLocation source_location;
+
+private:
+  Function* linked_function;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FUNCTIONLINK_H

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -2,7 +2,9 @@
 
 #include "clib/logfacility.h"
 #include "compiler/Report.h"
+#include "compiler/ast/TopLevelStatements.h"
 #include "compiler/model/CompilerWorkspace.h"
+#include "compiler/optimizer/ReferencedFunctionGatherer.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -11,8 +13,12 @@ Optimizer::Optimizer( Report& report )
 {
 }
 
-void Optimizer::optimize( CompilerWorkspace& )
+void Optimizer::optimize( CompilerWorkspace& workspace )
 {
+  ReferencedFunctionGatherer gatherer( workspace.module_function_declarations );
+  workspace.top_level_statements->accept( gatherer );
+  workspace.referenced_module_function_declarations =
+      gatherer.take_referenced_module_function_declarations();
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.cpp
+++ b/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.cpp
@@ -1,0 +1,46 @@
+#include "ReferencedFunctionGatherer.h"
+
+#include "compiler/ast/FunctionCall.h"
+#include "compiler/model/FunctionLink.h"
+
+namespace Pol::Bscript::Compiler
+{
+ReferencedFunctionGatherer::ReferencedFunctionGatherer(
+    std::vector<std::unique_ptr<ModuleFunctionDeclaration>>& all_module_function_declarations )
+{
+  for ( auto& mfd : all_module_function_declarations )
+  {
+    unreferenced_module_function_declarations.insert( mfd.get() );
+  }
+}
+
+void ReferencedFunctionGatherer::visit_function_call( FunctionCall& fc )
+{
+  visit_children( fc );
+
+  reference( *fc.function_link );
+}
+
+void ReferencedFunctionGatherer::reference( FunctionLink& link )
+{
+  if ( auto mfd = link.module_function_declaration() )
+    reference( mfd );
+}
+
+void ReferencedFunctionGatherer::reference( ModuleFunctionDeclaration* mfd )
+{
+  auto itr = unreferenced_module_function_declarations.find( mfd );
+  if ( itr != unreferenced_module_function_declarations.end() )
+  {
+    referenced_module_function_declarations.push_back( mfd );
+    unreferenced_module_function_declarations.erase( itr );
+  }
+}
+
+std::vector<ModuleFunctionDeclaration*>
+ReferencedFunctionGatherer::take_referenced_module_function_declarations()
+{
+  return std::move( referenced_module_function_declarations );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.h
+++ b/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.h
@@ -1,0 +1,38 @@
+#ifndef POLSERVER_REFERENCEDFUNCTIONGATHERER_H
+#define POLSERVER_REFERENCEDFUNCTIONGATHERER_H
+
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Function;
+class FunctionLink;
+class FunctionReference;
+
+class ReferencedFunctionGatherer : public NodeVisitor
+{
+public:
+  ReferencedFunctionGatherer(
+      std::vector<std::unique_ptr<ModuleFunctionDeclaration>>& all_module_function_declarations );
+
+  void visit_function_call( FunctionCall& ) override;
+
+  void reference( FunctionLink& link );
+  void reference( ModuleFunctionDeclaration* );
+
+  std::vector<ModuleFunctionDeclaration*> take_referenced_module_function_declarations();
+
+private:
+  // We keep the whole list of module functions, because for parity we may need to
+  // include some that were not referenced.  That's why this is a vector of bare pointers.
+  std::set<ModuleFunctionDeclaration*> unreferenced_module_function_declarations;
+  std::vector<ModuleFunctionDeclaration*> referenced_module_function_declarations;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_REFERENCEDFUNCTIONGATHERER_H


### PR DESCRIPTION
Adds:
- [ast/Argument](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/Argument.cpp): AST node for an argument passed to a function.
- [ast/FunctionCall](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionCall.cpp): AST node for a function call.
- [codegen/ModuleDeclarationRegistrar](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/codegen/ModuleDeclarationRegistrar.cpp): The code generator registers module function declarations with this in order to determine module indexes and function indexes for instructions.
- [model/FunctionLink](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/model/FunctionLink.cpp): this is a reference either:
  - from: a [FunctionCall](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionCall.cpp) or a [FunctionReference](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionReference.cpp)
  - to:  a [ModuleFunctionDeclaration](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ModuleFunctionDeclaration.cpp) or a [UserFunction](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/UserFunction.cpp)
- [optimizer/ReferencedFunctionGatherer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.cpp): a visitor that determines which module functions and user functions are referenced, by looking at function calls and function references.

Also:
- CodeGenerator registers module functions
- InstructionGenerator generates code for function calls
- InstructionEmitter generates `TOK_FUNC` instructions
- StoredTokenDecoder decodes `TOK_FUNC` instructions

After all of this, the compiler can compile `print("hello, world");`:
```
$ /home/vagrant/polserver/bin/ecompile -g -l compiler2/compiler2-001-hello-world.src
EScript Compiler v1.15
Copyright (C) 1993-2018 Eric N. Swanson

Compiling: compiler2/compiler2-001-hello-world.src
/vagrant/testsuite/escript/compiler2/compiler2-001-hello-world.src: 0 errors, 0 warnings.
Writing:   compiler2/compiler2-001-hello-world.ecl
code section: offset 64
data section: offset 94
Writing:   compiler2/compiler2-001-hello-world.lst

$ cat compiler2/compiler2-001-hello-world.lst
0: "hello, world" (string) len=12 offset=0x1
1: call module function (0, 0): Print
2: # (consume)
3: progend

$ /home/vagrant/polserver/bin/runecl -q compiler2/compiler2-001-hello-world.ecl
hello, world
```

