### PR TITLE
Compiler rewrite: add global variables

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -48,6 +48,8 @@ set (bscript_sources    # sorted !
   compiler/ast/Value.h
   compiler/ast/ValueConsumer.cpp
   compiler/ast/ValueConsumer.h
+  compiler/ast/VarStatement.cpp
+  compiler/ast/VarStatement.h
   compiler/astbuilder/BuilderWorkspace.cpp
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -18,6 +18,8 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Disambiguator.h
   compiler/analyzer/SemanticAnalyzer.cpp
   compiler/analyzer/SemanticAnalyzer.h
+  compiler/analyzer/Variables.cpp
+  compiler/analyzer/Variables.h
   compiler/ast/Argument.cpp
   compiler/ast/Argument.h
   compiler/ast/Expression.cpp
@@ -110,6 +112,9 @@ set (bscript_sources    # sorted !
   compiler/model/CompilerWorkspace.h
   compiler/model/FunctionLink.cpp
   compiler/model/FunctionLink.h
+  compiler/model/Variable.cpp
+  compiler/model/Variable.h
+  compiler/model/VariableScope.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
   compiler/optimizer/ReferencedFunctionGatherer.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -117,6 +117,7 @@ set (bscript_sources    # sorted !
   compiler/model/Variable.cpp
   compiler/model/Variable.h
   compiler/model/VariableScope.h
+  compiler/model/WarnOn.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
   compiler/optimizer/ReferencedFunctionGatherer.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -34,6 +34,8 @@ set (bscript_sources    # sorted !
   compiler/ast/FunctionParameterDeclaration.h
   compiler/ast/FunctionParameterList.cpp
   compiler/ast/FunctionParameterList.h
+  compiler/ast/Identifier.cpp
+  compiler/ast/Identifier.h
   compiler/ast/ModuleFunctionDeclaration.cpp
   compiler/ast/ModuleFunctionDeclaration.h
   compiler/ast/Node.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -45,7 +45,6 @@ void SemanticAnalyzer::visit_identifier( Identifier& node )
     report.error( node, "Unknown identifier '", node.name, "'.\n" );
     return;
   }
-  visit_children( node );
 }
 
 void SemanticAnalyzer::visit_var_statement( VarStatement& node )

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -1,9 +1,16 @@
 #include "SemanticAnalyzer.h"
 
 #include "compiler/Report.h"
+#include "compiler/ast/Argument.h"
+#include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/VarStatement.h"
 #include "compiler/model/CompilerWorkspace.h"
+#include "compiler/model/FunctionLink.h"
 #include "compiler/model/Variable.h"
 
 namespace Pol::Bscript::Compiler
@@ -23,6 +30,22 @@ void SemanticAnalyzer::register_const_declarations( CompilerWorkspace& /*workspa
 void SemanticAnalyzer::analyze( CompilerWorkspace& workspace )
 {
   workspace.top_level_statements->accept( *this );
+
+  workspace.global_variable_names = globals.get_names();
+}
+
+void SemanticAnalyzer::visit_identifier( Identifier& node )
+{
+  if ( auto global = globals.find( node.name ) )
+  {
+    node.variable = global;
+  }
+  else
+  {
+    report.error( node, "Unknown identifier '", node.name, "'.\n" );
+    return;
+  }
+  visit_children( node );
 }
 
 void SemanticAnalyzer::visit_var_statement( VarStatement& node )

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -2,12 +2,15 @@
 
 #include "compiler/Report.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/ast/VarStatement.h"
 #include "compiler/model/CompilerWorkspace.h"
+#include "compiler/model/Variable.h"
 
 namespace Pol::Bscript::Compiler
 {
 SemanticAnalyzer::SemanticAnalyzer( Report& report )
-  : report( report )
+  : report( report ),
+    globals( Global, report )
 {
 }
 
@@ -20,6 +23,20 @@ void SemanticAnalyzer::register_const_declarations( CompilerWorkspace& /*workspa
 void SemanticAnalyzer::analyze( CompilerWorkspace& workspace )
 {
   workspace.top_level_statements->accept( *this );
+}
+
+void SemanticAnalyzer::visit_var_statement( VarStatement& node )
+{
+  if ( auto existing = globals.find( node.name ) )
+  {
+    report.error( node, "Global variable '", node.name, "' already defined.\n",
+                  "  See also: ", existing->source_location );
+    return;
+  }
+
+  node.variable = globals.create( node.name, 0, false, false, node.source_location );
+
+  visit_children( node );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -17,7 +17,7 @@ namespace Pol::Bscript::Compiler
 {
 SemanticAnalyzer::SemanticAnalyzer( Report& report )
   : report( report ),
-    globals( Global, report )
+    globals( VariableScope::Global, report )
 {
 }
 

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -53,7 +53,7 @@ void SemanticAnalyzer::visit_var_statement( VarStatement& node )
   if ( auto existing = globals.find( node.name ) )
   {
     report.error( node, "Global variable '", node.name, "' already defined.\n",
-                  "  See also: ", existing->source_location );
+                  "  See also: ", existing->source_location, "\n" );
     return;
   }
 

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -56,7 +56,7 @@ void SemanticAnalyzer::visit_var_statement( VarStatement& node )
     return;
   }
 
-  node.variable = globals.create( node.name, 0, false, false, node.source_location );
+  node.variable = globals.create( node.name, 0, WarnOn::Never, node.source_location );
 
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -12,6 +12,7 @@
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
+class Identifier;
 class Report;
 class VarStatement;
 
@@ -25,6 +26,7 @@ public:
   static void register_const_declarations( CompilerWorkspace& );
   void analyze( CompilerWorkspace& );
 
+  void visit_identifier( Identifier& ) override;
   void visit_var_statement( VarStatement& ) override;
 
 private:

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -7,11 +7,13 @@
 #include <memory>
 
 #include "clib/maputil.h"
+#include "compiler/analyzer/Variables.h"
 
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
 class Report;
+class VarStatement;
 
 class SemanticAnalyzer : public NodeVisitor
 {
@@ -23,8 +25,12 @@ public:
   static void register_const_declarations( CompilerWorkspace& );
   void analyze( CompilerWorkspace& );
 
+  void visit_var_statement( VarStatement& ) override;
+
 private:
   Report& report;
+
+  Variables globals;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/Variables.cpp
+++ b/pol-core/bscript/compiler/analyzer/Variables.cpp
@@ -1,0 +1,39 @@
+#include "Variables.h"
+
+#include "compiler/Report.h"
+#include "compiler/file/SourceLocation.h"
+#include "compiler/model/Variable.h"
+
+namespace Pol::Bscript::Compiler
+{
+Variables::Variables( VariableScope scope, Report& report ) : scope( scope ), report( report ) {}
+
+std::shared_ptr<Variable> Variables::create( const std::string& name, unsigned block_depth,
+                                             bool warn_if_used, bool warn_if_unused,
+                                             const SourceLocation& source_location )
+{
+  auto index = names_by_index.size();
+  auto variable = std::make_shared<Variable>( scope, name, block_depth, index, warn_if_used,
+                                              warn_if_unused, source_location );
+  variables_by_name[name] = variable;
+  names_by_index.push_back( name );
+  return variable;
+}
+
+std::shared_ptr<Variable> Variables::find( const std::string& name ) const
+{
+  auto itr = variables_by_name.find( name );
+  return ( itr != variables_by_name.end() ) ? ( *itr ).second : std::shared_ptr<Variable>();
+}
+
+const std::vector<std::string>& Variables::get_names() const
+{
+  return names_by_index;
+}
+
+unsigned Variables::count() const
+{
+  return names_by_index.size();
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/Variables.cpp
+++ b/pol-core/bscript/compiler/analyzer/Variables.cpp
@@ -9,12 +9,11 @@ namespace Pol::Bscript::Compiler
 Variables::Variables( VariableScope scope, Report& report ) : scope( scope ), report( report ) {}
 
 std::shared_ptr<Variable> Variables::create( const std::string& name, unsigned block_depth,
-                                             bool warn_if_used, bool warn_if_unused,
-                                             const SourceLocation& source_location )
+                                             WarnOn warn_on, const SourceLocation& source_location )
 {
   auto index = names_by_index.size();
-  auto variable = std::make_shared<Variable>( scope, name, block_depth, index, warn_if_used,
-                                              warn_if_unused, source_location );
+  auto variable =
+      std::make_shared<Variable>( scope, name, block_depth, index, warn_on, source_location );
   variables_by_name[name] = variable;
   names_by_index.push_back( name );
   return variable;

--- a/pol-core/bscript/compiler/analyzer/Variables.h
+++ b/pol-core/bscript/compiler/analyzer/Variables.h
@@ -1,0 +1,43 @@
+#ifndef POLSERVER_VARIABLES_H
+#define POLSERVER_VARIABLES_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "clib/maputil.h"
+#include "compiler/model/VariableScope.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Report;
+class SourceLocation;
+class Variable;
+
+class Variables
+{
+public:
+  Variables( VariableScope, Report& );
+
+  std::shared_ptr<Variable> create( const std::string& name, unsigned block_depth,
+                                    bool warn_if_used, bool warn_if_unused, const SourceLocation& );
+
+  std::shared_ptr<Variable> find( const std::string& name ) const;
+
+  const std::vector<std::string>& get_names() const;
+  unsigned count() const;
+
+private:
+  const VariableScope scope;
+  Report& report;
+
+  typedef std::map<std::string, std::shared_ptr<Variable>, Clib::ci_cmp_pred> VariableMap;
+
+  VariableMap variables_by_name;
+  std::vector<std::string> names_by_index;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SCRIPTVARIABLES_H

--- a/pol-core/bscript/compiler/analyzer/Variables.h
+++ b/pol-core/bscript/compiler/analyzer/Variables.h
@@ -8,6 +8,7 @@
 
 #include "clib/maputil.h"
 #include "compiler/model/VariableScope.h"
+#include "compiler/model/WarnOn.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -21,7 +22,7 @@ public:
   Variables( VariableScope, Report& );
 
   std::shared_ptr<Variable> create( const std::string& name, unsigned block_depth,
-                                    bool warn_if_used, bool warn_if_unused, const SourceLocation& );
+                                    WarnOn, const SourceLocation& );
 
   std::shared_ptr<Variable> find( const std::string& name ) const;
 

--- a/pol-core/bscript/compiler/ast/Identifier.cpp
+++ b/pol-core/bscript/compiler/ast/Identifier.cpp
@@ -1,0 +1,25 @@
+#include "Identifier.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+Identifier::Identifier( const SourceLocation& source_location, std::string name )
+    : Expression( source_location ), name( std::move( name ) )
+{
+}
+
+void Identifier::accept( NodeVisitor& visitor )
+{
+  visitor.visit_identifier( *this );
+}
+
+void Identifier::describe_to( fmt::Writer& w ) const
+{
+  w << "identifier(" << name;
+  w << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Identifier.h
+++ b/pol-core/bscript/compiler/ast/Identifier.h
@@ -1,0 +1,28 @@
+#ifndef POLSERVER_IDENTIFIER_H
+#define POLSERVER_IDENTIFIER_H
+
+#include "compiler/ast/Expression.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class FunctionLink;
+class Variable;
+
+class Identifier : public Expression
+{
+public:
+  Identifier( const SourceLocation&, std::string name );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string name;
+
+  std::shared_ptr<Variable> variable;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_IDENTIFIER_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -39,6 +39,10 @@ void NodeVisitor::visit_function_parameter_list( FunctionParameterList& node )
   visit_children( node );
 }
 
+void NodeVisitor::visit_identifier( Identifier& )
+{
+}
+
 void NodeVisitor::visit_module_function_declaration( ModuleFunctionDeclaration& node )
 {
   visit_children( node );

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -10,6 +10,7 @@
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/ValueConsumer.h"
+#include "compiler/ast/VarStatement.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -54,6 +55,11 @@ void NodeVisitor::visit_top_level_statements( TopLevelStatements& node )
 }
 
 void NodeVisitor::visit_value_consumer( ValueConsumer& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_var_statement( VarStatement& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -13,6 +13,7 @@ class Node;
 class StringValue;
 class TopLevelStatements;
 class ValueConsumer;
+class VarStatement;
 
 class NodeVisitor
 {
@@ -28,6 +29,7 @@ public:
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_value_consumer( ValueConsumer& );
+  virtual void visit_var_statement( VarStatement& );
 
   virtual void visit_children( Node& parent );
 };

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -8,6 +8,7 @@ class FloatValue;
 class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
+class Identifier;
 class ModuleFunctionDeclaration;
 class Node;
 class StringValue;
@@ -25,6 +26,7 @@ public:
   virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
+  virtual void visit_identifier( Identifier& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );

--- a/pol-core/bscript/compiler/ast/VarStatement.cpp
+++ b/pol-core/bscript/compiler/ast/VarStatement.cpp
@@ -1,0 +1,43 @@
+#include "VarStatement.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+VarStatement::VarStatement( const SourceLocation& source_location, std::string name,
+                            std::unique_ptr<Expression> initializer )
+    : Statement( source_location, std::move( initializer ) ), name( std::move( name ) )
+{
+}
+
+VarStatement::VarStatement( const SourceLocation& source_location, std::string name )
+    : Statement( source_location ), name( std::move( name ) )
+{
+}
+
+VarStatement::VarStatement( const SourceLocation& source_location, std::string name,
+                            bool initialize_as_empty_array )
+    : Statement( source_location ),
+      name( std::move( name ) ),
+      initialize_as_empty_array( initialize_as_empty_array )
+{
+}
+
+void VarStatement::accept( NodeVisitor& visitor )
+{
+  visitor.visit_var_statement( *this );
+}
+
+void VarStatement::describe_to( fmt::Writer& w ) const
+{
+  w << "var-statement(" << name;
+  if ( initialize_as_empty_array )
+    w << ", initialize-as-empty-array";
+  w << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/VarStatement.h
+++ b/pol-core/bscript/compiler/ast/VarStatement.h
@@ -1,0 +1,30 @@
+#ifndef POLSERVER_VARSTATEMENT_H
+#define POLSERVER_VARSTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class Expression;
+class Variable;
+
+class VarStatement : public Statement
+{
+public:
+  VarStatement( const SourceLocation&, std::string name, std::unique_ptr<Expression> initializer );
+  VarStatement( const SourceLocation&, std::string name );
+  VarStatement( const SourceLocation&, std::string name, bool initialize_as_empty_array );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string name;
+  const bool initialize_as_empty_array = false;
+
+  std::shared_ptr<Variable> variable;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_VARSTATEMENT_H

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -19,6 +19,10 @@ void CompoundStatementBuilder::add_statements(
   {
     statements.push_back( consume_statement_result( expression( expr_ctx ) ) );
   }
+  else if ( auto var_statement = ctx->varStatement() )
+  {
+    add_var_statements( var_statement, statements );
+  }
   else
   {
     location_for( *ctx ).internal_error( "unhandled statement" );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -6,7 +6,9 @@
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
-#include "compiler/ast/Value.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/StringValue.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 
 using EscriptGrammar::EscriptParser;
@@ -52,6 +54,10 @@ std::unique_ptr<Expression> ExpressionBuilder::primary( EscriptParser::PrimaryCo
   else if ( auto par_expression = ctx->parExpression() )
   {
     return expression( par_expression->expression() );
+  }
+  else if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    return std::make_unique<Identifier>( location_for( *ctx ), text( identifier ) );
   }
   else if ( auto f_call = ctx->functionCall() )
   {

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -1,10 +1,14 @@
 #include "SimpleStatementBuilder.h"
 
 #include "compiler/Report.h"
-#include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/ast/Expression.h"
-#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
+#include "compiler/ast/VarStatement.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/model/CompilerWorkspace.h"
+
+using EscriptGrammar::EscriptParser;
 
 namespace Pol::Bscript::Compiler
 {
@@ -14,10 +18,53 @@ SimpleStatementBuilder::SimpleStatementBuilder( const SourceFileIdentifier& sour
 {
 }
 
+void SimpleStatementBuilder::add_var_statements(
+    EscriptParser::VarStatementContext* ctx, std::vector<std::unique_ptr<Statement>>& statements )
+{
+  if ( auto variable_declaration_list = ctx->variableDeclarationList() )
+  {
+    for ( auto decl : variable_declaration_list->variableDeclaration() )
+    {
+      auto loc = location_for( *decl );
+      std::string name = text( decl->IDENTIFIER() );
+      std::unique_ptr<VarStatement> var_ast;
+
+      if ( auto initializer_context = decl->variableDeclarationInitializer() )
+      {
+        if ( initializer_context->ARRAY() )
+        {
+          var_ast = std::make_unique<VarStatement>( loc, std::move( name ), true );
+        }
+        else
+        {
+          auto initializer = variable_initializer( initializer_context );
+          var_ast =
+              std::make_unique<VarStatement>( loc, std::move( name ), std::move( initializer ) );
+        }
+      }
+      else
+      {
+        var_ast = std::make_unique<VarStatement>( loc, std::move( name ) );
+      }
+      auto consumed = consume_statement_result( std::move( var_ast ) );
+      statements.push_back( std::move( consumed ) );
+    }
+  }
+}
+
 std::unique_ptr<Statement> SimpleStatementBuilder::consume_statement_result(
     std::unique_ptr<Statement> statement )
 {
   return std::make_unique<ValueConsumer>( statement->source_location, std::move( statement ) );
+}
+
+std::unique_ptr<Expression> SimpleStatementBuilder::variable_initializer(
+    EscriptParser::VariableDeclarationInitializerContext* ctx )
+{
+  if ( auto expr = ctx->expression() )
+    return expression( expr );
+  else
+    return std::unique_ptr<Expression>( new StringValue( location_for( *ctx ), "" ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -12,9 +12,14 @@ class SimpleStatementBuilder : public ExpressionBuilder
 public:
   SimpleStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  void add_var_statements( EscriptGrammar::EscriptParser::VarStatementContext*,
+                           std::vector<std::unique_ptr<Statement>>& );
+
   static std::unique_ptr<Statement> consume_statement_result(
       std::unique_ptr<Statement> statement );
 
+  std::unique_ptr<Expression> variable_initializer(
+      EscriptGrammar::EscriptParser::VariableDeclarationInitializerContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -27,6 +27,11 @@ void InstructionEmitter::initialize_data()
   data_emitter.store( &nul, sizeof nul );
 }
 
+void InstructionEmitter::access_variable( const Variable& v )
+{
+  emit_token( v.scope == Global ? TOK_GLOBALVAR : TOK_LOCALVAR, TYP_OPERAND, v.index );
+}
+
 void InstructionEmitter::array_declare()
 {
   emit_token( INS_DECLARE_ARRAY, TYP_RESERVED );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -3,9 +3,12 @@
 #include "StoredToken.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/codegen/ModuleDeclarationRegistrar.h"
+#include "compiler/model/Variable.h"
 #include "compiler/representation/CompiledScript.h"
 #include "escriptv.h"
 #include "modules.h"
+#include "token.h"
+#include "tokens.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -22,6 +25,27 @@ void InstructionEmitter::initialize_data()
 {
   std::byte nul{};
   data_emitter.store( &nul, sizeof nul );
+}
+
+void InstructionEmitter::array_declare()
+{
+  emit_token( INS_DECLARE_ARRAY, TYP_RESERVED );
+}
+
+void InstructionEmitter::assign()
+{
+  emit_token( TOK_ASSIGN, TYP_OPERATOR );
+}
+
+void InstructionEmitter::call_method_id( MethodID method_id, unsigned argument_count )
+{
+  emit_token( INS_CALL_METHOD_ID, (BTokenType)argument_count, method_id );
+}
+
+void InstructionEmitter::call_method( const std::string& name, unsigned argument_count )
+{
+  unsigned offset = emit_data( name );
+  emit_token( INS_CALL_METHOD, (BTokenType)argument_count, offset );
 }
 
 void InstructionEmitter::call_modulefunc(
@@ -42,6 +66,11 @@ void InstructionEmitter::call_modulefunc(
 void InstructionEmitter::consume()
 {
   emit_token( TOK_CONSUMER, TYP_UNARY_OPERATOR );
+}
+
+void InstructionEmitter::declare_variable( const Variable& v )
+{
+  emit_token( v.scope == Global ? RSV_GLOBAL : RSV_LOCAL, TYP_RESERVED, v.index );
 }
 
 void InstructionEmitter::progend()

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -29,7 +29,8 @@ void InstructionEmitter::initialize_data()
 
 void InstructionEmitter::access_variable( const Variable& v )
 {
-  emit_token( v.scope == Global ? TOK_GLOBALVAR : TOK_LOCALVAR, TYP_OPERAND, v.index );
+  BTokenId token_id = v.scope == VariableScope::Global ? TOK_GLOBALVAR : TOK_LOCALVAR;
+  emit_token( token_id, TYP_OPERAND, v.index );
 }
 
 void InstructionEmitter::array_declare()
@@ -75,7 +76,8 @@ void InstructionEmitter::consume()
 
 void InstructionEmitter::declare_variable( const Variable& v )
 {
-  emit_token( v.scope == Global ? RSV_GLOBAL : RSV_LOCAL, TYP_RESERVED, v.index );
+  BTokenId token_id = v.scope == VariableScope::Global ? RSV_GLOBAL : RSV_LOCAL;
+  emit_token( token_id, TYP_RESERVED, v.index );
 }
 
 void InstructionEmitter::progend()

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -39,6 +39,7 @@ public:
 
   void initialize_data();
 
+  void access_variable( const Variable& );
   void array_declare();
   void assign();
   void call_method( const std::string& name, unsigned argument_count );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -27,6 +27,9 @@ namespace Pol::Bscript::Compiler
 {
 class ModuleDeclarationRegistrar;
 class ModuleFunctionDeclaration;
+class Node;
+class Variable;
+class SourceLocation;
 
 class InstructionEmitter
 {
@@ -36,8 +39,13 @@ public:
 
   void initialize_data();
 
+  void array_declare();
+  void assign();
+  void call_method( const std::string& name, unsigned argument_count );
+  void call_method_id( MethodID method_id, unsigned argument_count );
   void call_modulefunc( const ModuleFunctionDeclaration& );
   void consume();
+  void declare_variable( const Variable& );
   void progend();
   void value( double );
   void value( const std::string& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -4,9 +4,12 @@
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
+#include "compiler/ast/VarStatement.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/FunctionLink.h"
+#include "compiler/model/Variable.h"
+#include "symcont.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -45,6 +48,24 @@ void InstructionGenerator::visit_value_consumer( ValueConsumer& node )
   visit_children( node );
 
   emit.consume();
+}
+
+void InstructionGenerator::visit_var_statement( VarStatement& node )
+{
+  if ( !node.variable )
+    node.internal_error( "variable is not defined" );
+  emit.declare_variable( *node.variable );
+
+  if ( node.initialize_as_empty_array )
+  {
+    emit.array_declare();
+  }
+  else if ( !node.children.empty() )
+  {
+    visit_children( node );
+
+    emit.assign();
+  }
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -2,6 +2,10 @@
 
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
@@ -17,6 +21,18 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
   : emitter( emitter ),
     emit( emitter )
 {
+}
+
+void InstructionGenerator::visit_identifier( Identifier& node )
+{
+  if ( auto var = node.variable )
+  {
+    emit.access_variable( *var );
+  }
+  else
+  {
+    node.internal_error( "variable is not set" );
+  }
 }
 
 void InstructionGenerator::visit_float_value( FloatValue& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -17,6 +17,7 @@ public:
 
   void visit_float_value( FloatValue& ) override;
   void visit_function_call( FunctionCall& ) override;
+  void visit_identifier( Identifier& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
   void visit_var_statement( VarStatement& ) override;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -19,6 +19,7 @@ public:
   void visit_function_call( FunctionCall& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
+  void visit_var_statement( VarStatement& ) override;
 
 private:
   // There are two of these because sometimes when calling a method

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -29,12 +29,20 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     break;
   }
 
+  case TOK_ASSIGN:
+    w << ":=";
+    break;
+
   case TOK_CONSUMER:
     w << "# (consume)";
     break;
 
   case CTRL_PROGEND:
     w << "progend";
+    break;
+
+  case RSV_GLOBAL:
+    w << "declare global #" << tkn.offset;
     break;
 
   case TOK_FUNC:

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -68,6 +68,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     break;
   }
 
+  case TOK_GLOBALVAR:
+    w << "global variable #" << tkn.offset;
+    break;
+
   default:
     w << "id=0x" << fmt::hex( tkn.id ) << " type=" << tkn.type << " offset=" << tkn.offset
       << " module=" << tkn.module;

--- a/pol-core/bscript/compiler/model/Variable.cpp
+++ b/pol-core/bscript/compiler/model/Variable.cpp
@@ -1,0 +1,30 @@
+#include "Variable.h"
+
+#include <utility>
+
+namespace Pol::Bscript::Compiler
+{
+Variable::Variable( VariableScope scope, std::string name, unsigned block_depth, size_t index,
+                    bool warn_if_used, bool warn_if_unused, const SourceLocation& source_location )
+  : scope( scope ),
+    name( std::move( name ) ),
+    block_depth( block_depth ),
+    index( index ),
+    warn_if_used( warn_if_used ),
+    warn_if_unused( warn_if_unused ),
+    source_location( source_location ),
+    used( false )
+{
+}
+
+void Variable::mark_used()
+{
+  used = true;
+}
+
+bool Variable::was_used() const
+{
+  return used;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/Variable.cpp
+++ b/pol-core/bscript/compiler/model/Variable.cpp
@@ -5,13 +5,12 @@
 namespace Pol::Bscript::Compiler
 {
 Variable::Variable( VariableScope scope, std::string name, unsigned block_depth, size_t index,
-                    bool warn_if_used, bool warn_if_unused, const SourceLocation& source_location )
+                    WarnOn warn_on, const SourceLocation& source_location )
   : scope( scope ),
     name( std::move( name ) ),
     block_depth( block_depth ),
     index( index ),
-    warn_if_used( warn_if_used ),
-    warn_if_unused( warn_if_unused ),
+    warn_on( warn_on ),
     source_location( source_location ),
     used( false )
 {

--- a/pol-core/bscript/compiler/model/Variable.h
+++ b/pol-core/bscript/compiler/model/Variable.h
@@ -1,0 +1,34 @@
+#ifndef POLSERVER_VARIABLE_H
+#define POLSERVER_VARIABLE_H
+
+#include <string>
+#include "compiler/model/VariableScope.h"
+
+namespace Pol::Bscript::Compiler
+{
+class SourceLocation;
+
+class Variable
+{
+public:
+  Variable( VariableScope, std::string name, unsigned block_depth, size_t index, bool warn_if_used,
+            bool warn_if_unused, const SourceLocation& source_location );
+
+  void mark_used();
+  bool was_used() const;
+
+  const VariableScope scope;
+  const std::string name;
+  const unsigned block_depth;
+  const size_t index;
+  const bool warn_if_used;
+  const bool warn_if_unused;
+  const SourceLocation& source_location;
+
+private:
+  bool used;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SCRIPTVARIABLE_H

--- a/pol-core/bscript/compiler/model/Variable.h
+++ b/pol-core/bscript/compiler/model/Variable.h
@@ -1,8 +1,9 @@
 #ifndef POLSERVER_VARIABLE_H
 #define POLSERVER_VARIABLE_H
 
-#include <string>
 #include "compiler/model/VariableScope.h"
+#include "compiler/model/WarnOn.h"
+#include <string>
 
 namespace Pol::Bscript::Compiler
 {
@@ -11,18 +12,17 @@ class SourceLocation;
 class Variable
 {
 public:
-  Variable( VariableScope, std::string name, unsigned block_depth, size_t index, bool warn_if_used,
-            bool warn_if_unused, const SourceLocation& source_location );
+  Variable( VariableScope, std::string name, unsigned block_depth, size_t index, WarnOn,
+            const SourceLocation& source_location );
 
   void mark_used();
-  bool was_used() const;
+  [[nodiscard]] bool was_used() const;
 
   const VariableScope scope;
   const std::string name;
   const unsigned block_depth;
   const size_t index;
-  const bool warn_if_used;
-  const bool warn_if_unused;
+  const WarnOn warn_on;
   const SourceLocation& source_location;
 
 private:

--- a/pol-core/bscript/compiler/model/VariableScope.h
+++ b/pol-core/bscript/compiler/model/VariableScope.h
@@ -1,0 +1,14 @@
+#ifndef POLSERVER_VARIABLESCOPE_H
+#define POLSERVER_VARIABLESCOPE_H
+
+namespace Pol::Bscript::Compiler
+{
+enum VariableScope
+{
+  Local,
+  Global
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_VARIABLESCOPE_H

--- a/pol-core/bscript/compiler/model/VariableScope.h
+++ b/pol-core/bscript/compiler/model/VariableScope.h
@@ -3,7 +3,7 @@
 
 namespace Pol::Bscript::Compiler
 {
-enum VariableScope
+enum class VariableScope
 {
   Local,
   Global

--- a/pol-core/bscript/compiler/model/WarnOn.h
+++ b/pol-core/bscript/compiler/model/WarnOn.h
@@ -1,0 +1,15 @@
+#ifndef POLSERVER_WARNON_H
+#define POLSERVER_WARNON_H
+
+namespace Pol::Bscript::Compiler
+{
+enum class WarnOn
+{
+  Never,
+  IfNotUsed,
+  IfUsed
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_WARNON_H


### PR DESCRIPTION
Adds support for `var` statements at the global level.

Adds:
- [analyzer/Variables](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/Variables.cpp): keeps track of the variables in scope (either local or global).
- [ast/Identifier](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/Identifier.cpp): AST node for an identifier.
  - The optimizer will replace constant identifiers with their constant value (in a later PR).
  - The semantic analyzer will set the variable field for local or global variable identifiers.
- [ast/VarStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/VarStatement.cpp): AST node for a `var` statement.
  - A single `var` statement will generate one VarStatement per variable declared.
- [model/Variable](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/model/Variable.h): Describes a variable, including its index within its scope.

```
$ cat a.src
var x := "a";
var y := "c";
print(y);
print(x);

$ /home/vagrant/polserver/bin/ecompile -g -l a.src
EScript Compiler v1.15
Copyright (C) 1993-2018 Eric N. Swanson

Compiling: a.src
/vagrant/testsuite/escript/a.src: 0 errors, 0 warnings.
Writing:   a.ecl
code section: offset 64
data section: offset 149
Writing:   a.lst

$ /home/vagrant/polserver/bin/runecl -q a.ecl
c
a
```