### PR TITLE
New compiler: Add IntegerValue

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -36,6 +36,8 @@ set (bscript_sources    # sorted !
   compiler/ast/FunctionParameterList.h
   compiler/ast/Identifier.cpp
   compiler/ast/Identifier.h
+  compiler/ast/IntegerValue.cpp
+  compiler/ast/IntegerValue.h
   compiler/ast/ModuleFunctionDeclaration.cpp
   compiler/ast/ModuleFunctionDeclaration.h
   compiler/ast/Node.cpp

--- a/pol-core/bscript/compiler/ast/IntegerValue.cpp
+++ b/pol-core/bscript/compiler/ast/IntegerValue.cpp
@@ -1,0 +1,24 @@
+#include "IntegerValue.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+IntegerValue::IntegerValue( const SourceLocation& source_location, int value )
+    : Value( source_location ), value( value )
+{
+}
+
+void IntegerValue::accept( NodeVisitor& visitor )
+{
+  visitor.visit_integer_value( *this );
+}
+
+void IntegerValue::describe_to( fmt::Writer& w ) const
+{
+  w << "integer-value(" << value << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/IntegerValue.h
+++ b/pol-core/bscript/compiler/ast/IntegerValue.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_INTEGERVALUE_H
+#define POLSERVER_INTEGERVALUE_H
+
+#include "compiler/ast/Value.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+
+class IntegerValue : public Value
+{
+public:
+  IntegerValue( const SourceLocation&, int value );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const int value;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_INTEGERVALUE_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -43,6 +43,10 @@ void NodeVisitor::visit_identifier( Identifier& )
 {
 }
 
+void NodeVisitor::visit_integer_value( IntegerValue& )
+{
+}
+
 void NodeVisitor::visit_module_function_declaration( ModuleFunctionDeclaration& node )
 {
   visit_children( node );

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -9,6 +9,7 @@ class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
 class Identifier;
+class IntegerValue;
 class ModuleFunctionDeclaration;
 class Node;
 class StringValue;
@@ -27,6 +28,7 @@ public:
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
   virtual void visit_identifier( Identifier& );
+  virtual void visit_integer_value( IntegerValue& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -148,7 +148,7 @@ int ValueBuilder::to_int( EscriptParser::IntegerLiteralContext* ctx )
   }
   else if ( auto hex_literal = ctx->HEX_LITERAL() )
   {
-    return (int)std::stoul( hex_literal->getSymbol()->getText(), nullptr, 16 );
+    return static_cast<int>( std::stoul( hex_literal->getSymbol()->getText(), nullptr, 16 ) );
   }
   else if ( auto oct_literal = ctx->OCT_LITERAL() )
   {

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
@@ -7,6 +7,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class IntegerValue;
 class FloatValue;
 class StringValue;
 class Value;
@@ -19,11 +20,17 @@ public:
   std::unique_ptr<FloatValue> float_value(
       EscriptGrammar::EscriptParser::FloatLiteralContext* );
 
+  std::unique_ptr<IntegerValue> integer_value(
+      EscriptGrammar::EscriptParser::IntegerLiteralContext* );
+
   std::unique_ptr<StringValue> string_value( antlr4::tree::TerminalNode* string_literal );
 
   std::string unquote( antlr4::tree::TerminalNode* string_literal );
 
   std::unique_ptr<Value> value( EscriptGrammar::EscriptParser::LiteralContext* );
+
+private:
+  int to_int( EscriptGrammar::EscriptParser::IntegerLiteralContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -91,6 +91,12 @@ void InstructionEmitter::value( double v )
   emit_token( TOK_DOUBLE, TYP_OPERAND, offset );
 }
 
+void InstructionEmitter::value( int v )
+{
+  unsigned offset = data_emitter.append( v );
+  emit_token( TOK_LONG, TYP_OPERAND, offset );
+}
+
 void InstructionEmitter::value( const std::string& v )
 {
   unsigned data_offset = emit_data( v );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -49,6 +49,7 @@ public:
   void declare_variable( const Variable& );
   void progend();
   void value( double );
+  void value( int );
   void value( const std::string& );
 
 private:

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -5,6 +5,7 @@
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/Identifier.h"
+#include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
@@ -36,6 +37,11 @@ void InstructionGenerator::visit_identifier( Identifier& node )
 }
 
 void InstructionGenerator::visit_float_value( FloatValue& node )
+{
+  emit.value( node.value );
+}
+
+void InstructionGenerator::visit_integer_value( IntegerValue& node )
 {
   emit.value( node.value );
 }

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -18,6 +18,7 @@ public:
   void visit_float_value( FloatValue& ) override;
   void visit_function_call( FunctionCall& ) override;
   void visit_identifier( Identifier& ) override;
+  void visit_integer_value( IntegerValue& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
   void visit_var_statement( VarStatement& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -16,6 +16,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 {
   switch ( tkn.id )
   {
+  case TOK_LONG:
+    w << integer_at( tkn.offset ) << " (integer)"
+      << " offset=0x" << fmt::hex( tkn.offset );
+    break;
   case TOK_DOUBLE:
     w << double_at( tkn.offset ) << " (float)"
       << " offset=0x" << fmt::hex( tkn.offset );
@@ -85,6 +89,16 @@ double StoredTokenDecoder::double_at( unsigned offset ) const
                               ".  Data size is " + std::to_string( data.size() ) );
 
   return *reinterpret_cast<const double*>( &data[offset] );
+}
+
+int StoredTokenDecoder::integer_at( unsigned offset ) const
+{
+  if ( offset > data.size() - sizeof( int ) )
+    throw std::runtime_error( "data overflow reading integer at offset " +
+                              std::to_string( offset ) + ".  Data size is " +
+                              std::to_string( data.size() ) );
+
+  return *reinterpret_cast<const int*>( &data[offset] );
 }
 
 std::string StoredTokenDecoder::string_at( unsigned offset ) const

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.h
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.h
@@ -24,6 +24,7 @@ public:
 
 private:
   double double_at( unsigned offset ) const;
+  int integer_at( unsigned offset ) const;
   std::string string_at( unsigned offset ) const;
 
   const std::vector<ModuleDescriptor>& module_descriptors;


### PR DESCRIPTION
The last two PRs were pretty large, so here is a smaller one.

This adds support for integer values.

The grammar actually defines negative integer values as `unary operator -` followed by `positive integer literal`.  The next PRs will add the UnaryOperator and enough of the optimizer to convert such sequences to an IntegerValue with a negative value.