### PR TITLE
New compiler: Add optimized unary expressions

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -126,6 +126,8 @@ set (bscript_sources    # sorted !
   compiler/optimizer/Optimizer.h
   compiler/optimizer/ReferencedFunctionGatherer.cpp
   compiler/optimizer/ReferencedFunctionGatherer.h
+  compiler/optimizer/UnaryOperatorOptimizer.cpp
+  compiler/optimizer/UnaryOperatorOptimizer.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
   compiler/representation/ExportedFunction.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -50,6 +50,8 @@ set (bscript_sources    # sorted !
   compiler/ast/StringValue.h
   compiler/ast/TopLevelStatements.cpp
   compiler/ast/TopLevelStatements.h
+  compiler/ast/UnaryOperator.cpp
+  compiler/ast/UnaryOperator.h
   compiler/ast/Value.cpp
   compiler/ast/Value.h
   compiler/ast/ValueConsumer.cpp

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -9,6 +9,7 @@
 #include "compiler/ast/Node.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/ast/UnaryOperator.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
 
@@ -58,6 +59,11 @@ void NodeVisitor::visit_string_value( StringValue& node )
 }
 
 void NodeVisitor::visit_top_level_statements( TopLevelStatements& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_unary_operator( UnaryOperator& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -14,6 +14,7 @@ class ModuleFunctionDeclaration;
 class Node;
 class StringValue;
 class TopLevelStatements;
+class UnaryOperator;
 class ValueConsumer;
 class VarStatement;
 
@@ -32,6 +33,7 @@ public:
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
+  virtual void visit_unary_operator( UnaryOperator& );
   virtual void visit_value_consumer( ValueConsumer& );
   virtual void visit_var_statement( VarStatement& );
 

--- a/pol-core/bscript/compiler/ast/UnaryOperator.cpp
+++ b/pol-core/bscript/compiler/ast/UnaryOperator.cpp
@@ -1,0 +1,38 @@
+#include "UnaryOperator.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+UnaryOperator::UnaryOperator( const SourceLocation& source_location, std::string op,
+                              BTokenId token_id, std::unique_ptr<Expression> operand )
+    : Expression( source_location, std::move( operand ) ),
+      op( std::move( op ) ),
+      token_id( token_id )
+{
+}
+
+void UnaryOperator::accept( NodeVisitor& visitor )
+{
+  visitor.visit_unary_operator( *this );
+}
+
+void UnaryOperator::describe_to( fmt::Writer& w ) const
+{
+  w << "unary-operator(" << op << ")";
+}
+
+Expression& UnaryOperator::operand()
+{
+  return child<Expression>( 0 );
+}
+
+std::unique_ptr<Expression> UnaryOperator::take_operand()
+{
+  return take_child<Expression>( 0 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/UnaryOperator.h
+++ b/pol-core/bscript/compiler/ast/UnaryOperator.h
@@ -1,0 +1,32 @@
+#ifndef POLSERVER_UNARYOPERATOR_H
+#define POLSERVER_UNARYOPERATOR_H
+
+#include "compiler/ast/Expression.h"
+
+#ifndef __TOKENS_H
+#include "tokens.h"
+#endif
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+
+class UnaryOperator : public Expression
+{
+public:
+  UnaryOperator( const SourceLocation& source_location, std::string op, BTokenId token_id,
+                 std::unique_ptr<Expression> operand );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Expression& operand();
+  std::unique_ptr<Expression> take_operand();
+
+  const std::string op;
+  const BTokenId token_id;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_UNARYOPERATOR_H

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -53,6 +53,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   compiler_workspace->top_level_statements =
       std::make_unique<TopLevelStatements>( source_location );
 
+  src_processor.use_module( "basic", source_location );
   src_processor.use_module( "basicio", source_location );
   src_processor.process_source( *sf );
 

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -3,21 +3,36 @@
 
 #include "compiler/astbuilder/ValueBuilder.h"
 
+#ifndef __TOKENS_H
+#include "tokens.h"
+#endif
+
 namespace Pol::Bscript::Compiler
 {
 class Argument;
 class Expression;
 class FunctionCall;
+class GetMember;
+class MethodCall;
+class UnaryOperator;
 
 class ExpressionBuilder : public ValueBuilder
 {
 public:
   ExpressionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  [[noreturn]] static BTokenId unhandled_operator( const SourceLocation& );
+
   std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
 
   std::unique_ptr<FunctionCall> function_call( EscriptGrammar::EscriptParser::FunctionCallContext*,
                                                const std::string& scope );
+
+  std::unique_ptr<Expression> prefix_unary_operator(
+      EscriptGrammar::EscriptParser::ExpressionContext* );
+
+  std::unique_ptr<Expression> postfix_unary_operator(
+      EscriptGrammar::EscriptParser::ExpressionContext* );
 
   std::unique_ptr<Expression> primary( EscriptGrammar::EscriptParser::PrimaryContext* );
 

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -85,6 +85,11 @@ void InstructionEmitter::progend()
   emit_token( CTRL_PROGEND, TYP_CONTROL );
 }
 
+void InstructionEmitter::unary_operator( BTokenId token_id )
+{
+  emit_token( token_id, TYP_UNARY_OPERATOR );
+}
+
 void InstructionEmitter::value( double v )
 {
   unsigned offset = data_emitter.append( v );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -48,6 +48,7 @@ public:
   void consume();
   void declare_variable( const Variable& );
   void progend();
+  void unary_operator( BTokenId );
   void value( double );
   void value( int );
   void value( const std::string& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -8,6 +8,7 @@
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/StringValue.h"
+#include "compiler/ast/UnaryOperator.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
 #include "compiler/codegen/InstructionEmitter.h"
@@ -63,6 +64,12 @@ void InstructionGenerator::visit_function_call( FunctionCall& call )
 void InstructionGenerator::visit_string_value( StringValue& lit )
 {
   emit.value( lit.value );
+}
+
+void InstructionGenerator::visit_unary_operator( UnaryOperator& unary_operator )
+{
+  visit_children( unary_operator );
+  emit.unary_operator( unary_operator.token_id );
 }
 
 void InstructionGenerator::visit_value_consumer( ValueConsumer& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -20,6 +20,7 @@ public:
   void visit_identifier( Identifier& ) override;
   void visit_integer_value( IntegerValue& ) override;
   void visit_string_value( StringValue& ) override;
+  void visit_unary_operator( UnaryOperator& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
   void visit_var_statement( VarStatement& ) override;
 

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -37,6 +37,19 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << ":=";
     break;
 
+  case TOK_UNPLUS:
+    w << "unary +";
+    break;
+  case TOK_UNMINUS:
+    w << "unary -";
+    break;
+  case TOK_LOG_NOT:
+    w << "! (logical inversion)";
+    break;
+  case TOK_BITWISE_NOT:
+    w << "~ (bitwise inversion)";
+    break;
+
   case TOK_CONSUMER:
     w << "# (consume)";
     break;
@@ -47,6 +60,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 
   case RSV_GLOBAL:
     w << "declare global #" << tkn.offset;
+    break;
+
+  case INS_DECLARE_ARRAY:
+    w << "declare array";
     break;
 
   case TOK_FUNC:
@@ -74,6 +91,19 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 
   case TOK_GLOBALVAR:
     w << "global variable #" << tkn.offset;
+    break;
+
+  case TOK_UNPLUSPLUS:
+    w << "prefix unary ++";
+    break;
+  case TOK_UNMINUSMINUS:
+    w << "prefix unary --";
+    break;
+  case TOK_UNPLUSPLUS_POST:
+    w << "postfix unary ++";
+    break;
+  case TOK_UNMINUSMINUS_POST:
+    w << "postfix unary --";
     break;
 
   default:

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -3,8 +3,11 @@
 #include "clib/logfacility.h"
 #include "compiler/Report.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/ast/UnaryOperator.h"
+#include "compiler/ast/ValueConsumer.h"
 #include "compiler/model/CompilerWorkspace.h"
 #include "compiler/optimizer/ReferencedFunctionGatherer.h"
+#include "compiler/optimizer/UnaryOperatorOptimizer.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -19,6 +22,29 @@ void Optimizer::optimize( CompilerWorkspace& workspace )
   workspace.top_level_statements->accept( gatherer );
   workspace.referenced_module_function_declarations =
       gatherer.take_referenced_module_function_declarations();
+}
+
+void Optimizer::visit_children( Node& node )
+{
+  unsigned i = 0;
+  for ( auto& child : node.children )
+  {
+    child->accept( *this );
+
+    if ( optimized_replacement )
+    {
+      node.children[i] = std::move( optimized_replacement );
+    }
+
+    ++i;
+  }
+}
+
+void Optimizer::visit_unary_operator( UnaryOperator& unary_operator )
+{
+  visit_children( unary_operator );
+
+  optimized_replacement = UnaryOperatorOptimizer( unary_operator ).optimize();
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -16,6 +16,11 @@ public:
   explicit Optimizer( Report& );
 
   void optimize( CompilerWorkspace& );
+  void visit_children( Node& ) override;
+
+  void visit_unary_operator( UnaryOperator& ) override;
+
+  std::unique_ptr<Node> optimized_replacement;
 
 private:
   Report& report;

--- a/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.cpp
@@ -1,0 +1,62 @@
+#include "UnaryOperatorOptimizer.h"
+
+#include "compiler/ast/FloatValue.h"
+#include "compiler/ast/IntegerValue.h"
+#include "compiler/ast/UnaryOperator.h"
+
+namespace Pol::Bscript::Compiler
+{
+UnaryOperatorOptimizer::UnaryOperatorOptimizer( UnaryOperator& unary_operator )
+    : unary_operator( unary_operator )
+{
+}
+
+std::unique_ptr<Expression> UnaryOperatorOptimizer::optimize()
+{
+  unary_operator.operand().accept( *this );
+  return std::move( optimized_result );
+}
+
+void UnaryOperatorOptimizer::visit_children( Node& ) {}
+
+void UnaryOperatorOptimizer::visit_float_value( FloatValue& fv )
+{
+  double value;
+
+  switch ( unary_operator.token_id )
+  {
+  case TOK_UNMINUS:
+    value = -fv.value;
+    break;
+
+  default:
+    return;
+  }
+
+  optimized_result = std::make_unique<FloatValue>( fv.source_location, value );
+}
+
+void UnaryOperatorOptimizer::visit_integer_value( IntegerValue& iv )
+{
+  int value;
+
+  switch ( unary_operator.token_id )
+  {
+  case TOK_UNMINUS:
+    value = -iv.value;
+    break;
+  case TOK_LOG_NOT:
+    value = !iv.value;
+    break;
+  case TOK_BITWISE_NOT:
+    value = static_cast<int>( ~static_cast<unsigned>( iv.value ) );
+    break;
+
+  default:
+    return;
+  }
+
+  optimized_result = std::make_unique<IntegerValue>( iv.source_location, value );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.h
@@ -1,0 +1,35 @@
+#ifndef POLSERVER_UNARYOPERATOROPTIMIZER_H
+#define POLSERVER_UNARYOPERATOROPTIMIZER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class Identifier;
+class IntegerValue;
+class FloatValue;
+class UnaryOperator;
+
+class UnaryOperatorOptimizer : public NodeVisitor
+{
+public:
+  explicit UnaryOperatorOptimizer( UnaryOperator& unary_operator );
+
+  std::unique_ptr<Expression> optimize();
+
+  void visit_children( Node& ) override;
+  void visit_float_value( FloatValue& literal ) override;
+  void visit_integer_value( IntegerValue& literal ) override;
+
+private:
+  std::unique_ptr<Expression> optimized_result;
+
+  UnaryOperator& unary_operator;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_UNARYOPERATOROPTIMIZER_H


### PR DESCRIPTION
Adds:
- [UnaryOperator](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/UnaryOperator.h): AST node for unary operators `-`, `++`, `--`, and so forth
- [UnaryOperatorOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.cpp): optimizes a unary operator with its operand
  - now integer and float negation, and integer inversion
  - later x[y]++ to a single instruction

Also:
- automatically include `basic.em`, which includes some parameter defaults like `-1`.

This allows the compiler to generate output for a `hello, world` script with the exact same `.ecl` output as the legacy compiler:
```
$ /home/vagrant/polserver/bin/ecompile -f -s -l -G compiler2/compiler2-001-hello-world.src
EScript Compiler v1.15
Copyright (C) 1993-2018 Eric N. Swanson

Comparing compiler output: compiler2/compiler2-001-hello-world.src
/vagrant/testsuite/escript/compiler2/compiler2-001-hello-world.src: 0 errors, 0 warnings.
Listings match: 1
Binary (.ecl) outputs match: 1
Compilation Summary:
     Result matches: 1
     Output matches: 1
```

Also for some other scripts in the test suite:
```
$ /home/vagrant/polserver/bin/ecompile -f -s -l -G -b
Compilation Summary:
    Compiled 507 scripts in 3011 ms.
    448 of those scripts had errors.
     Result matches: 59
  Result mismatches: 448
```
