### PR TITLE
New compiler: program declarations

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -28,6 +28,8 @@ set (bscript_sources    # sorted !
   compiler/ast/FloatValue.h
   compiler/ast/Function.cpp
   compiler/ast/Function.h
+  compiler/ast/FunctionBody.cpp
+  compiler/ast/FunctionBody.h
   compiler/ast/FunctionCall.cpp
   compiler/ast/FunctionCall.h
   compiler/ast/FunctionParameterDeclaration.cpp
@@ -44,6 +46,12 @@ set (bscript_sources    # sorted !
   compiler/ast/Node.h
   compiler/ast/NodeVisitor.cpp
   compiler/ast/NodeVisitor.h
+  compiler/ast/Program.cpp
+  compiler/ast/Program.h
+  compiler/ast/ProgramParameterDeclaration.cpp
+  compiler/ast/ProgramParameterDeclaration.h
+  compiler/ast/ProgramParameterList.cpp
+  compiler/ast/ProgramParameterList.h
   compiler/ast/Statement.cpp
   compiler/ast/Statement.h
   compiler/ast/StringValue.cpp

--- a/pol-core/bscript/compiler/analyzer/Disambiguator.cpp
+++ b/pol-core/bscript/compiler/analyzer/Disambiguator.cpp
@@ -1,5 +1,6 @@
 #include "Disambiguator.h"
 
+#include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/model/CompilerWorkspace.h"
 
@@ -13,6 +14,10 @@ Disambiguator::Disambiguator( Report& report )
 void Disambiguator::disambiguate( CompilerWorkspace& workspace )
 {
   workspace.top_level_statements->accept( *this );
+  if ( auto program = workspace.program.get() )
+  {
+    program->accept( *this );
+  }
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -7,6 +7,7 @@
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/VarStatement.h"
 #include "compiler/model/CompilerWorkspace.h"
@@ -30,6 +31,10 @@ void SemanticAnalyzer::register_const_declarations( CompilerWorkspace& /*workspa
 void SemanticAnalyzer::analyze( CompilerWorkspace& workspace )
 {
   workspace.top_level_statements->accept( *this );
+  if ( auto& program = workspace.program )
+  {
+    program->accept( *this );
+  }
 
   workspace.global_variable_names = globals.get_names();
 }

--- a/pol-core/bscript/compiler/ast/FunctionBody.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionBody.cpp
@@ -1,0 +1,31 @@
+#include "FunctionBody.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionBody::FunctionBody( const SourceLocation& source_location,
+                            std::vector<std::unique_ptr<Statement>> statements )
+    : Node( source_location, std::move( statements ) )
+{
+}
+
+void FunctionBody::accept( NodeVisitor& visitor )
+{
+  visitor.visit_function_body( *this );
+}
+
+void FunctionBody::describe_to( fmt::Writer& w ) const
+{
+  w << "user-function-body";
+}
+
+Statement* FunctionBody::last_statement()
+{
+  return children.empty() ? nullptr : static_cast<Statement*>( children.back().get() );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionBody.h
+++ b/pol-core/bscript/compiler/ast/FunctionBody.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_FUNCTIONBODY_H
+#define POLSERVER_FUNCTIONBODY_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Statement;
+
+class FunctionBody : public Node // This is used for both UserFunction and Program.  Better name?
+{
+public:
+  FunctionBody( const SourceLocation&, std::vector<std::unique_ptr<Statement>> );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Statement* last_statement();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FUNCTIONBODY_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -2,11 +2,15 @@
 
 #include "compiler/ast/Argument.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Node.h"
+#include "compiler/ast/Program.h"
+#include "compiler/ast/ProgramParameterDeclaration.h"
+#include "compiler/ast/ProgramParameterList.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/UnaryOperator.h"
@@ -21,6 +25,11 @@ void NodeVisitor::visit_argument( Argument& node )
 }
 
 void NodeVisitor::visit_float_value( FloatValue& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_function_body( FunctionBody& node )
 {
   visit_children( node );
 }
@@ -49,6 +58,21 @@ void NodeVisitor::visit_integer_value( IntegerValue& )
 }
 
 void NodeVisitor::visit_module_function_declaration( ModuleFunctionDeclaration& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_program( Program& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_program_parameter_declaration( ProgramParameterDeclaration& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_program_parameter_list( ProgramParameterList& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -5,6 +5,7 @@ namespace Pol::Bscript::Compiler
 {
 class Argument;
 class FloatValue;
+class FunctionBody;
 class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
@@ -12,6 +13,9 @@ class Identifier;
 class IntegerValue;
 class ModuleFunctionDeclaration;
 class Node;
+class Program;
+class ProgramParameterDeclaration;
+class ProgramParameterList;
 class StringValue;
 class TopLevelStatements;
 class UnaryOperator;
@@ -25,12 +29,16 @@ public:
 
   virtual void visit_argument( Argument& );
   virtual void visit_float_value( FloatValue& );
+  virtual void visit_function_body( FunctionBody& );
   virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
   virtual void visit_identifier( Identifier& );
   virtual void visit_integer_value( IntegerValue& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
+  virtual void visit_program( Program& );
+  virtual void visit_program_parameter_declaration( ProgramParameterDeclaration& );
+  virtual void visit_program_parameter_list( ProgramParameterList& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_unary_operator( UnaryOperator& );

--- a/pol-core/bscript/compiler/ast/Program.cpp
+++ b/pol-core/bscript/compiler/ast/Program.cpp
@@ -1,0 +1,43 @@
+#include "Program.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/FunctionBody.h"
+#include "compiler/ast/NodeVisitor.h"
+#include "compiler/ast/ProgramParameterList.h"
+
+namespace Pol::Bscript::Compiler
+{
+Program::Program( const SourceLocation& source_location,
+                  std::unique_ptr<ProgramParameterList> parameter_list,
+                  std::unique_ptr<FunctionBody> body )
+  : Node( source_location )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( parameter_list ) );
+  children.push_back( std::move( body ) );
+}
+
+Program::~Program() = default;
+
+void Program::accept( NodeVisitor& visitor )
+{
+  visitor.visit_program( *this );
+}
+
+void Program::describe_to( fmt::Writer& w ) const
+{
+  w << "program";
+}
+
+ProgramParameterList& Program::parameter_list()
+{
+  return child<ProgramParameterList>( 0 );
+}
+
+FunctionBody& Program::body()
+{
+  return child<FunctionBody>( 1 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Program.h
+++ b/pol-core/bscript/compiler/ast/Program.h
@@ -1,0 +1,27 @@
+#ifndef POLSERVER_PROGRAM_H
+#define POLSERVER_PROGRAM_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ProgramParameterList;
+class FunctionBody;
+
+class Program : public Node
+{
+public:
+  Program( const SourceLocation&, std::unique_ptr<ProgramParameterList>,
+           std::unique_ptr<FunctionBody> );
+  ~Program();
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  ProgramParameterList& parameter_list();
+  FunctionBody& body();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_PROGRAM_H

--- a/pol-core/bscript/compiler/ast/ProgramParameterDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ProgramParameterDeclaration.cpp
@@ -1,0 +1,28 @@
+#include "ProgramParameterDeclaration.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ProgramParameterDeclaration::ProgramParameterDeclaration( const SourceLocation& source_location,
+                                                          std::string name, bool unused )
+  : Node( source_location ), name( std::move( name ) ), unused( unused )
+{
+}
+void ProgramParameterDeclaration::accept( NodeVisitor& visitor )
+{
+  visitor.visit_program_parameter_declaration( *this );
+}
+
+void ProgramParameterDeclaration::describe_to( fmt::Writer& w ) const
+{
+  w << "program-parameter-declaration(" << name;
+  if ( unused )
+    w << ", unused";
+  w << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ProgramParameterDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ProgramParameterDeclaration.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_PROGRAMPARAMETERDECLARATION_H
+#define POLSERVER_PROGRAMPARAMETERDECLARATION_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ProgramParameterDeclaration : public Node
+{
+public:
+  ProgramParameterDeclaration( const SourceLocation&, std::string name, bool unused );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string name;
+  const bool unused;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_PROGRAMPARAMETERDECLARATION_H

--- a/pol-core/bscript/compiler/ast/ProgramParameterList.cpp
+++ b/pol-core/bscript/compiler/ast/ProgramParameterList.cpp
@@ -1,0 +1,27 @@
+#include "ProgramParameterList.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/ProgramParameterDeclaration.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ProgramParameterList::ProgramParameterList(
+    const SourceLocation& source_location,
+    std::vector<std::unique_ptr<ProgramParameterDeclaration>> parameters )
+  : Node( source_location, std::move( parameters ) )
+{
+}
+
+void ProgramParameterList::accept( NodeVisitor& visitor )
+{
+  return visitor.visit_program_parameter_list( *this );
+}
+
+void ProgramParameterList::describe_to( fmt::Writer& w ) const
+{
+  w << "program-parameter-list";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ProgramParameterList.h
+++ b/pol-core/bscript/compiler/ast/ProgramParameterList.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_PROGRAMPARAMETERLIST_H
+#define POLSERVER_PROGRAMPARAMETERLIST_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ProgramParameterDeclaration;
+
+class ProgramParameterList : public Node
+{
+public:
+  ProgramParameterList( const SourceLocation&,
+                        std::vector<std::unique_ptr<ProgramParameterDeclaration>> parameters );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_PROGRAMPARAMETERLIST_H

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -29,4 +29,17 @@ void CompoundStatementBuilder::add_statements(
   }
 }
 
+std::vector<std::unique_ptr<Statement>> CompoundStatementBuilder::block_statements(
+        EscriptParser::BlockContext* ctx )
+{
+  std::vector<std::unique_ptr<Statement>> statements;
+
+  for ( auto statement_context : ctx->statement() )
+  {
+    add_statements( statement_context, statements );
+  }
+
+  return statements;
+}
+
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -14,6 +14,8 @@ public:
   void add_statements( EscriptGrammar::EscriptParser::StatementContext*,
                        std::vector<std::unique_ptr<Statement>>& );
 
+  std::vector<std::unique_ptr<Statement>> block_statements(
+      EscriptGrammar::EscriptParser::BlockContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ProgramBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ProgramBuilder.cpp
@@ -1,11 +1,46 @@
 #include "ProgramBuilder.h"
 
+#include "compiler/ast/FunctionBody.h"
+#include "compiler/ast/Program.h"
+#include "compiler/ast/ProgramParameterDeclaration.h"
+#include "compiler/ast/ProgramParameterList.h"
+#include "compiler/ast/Statement.h"
+
+using EscriptGrammar::EscriptParser;
+
 namespace Pol::Bscript::Compiler
 {
 ProgramBuilder::ProgramBuilder( const SourceFileIdentifier& source_file_identifier,
                                 BuilderWorkspace& workspace )
   : CompoundStatementBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<Program> ProgramBuilder::program( EscriptParser::ProgramDeclarationContext* ctx )
+{
+  std::vector<std::unique_ptr<ProgramParameterDeclaration>> parameter_declarations;
+
+  if ( auto params = ctx->programParameters() )
+  {
+    if ( auto param_list = params->programParameterList() )
+    {
+      for ( auto param : param_list->programParameter() )
+      {
+        auto name = text( param->IDENTIFIER() );
+        bool unused = param->UNUSED() != nullptr;
+        parameter_declarations.push_back( std::make_unique<ProgramParameterDeclaration>(
+            location_for( *param ), std::move( name ), unused ) );
+      }
+    }
+  }
+  auto parameter_list = std::make_unique<ProgramParameterList>(
+      location_for( *ctx->programParameters() ), std::move( parameter_declarations ) );
+
+  auto body =
+      std::make_unique<FunctionBody>( location_for( *ctx ), block_statements( ctx->block() ) );
+
+  return std::make_unique<Program>( location_for( *ctx ), std::move( parameter_list ),
+                                    std::move( body ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/ProgramBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ProgramBuilder.h
@@ -5,14 +5,15 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Program;
 
 class ProgramBuilder : public CompoundStatementBuilder
 {
 public:
   ProgramBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  std::unique_ptr<Program> program( EscriptGrammar::EscriptParser::ProgramDeclarationContext* );
 };
-
 
 }  // namespace Pol::Bscript::Compiler
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -4,6 +4,7 @@
 #include "clib/timer.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
+#include "compiler/ast/Program.h"
 #include "compiler/ast/Statement.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
@@ -90,6 +91,22 @@ void SourceFileProcessor::process_source( SourceFile& sf )
 
     profile.ast_src_micros.fetch_add( ast_us_elapsed );
   }
+}
+
+antlrcpp::Any SourceFileProcessor::visitProgramDeclaration(
+    EscriptParser::ProgramDeclarationContext* ctx )
+{
+  if ( workspace.compiler_workspace.program )
+  {
+    report.error( location_for( *ctx ), "Multiple program statements.\n",
+                  "  Other declaration: ", workspace.compiler_workspace.program->source_location,
+                  "\n" );
+  }
+  else
+  {
+    workspace.compiler_workspace.program = tree_builder.program( ctx );
+  }
+  return antlrcpp::Any();
 }
 
 antlrcpp::Any SourceFileProcessor::visitStatement( EscriptParser::StatementContext* ctx )

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -24,6 +24,8 @@ public:
                    long long* micros_counted = nullptr );
   void process_source( SourceFile& );
 
+  antlrcpp::Any visitProgramDeclaration(
+      EscriptGrammar::EscriptParser::ProgramDeclarationContext* ) override;
   antlrcpp::Any visitStatement( EscriptGrammar::EscriptParser::StatementContext* ) override;
 
   SourceLocation location_for( antlr4::ParserRuleContext& ) const;

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -1,6 +1,7 @@
 #include "CompilerWorkspace.h"
 
 #include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/file/SourceFileIdentifier.h"
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -9,6 +9,7 @@ namespace Pol::Bscript::Compiler
 {
 class Block;
 class ModuleFunctionDeclaration;
+class Program;
 class SourceFile;
 class SourceFileIdentifier;
 class TopLevelStatements;
@@ -21,6 +22,7 @@ public:
 
   std::unique_ptr<TopLevelStatements> top_level_statements;
   std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;
+  std::unique_ptr<Program> program;
 
   // These reference ModuleFunctionDeclaration objects that are in module_functions
   std::vector<ModuleFunctionDeclaration*> referenced_module_function_declarations;

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -2,6 +2,7 @@
 
 #include "clib/logfacility.h"
 #include "compiler/Report.h"
+#include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/UnaryOperator.h"
 #include "compiler/ast/ValueConsumer.h"
@@ -20,6 +21,10 @@ void Optimizer::optimize( CompilerWorkspace& workspace )
 {
   ReferencedFunctionGatherer gatherer( workspace.module_function_declarations );
   workspace.top_level_statements->accept( gatherer );
+  if ( auto program = workspace.program.get() )
+  {
+    program->accept( gatherer );
+  }
   workspace.referenced_module_function_declarations =
       gatherer.take_referenced_module_function_declarations();
 }

--- a/pol-core/pol/module/osmod.h
+++ b/pol-core/pol/module/osmod.h
@@ -88,9 +88,6 @@ public:
   Core::HoldListType in_hold_list() const;
   void in_hold_list( Core::HoldListType in_hold_list );
 
-protected:
-
-  friend class Bscript::TmplExecutorModule<OSExecutorModule, Core::PolModule>;
 
   Bscript::BObjectImp* mf_Create_Debug_Context();
   Bscript::BObjectImp* mf_GetPid();
@@ -121,6 +118,8 @@ protected:
   Bscript::BObjectImp* mf_Clear_Event_Queue();  // DAVE
 
   Bscript::BObjectImp* mf_PerformanceMeasure();
+
+protected:
 
   bool critical_;
   unsigned char priority_;


### PR DESCRIPTION
Adds:
- [ast/FunctionBody](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionBody.h): holds statements for both program bodies and user function bodies.
  - This differs from a `Block` in that the program and the function manage their own blocks, adding their parameters to the scope.
- [ast/Program](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/Program.h#L12): AST Node for a `program` declaration
- [ast/ProgramParameterDeclaration](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ProgramParameterDeclaration.h): AST node for a program parameter declaration
- [ast/ProgramParameterList](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ProgramParameterList.h#L10): AST node that holds all of the parameter declarations for a program.

Also:
- generate code for program sections

This is enough to compile this script with parity:
```
program prog()
    print("hello, world");
endprogram
```

This doesn't yet make the semantic analyzer visit program declarations.  That requires local variable scopes, which are coming up next.