### PR TITLE
Refactor suspicious activity warnings and suppress B1 overflow warnings

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -980,7 +980,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
     <explain>EnforceMountObjtype: will enforce that only items with the mount objtype (as defined in extobj.cfg) can be mounted.</explain>
     <explain>AllowMultiClientsPerAccount: when true, will allow multiple characters from the same account to be logged in at the same time</explain>
     <explain>ProfileCProps: when true, will record CProp usage statistics. Helps detecting unused CProps, at the cost of some RAM and an unnoticeable performance impact. It should be enabled from startup, or the core will be unable to detect the type of some CProps.</explain>
-    <explain>ShowWarningGump: will show unexpected gump warning messages on the console.</explain>
+    <explain>ShowWarningGump: will show unexpected gump responses and B1 packet overflow messages on the console.</explain>
     <explain>ShowWarningItem: will show equip item and drop item warning messages on the console.</explain>
     <explain>ShowWarningCursorSequence: will show a warning when a player sends click packets out of sequence, this is usually due to the player running some sort of macro or client injection program.</explain>
 </cfgfile>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-18-2020</datemodified>
+		<datemodified>08-27-2020</datemodified>
 	</header>
 	<version name="POL100">
+		<entry>
+			<date>08-27-2020</date>
+			<author>Nando:</author>
+			<change type="Changed">If &quot;ShowGumpWarnings&quot; in pol.cfg is disabled, it will also disable warnings about<br/>
+overflow in the gump responses (B1 packet). Those messages may indicates the use of macro<br/>
+tools or custom clients.</change>
+		</entry>
 		<entry>
 			<date>08-18-2020</date>
 			<author>Nando:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 ﻿-- POL100 --
+08-27-2020 Nando:
+  Changed: If "ShowGumpWarnings" in pol.cfg is disabled, it will also disable warnings about
+           overflow in the gump responses (B1 packet). Those messages may indicates the use of macro
+           tools or custom clients.
+
 08-18-2020 Nando:
     Added: Parameter "max_cmdlevel" to polsys::ListTextCommands(). Indicates the maximum cmdlevel to include in the list.
            

--- a/pol-core/pol/CMakeSources.cmake
+++ b/pol-core/pol/CMakeSources.cmake
@@ -369,6 +369,8 @@ set (pol_sources  # sorted !
   syshook.h
   syshookscript.cpp
   syshookscript.h
+  systems/suspiciousacts.cpp
+  systems/suspiciousacts.h
   target.cpp
   target.h
   tasks.cpp

--- a/pol-core/pol/dropitem.cpp
+++ b/pol-core/pol/dropitem.cpp
@@ -58,6 +58,7 @@
 #include "statmsg.h"
 #include "storage.h"
 #include "syshook.h"
+#include "systems/suspiciousacts.h"
 #include "ufunc.h"
 #include "uobject.h"
 #include "uoscrobj.h"
@@ -800,23 +801,13 @@ void drop_item( Network::Client* client, PKTIN_08_V1* msg )
   Items::Item* item = client->chr->gotten_item();
   if ( item == nullptr )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to drop item 0x{:X}, but had not gotten an item.\n" )
-          << client->chr->serial << item_serial;
-    }
+    SuspiciousActs::DropItemButNoneGotten( client, item_serial );
     return;
   }
   if ( item->serial != item_serial )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to drop item 0x{:X}, but instead had gotten item 0x{:X}.\n" )
-          << client->chr->serial << item_serial << item->serial;
-    }
-    item->gotten_by( nullptr );
+    SuspiciousActs::DropItemOtherThanGotten( client, item_serial, item->serial );
+    item->gotten_by( nullptr ); // TODO: shouldn't we clear_gotten_item() here?
     return;
   }
   item->inuse( false );
@@ -876,22 +867,12 @@ void drop_item_v2( Network::Client* client, PKTIN_08_V2* msg )
   Items::Item* item = client->chr->gotten_item();
   if ( item == nullptr )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to drop item 0x{:X}, but had not gotten an item.\n" )
-          << client->chr->serial << item_serial;
-    }
+    SuspiciousActs::DropItemButNoneGotten( client, item_serial );
     return;
   }
   if ( item->serial != item_serial )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to drop item 0x{:X}, but instead had gotten item 0x{:X}.\n" )
-          << client->chr->serial << item_serial << item->serial;
-    }
+    SuspiciousActs::DropItemOtherThanGotten( client, item_serial, item->serial );
     item->gotten_by( nullptr );
     return;
   }

--- a/pol-core/pol/eqpitem.cpp
+++ b/pol-core/pol/eqpitem.cpp
@@ -20,6 +20,7 @@
 #include "network/client.h"
 #include "network/pktdef.h"
 #include "network/pktin.h"
+#include "systems/suspiciousacts.h"
 #include "realms/realm.h"
 #include "reftypes.h"
 #include "ufunc.h"
@@ -44,26 +45,16 @@ void equip_item( Network::Client* client, PKTIN_13* msg )
 
   if ( item == nullptr )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to equip item 0x{:X}, which did not exist in gotten_items.\n" )
-          << client->chr->serial << serial;
-    }
+    SuspiciousActs::EquipItemButNoneGotten( client, serial );
     send_item_move_failure( client, MOVE_ITEM_FAILURE_ILLEGAL_EQUIP );  // 5
     return;
   }
 
   if ( item->serial != serial )
   {
-    if ( Plib::systemstate.config.show_warning_item )
-    {
-      POLLOG_ERROR.Format(
-          "Character 0x{:X} tried to equip item 0x{:X}, but had gotten item 0x{:X}\n" )
-          << client->chr->serial << serial << item->serial;
-    }
+    SuspiciousActs::EquipItemOtherThanGotten( client, serial, item->serial );
     send_item_move_failure( client, MOVE_ITEM_FAILURE_ILLEGAL_EQUIP );  // 5
-    item->gotten_by( nullptr );
+    item->gotten_by( nullptr ); // TODO: shouldn't we clear_gotten_item() here?
     return;
   }
 

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -1463,7 +1463,7 @@ void gumpbutton_handler( Client* client, PKTIN_B1* msg )
   UOExecutorModule* uoemod = client->gd->find_gumpmod( gumpid );
   if ( uoemod == nullptr )
   {
-    SuspiciousActs::UnexpectedGumpResponse( client, gumpid, buttonid );
+    SuspiciousActs::GumpResponseWasUnexpected( client, gumpid, buttonid );
     return;
   }
 
@@ -1496,7 +1496,7 @@ void gumpbutton_handler( Client* client, PKTIN_B1* msg )
                       sizeof( PKTIN_B1::STRINGS_HEADER );
     if ( stridx > msglen )
     {
-      ERROR_PRINT << "Blech! B1 message specified too many ints!\n";
+      SuspiciousActs::GumpResponseHasTooManyInts( client );
       clear_gumphandler( client, uoemod );
       return;
     }
@@ -1508,9 +1508,7 @@ void gumpbutton_handler( Client* client, PKTIN_B1* msg )
     // -2 per entry to only count tag+length (data has size of 2 in struct)
     if ( stridx + ( sizeof( PKTIN_B1::STRING_ENTRY ) - 2 ) * strings_count > msglen + 1u )
     {
-      ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character "
-                  << client->chr->name()
-                  << ") Blech! B1 message specified too many ints and/or strings!\n";
+      SuspiciousActs::GumpResponseHasTooManyIntsOrStrings( client );
       uoex.ValueStack.back().set(
           new BObject( new BError( "B1 message specified too many ints and/or strings." ) ) );
       clear_gumphandler( client, uoemod );
@@ -1538,9 +1536,7 @@ void gumpbutton_handler( Client* client, PKTIN_B1* msg )
         stridx += offsetof( PKTIN_B1::STRING_ENTRY, data ) + length * 2;
         if ( stridx > msglen )
         {
-          ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character "
-                      << client->chr->name()
-                      << ") Blech! B1 message strings overflow message buffer!\n";
+          SuspiciousActs::GumpResponseOverflows( client );
           break;
         }
 

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -95,12 +95,12 @@
 #include "../uoexec.h"
 #include "../uoscrobj.h"
 #include "../uworld.h"
+#include "systems/suspiciousacts.h"
 #include "uomod.h"
 
 #ifdef MEMORYLEAK
 #include "../../clib/opnew.h"
 #endif
-
 
 
 #include <zlib.h>
@@ -209,9 +209,8 @@ BObjectImp* UOExecutorModule::mf_SendBuyWindow( /* character, container, vendor,
   UContainer *for_sale, *bought;
   unsigned char save_layer_one, save_layer_two;
 
-  if ( getCharacterParam( 0, chr ) && getItemParam( 1, item ) &&
-       getCharacterParam( 2, mrchnt ) && getItemParam( 3, item2 ) &&
-       getParam( 4, flags ) )
+  if ( getCharacterParam( 0, chr ) && getItemParam( 1, item ) && getCharacterParam( 2, mrchnt ) &&
+       getItemParam( 3, item2 ) && getParam( 4, flags ) )
   {
     if ( !chr->has_active_client() )
     {
@@ -712,8 +711,8 @@ BObjectImp* UOExecutorModule::mf_SendSellWindow( /* character, vendor, i1, i2, i
   UContainer* merchant_buyable = nullptr;
 
   if ( !( getCharacterParam( 0, chr ) && getCharacterParam( 1, mrchnt ) &&
-          getItemParam( 2, wi1a ) && getItemParam( 3, wi1b ) &&
-          getItemParam( 4, wi1c ) && getParam( 5, flags ) ) )
+          getItemParam( 2, wi1a ) && getItemParam( 3, wi1b ) && getItemParam( 4, wi1c ) &&
+          getParam( 5, flags ) ) )
   {
     return new BError( "A parameter was invalid" );
   }
@@ -1357,8 +1356,7 @@ BObjectImp* UOExecutorModule::mf_CloseGump( /* who, pid, response := 0 */ )
   unsigned int pid;
   BObjectImp* resp;
 
-  if ( !( getCharacterParam( 0, chr ) && exec.getParam( 1, pid ) &&
-          ( getParamImp( 2, resp ) ) ) )
+  if ( !( getCharacterParam( 0, chr ) && exec.getParam( 1, pid ) && ( getParamImp( 2, resp ) ) ) )
   {
     return new BError( "Invalid parameter" );
   }
@@ -1394,8 +1392,7 @@ BObjectImp* UOExecutorModule::mf_CloseWindow( /* chr, type, obj */ )
   unsigned int type;
   UObject* obj;
 
-  if ( !getCharacterParam( 0, chr ) || !getParam( 1, type ) ||
-       !getUObjectParam( 2, obj ) )
+  if ( !getCharacterParam( 0, chr ) || !getParam( 1, type ) || !getUObjectParam( 2, obj ) )
     return new BError( "Invalid parameter" );
 
   if ( !chr->has_active_client() )
@@ -1466,13 +1463,7 @@ void gumpbutton_handler( Client* client, PKTIN_B1* msg )
   UOExecutorModule* uoemod = client->gd->find_gumpmod( gumpid );
   if ( uoemod == nullptr )
   {
-    if ( Plib::systemstate.config.show_warning_gump )
-    {
-      POLLOG_INFO.Format(
-          "\nWarning: Character 0x{:X} sent an unexpected gump menu selection. Gump ID 0x{:X}, "
-          "button ID 0x{:X}\n" )
-          << client->chr->serial << gumpid << buttonid;
-    }
+    SuspiciousActs::UnexpectedGumpResponse( client, gumpid, buttonid );
     return;
   }
 
@@ -2832,8 +2823,7 @@ BObjectImp* UOExecutorModule::mf_ListStaticsNearLocationOfType(
   Realms::Realm* realm;
 
   if ( getParam( 0, x ) && getParam( 1, y ) && getParam( 2, z ) && getParam( 3, range ) &&
-       getObjtypeParam( 4, objtype ) && getParam( 5, flags ) &&
-       getStringParam( 6, strrealm ) )
+       getObjtypeParam( 4, objtype ) && getParam( 5, flags ) && getStringParam( 6, strrealm ) )
   {
     realm = find_realm( strrealm->value() );
     if ( !realm )

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -256,6 +256,7 @@ void PolConfig::read_pol_config( bool initial_load )
   Plib::systemstate.config.thread_decay_statistics =
       elem.remove_bool( "ThreadDecayStatistics", false );
 
+  // These warnings disable the logging of suspicious acts
   Plib::systemstate.config.show_warning_gump = elem.remove_bool( "ShowWarningGump", true );
   Plib::systemstate.config.show_warning_item = elem.remove_bool( "ShowWarningItem", true );
   Plib::systemstate.config.show_warning_cursor_seq =

--- a/pol-core/pol/systems/suspiciousacts.cpp
+++ b/pol-core/pol/systems/suspiciousacts.cpp
@@ -24,22 +24,34 @@ void SuspiciousActs::GumpResponseWasUnexpected( Network::Client* client, u32 gum
 void SuspiciousActs::GumpResponseHasTooManyInts( Network::Client* client )
 {
   // TODO: report the extra ints?
-  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
-              << ") Blech! B1 message specified too many ints!\n";
+  if ( Plib::systemstate.config.show_warning_gump )
+  {
+    ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character "
+                << client->chr->name()
+                << ") Blech! B1 message specified more ints than it can hold!\n";
+  }
 }
 
 void SuspiciousActs::GumpResponseHasTooManyIntsOrStrings( Network::Client* client )
 {
   // TODO: report the extra ints/strings?
-  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
-              << ") Blech! B1 message specified too many ints and/or strings!\n";
+  if ( Plib::systemstate.config.show_warning_gump )
+  {
+    ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character "
+                << client->chr->name()
+                << ") Blech! B1 message specified too many ints and/or strings!\n";
+  }
 }
 
 void SuspiciousActs::GumpResponseOverflows( Network::Client* client )
 {
   // TODO: report by how much?
-  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
-              << ") Blech! B1 message strings overflow message buffer!\n";
+  if ( Plib::systemstate.config.show_warning_gump )
+  {
+    ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character "
+                << client->chr->name()
+                << ") Blech! B1 message strings overflow the message buffer!\n";
+  }
 }
 
 void SuspiciousActs::DropItemButNoneGotten( Network::Client* client, u32 dropped_item_serial )

--- a/pol-core/pol/systems/suspiciousacts.cpp
+++ b/pol-core/pol/systems/suspiciousacts.cpp
@@ -10,7 +10,7 @@
 
 using namespace Pol;
 
-void SuspiciousActs::UnexpectedGumpResponse( Network::Client* client, u32 gumpid, u32 buttonid )
+void SuspiciousActs::GumpResponseWasUnexpected( Network::Client* client, u32 gumpid, u32 buttonid )
 {
   if ( Plib::systemstate.config.show_warning_gump )
   {
@@ -19,6 +19,27 @@ void SuspiciousActs::UnexpectedGumpResponse( Network::Client* client, u32 gumpid
         "button ID 0x{:X}\n" )
         << client->chr->serial << gumpid << buttonid;
   }
+}
+
+void SuspiciousActs::GumpResponseHasTooManyInts( Network::Client* client )
+{
+  // TODO: report the extra ints?
+  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
+              << ") Blech! B1 message specified too many ints!\n";
+}
+
+void SuspiciousActs::GumpResponseHasTooManyIntsOrStrings( Network::Client* client )
+{
+  // TODO: report the extra ints/strings?
+  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
+              << ") Blech! B1 message specified too many ints and/or strings!\n";
+}
+
+void SuspiciousActs::GumpResponseOverflows( Network::Client* client )
+{
+  // TODO: report by how much?
+  ERROR_PRINT << "Client (Account " << client->acct->name() << ", Character " << client->chr->name()
+              << ") Blech! B1 message strings overflow message buffer!\n";
 }
 
 void SuspiciousActs::DropItemButNoneGotten( Network::Client* client, u32 dropped_item_serial )
@@ -68,7 +89,7 @@ void SuspiciousActs::OutOfSequenceCursor( Network::Client* client )
   Mobile::Character* targetter = client->chr;
 
   if ( Plib::systemstate.config.show_warning_cursor_seq )
-  {  
+  {
     POLLOG_ERROR << targetter->acct->name() << "/" << targetter->name()
                  << " used out of sequence cursor.\n";
   }

--- a/pol-core/pol/systems/suspiciousacts.cpp
+++ b/pol-core/pol/systems/suspiciousacts.cpp
@@ -1,0 +1,75 @@
+#include "suspiciousacts.h"
+
+#include "clib/logfacility.h"
+#include "clib/rawtypes.h"
+#include "plib/systemstate.h"
+
+#include "accounts/account.h"
+#include "mobile/charactr.h"
+#include "network/client.h"
+
+using namespace Pol;
+
+void SuspiciousActs::UnexpectedGumpResponse( Network::Client* client, u32 gumpid, u32 buttonid )
+{
+  if ( Plib::systemstate.config.show_warning_gump )
+  {
+    POLLOG_INFO.Format(
+        "\nWarning: Character 0x{:X} sent an unexpected gump menu selection. Gump ID 0x{:X}, "
+        "button ID 0x{:X}\n" )
+        << client->chr->serial << gumpid << buttonid;
+  }
+}
+
+void SuspiciousActs::DropItemButNoneGotten( Network::Client* client, u32 dropped_item_serial )
+{
+  if ( Plib::systemstate.config.show_warning_item )
+  {
+    POLLOG_ERROR.Format(
+        "Character 0x{:X} tried to drop item 0x{:X}, but had not gotten an item.\n" )
+        << client->chr->serial << dropped_item_serial;
+  }
+}
+
+void SuspiciousActs::DropItemOtherThanGotten( Network::Client* client, u32 dropped_item_serial,
+                                              u32 gotten_item_serial )
+{
+  if ( Plib::systemstate.config.show_warning_item )
+  {
+    POLLOG_ERROR.Format(
+        "Character 0x{:X} tried to drop item 0x{:X}, but instead had gotten item 0x{:X}.\n" )
+        << client->chr->serial << dropped_item_serial << gotten_item_serial;
+  }
+}
+
+void SuspiciousActs::EquipItemButNoneGotten( Network::Client* client, u32 equipped_item_serial )
+{
+  if ( Plib::systemstate.config.show_warning_item )
+  {
+    POLLOG_ERROR.Format(
+        "Character 0x{:X} tried to equip item 0x{:X}, which did not exist in gotten_items.\n" )
+        << client->chr->serial << equipped_item_serial;
+  }
+}
+
+void SuspiciousActs::EquipItemOtherThanGotten( Network::Client* client, u32 equipped_item_serial,
+                                               u32 gotten_item_serial )
+{
+  if ( Plib::systemstate.config.show_warning_item )
+  {
+    POLLOG_ERROR.Format(
+        "Character 0x{:X} tried to equip item 0x{:X}, but had gotten item 0x{:X}\n" )
+        << client->chr->serial << equipped_item_serial << gotten_item_serial;
+  }
+}
+
+void SuspiciousActs::OutOfSequenceCursor( Network::Client* client )
+{
+  Mobile::Character* targetter = client->chr;
+
+  if ( Plib::systemstate.config.show_warning_cursor_seq )
+  {  
+    POLLOG_ERROR << targetter->acct->name() << "/" << targetter->name()
+                 << " used out of sequence cursor.\n";
+  }
+}

--- a/pol-core/pol/systems/suspiciousacts.h
+++ b/pol-core/pol/systems/suspiciousacts.h
@@ -8,7 +8,8 @@ namespace Pol::Network
 class Client;
 }
 
-// For now the reporting is done with static functions, so a namespace is fine. We can make this a class later if needed.
+// For now the reporting is done with static functions, so a namespace is fine. We can make this a
+// class later if needed.
 namespace Pol::SuspiciousActs
 {
 void GumpResponseWasUnexpected( Pol::Network::Client* client, u32 gumpid, u32 buttonid );
@@ -18,13 +19,13 @@ void GumpResponseOverflows( Network::Client* client );
 
 void DropItemButNoneGotten( Network::Client* client, u32 item_serial );
 void DropItemOtherThanGotten( Network::Client* client, u32 dropped_item_serial,
-                                u32 gotten_item_serial );
+                              u32 gotten_item_serial );
 
 void EquipItemButNoneGotten( Network::Client* client, u32 equipped_item_serial );
 void EquipItemOtherThanGotten( Network::Client* client, u32 equipped_item_serial,
                                u32 gotten_item_serial );
 
 void OutOfSequenceCursor( Network::Client* client );
-}
+}  // namespace Pol::SuspiciousActs
 
 #endif  // !H_SYSTEMS_SUSPICIOUSACTS

--- a/pol-core/pol/systems/suspiciousacts.h
+++ b/pol-core/pol/systems/suspiciousacts.h
@@ -11,13 +11,19 @@ class Client;
 // For now the reporting is done with static functions, so a namespace is fine. We can make this a class later if needed.
 namespace Pol::SuspiciousActs
 {
-void UnexpectedGumpResponse( Pol::Network::Client* client, u32 gumpid, u32 buttonid );
+void GumpResponseWasUnexpected( Pol::Network::Client* client, u32 gumpid, u32 buttonid );
+void GumpResponseHasTooManyInts( Network::Client* client );
+void GumpResponseHasTooManyIntsOrStrings( Network::Client* client );
+void GumpResponseOverflows( Network::Client* client );
+
 void DropItemButNoneGotten( Network::Client* client, u32 item_serial );
 void DropItemOtherThanGotten( Network::Client* client, u32 dropped_item_serial,
                                 u32 gotten_item_serial );
+
 void EquipItemButNoneGotten( Network::Client* client, u32 equipped_item_serial );
 void EquipItemOtherThanGotten( Network::Client* client, u32 equipped_item_serial,
                                u32 gotten_item_serial );
+
 void OutOfSequenceCursor( Network::Client* client );
 }
 

--- a/pol-core/pol/systems/suspiciousacts.h
+++ b/pol-core/pol/systems/suspiciousacts.h
@@ -1,0 +1,24 @@
+#ifndef H_SYSTEMS_SUSPICIOUSACTS
+#define H_SYSTEMS_SUSPICIOUSACTS
+
+#include "clib/rawtypes.h"
+
+namespace Pol::Network
+{
+class Client;
+}
+
+// For now the reporting is done with static functions, so a namespace is fine. We can make this a class later if needed.
+namespace Pol::SuspiciousActs
+{
+void UnexpectedGumpResponse( Pol::Network::Client* client, u32 gumpid, u32 buttonid );
+void DropItemButNoneGotten( Network::Client* client, u32 item_serial );
+void DropItemOtherThanGotten( Network::Client* client, u32 dropped_item_serial,
+                                u32 gotten_item_serial );
+void EquipItemButNoneGotten( Network::Client* client, u32 equipped_item_serial );
+void EquipItemOtherThanGotten( Network::Client* client, u32 equipped_item_serial,
+                               u32 gotten_item_serial );
+void OutOfSequenceCursor( Network::Client* client );
+}
+
+#endif  // !H_SYSTEMS_SUSPICIOUSACTS

--- a/pol-core/pol/target.cpp
+++ b/pol-core/pol/target.cpp
@@ -15,10 +15,8 @@
 #include "../clib/logfacility.h"
 #include "../clib/rawtypes.h"
 #include "../plib/systemstate.h"
-#include "accounts/account.h"
 #include "fnsearch.h"
 #include "globals/uvars.h"
-#include "regions/guardrgn.h"
 #include "item/itemdesc.h"
 #include "mobile/charactr.h"
 #include "multi/multi.h"
@@ -28,6 +26,8 @@
 #include "network/pktboth.h"
 #include "polclass.h"
 #include "realms/realm.h"
+#include "regions/guardrgn.h"
+#include "systems/suspiciousacts.h"
 #include "ufunc.h"
 #include "uobject.h"
 
@@ -50,10 +50,7 @@ void handle_target_cursor( Network::Client* client, PKTBI_6C* msg )
   TargetCursor* tcursor = gamestate.target_cursors._target_cursors[target_cursor_serial - 1];
   if ( tcursor != targetter->tcursor2 )
   {
-    if ( Plib::systemstate.config.show_warning_cursor_seq )
-      POLLOG_ERROR << targetter->acct->name() << "/" << targetter->name()
-                   << " used out of sequence cursor.\n";
-
+    SuspiciousActs::OutOfSequenceCursor( client );
     targetter->tcursor2 = nullptr;
     return;
   }


### PR DESCRIPTION
Suspicious activity warnings are now individual functions. Those functions could later be used to report events to a script or penalize misbehaving players.