### PR TITLE
General cleanup of module includes

### DIFF
--- a/pol-core/pol/module/attributemod.h
+++ b/pol-core/pol/module/attributemod.h
@@ -31,28 +31,29 @@ class AttributeExecutorModule
 public:
   AttributeExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_CheckSkill();  // Character, SkillId, Difficulty, Points
+  [[nodiscard]] Bscript::BObjectImp* mf_CheckSkill();  // Character, SkillId, Difficulty, Points
 
-  Bscript::BObjectImp* mf_GetAttributeName( /* alias name */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeName( /* alias name */ );
 
-  Bscript::BObjectImp* mf_GetAttributeDefaultCap( /* alias name */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeDefaultCap( /* alias name */ );
 
-  Bscript::BObjectImp* mf_GetAttribute( /* mob, attrname */ );
-  Bscript::BObjectImp* mf_GetAttributeBaseValue( /* mob, attrname */ );
-  Bscript::BObjectImp* mf_GetAttributeTemporaryMod( /* mob, attrname */ );
-  Bscript::BObjectImp* mf_GetAttributeIntrinsicMod( /* mob, attrname */ );
-  Bscript::BObjectImp* mf_GetAttributeLock( /* mob, attrname */ );
-  Bscript::BObjectImp* mf_GetAttributeCap( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttribute( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeBaseValue( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeTemporaryMod( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeIntrinsicMod( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeLock( /* mob, attrname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAttributeCap( /* mob, attrname */ );
 
-  Bscript::BObjectImp* mf_SetAttributeCap( /* mob, attrname, value */ );
-  Bscript::BObjectImp* mf_SetAttributeLock( /* mob, attrname, lockstate */ );
-  Bscript::BObjectImp* mf_SetAttributeBaseValue( /* mob, attributeid, basevalue */ );
-  Bscript::BObjectImp* mf_SetAttributeTemporaryMod( /* mob, attributeid, temporary_mod */ );
-  Bscript::BObjectImp* mf_AlterAttributeTemporaryMod( /* mob, attributeid, temporary_mod */ );
-  Bscript::BObjectImp* mf_SetAttributeIntrinsicMod( /* mob, attributeid, intrinsic_mod */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetAttributeCap( /* mob, attrname, value */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetAttributeLock( /* mob, attrname, lockstate */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetAttributeBaseValue( /* mob, attributeid, basevalue */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetAttributeTemporaryMod(
+      /* mob, attributeid, temporary_mod */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_AlterAttributeTemporaryMod(
+      /* mob, attributeid, temporary_mod */ );
 
-  Bscript::BObjectImp* mf_RawSkillToBaseSkill();
-  Bscript::BObjectImp* mf_BaseSkillToRawSkill();
+  [[nodiscard]] Bscript::BObjectImp* mf_RawSkillToBaseSkill();
+  [[nodiscard]] Bscript::BObjectImp* mf_BaseSkillToRawSkill();
 };
 }  // namespace Module
 }  // namespace Pol

--- a/pol-core/pol/module/basiciomod.h
+++ b/pol-core/pol/module/basiciomod.h
@@ -26,7 +26,7 @@ class BasicIoExecutorModule
     : public Bscript::TmplExecutorModule<BasicIoExecutorModule, Bscript::ExecutorModule>
 {
 public:
-  Bscript::BObjectImp* mf_Print();
+  [[nodiscard]] Bscript::BObjectImp* mf_Print();
 
   BasicIoExecutorModule( Bscript::Executor& exec );
 };

--- a/pol-core/pol/module/basicmod.h
+++ b/pol-core/pol/module/basicmod.h
@@ -29,41 +29,41 @@ class BasicExecutorModule
 {
 public:
   /* These probably belong in a string module */
-  Bscript::BObjectImp* mf_Find();
-  Bscript::BObjectImp* mf_Len();
-  Bscript::BObjectImp* mf_Upper();
-  Bscript::BObjectImp* mf_Lower();
-  Bscript::BObjectImp* mf_SubStr();
-  Bscript::BObjectImp* mf_Trim();
-  Bscript::BObjectImp* mf_StrReplace();
-  Bscript::BObjectImp* mf_SubStrReplace();
-  Bscript::BObjectImp* mf_Compare();
-  Bscript::BObjectImp* mf_CInt();
-  Bscript::BObjectImp* mf_CStr();
-  Bscript::BObjectImp* mf_CDbl();
-  Bscript::BObjectImp* mf_CAsc();
-  Bscript::BObjectImp* mf_CAscZ();
-  Bscript::BObjectImp* mf_CChr();
-  Bscript::BObjectImp* mf_CChrZ();
+  [[nodiscard]] Bscript::BObjectImp* mf_Find();
+  [[nodiscard]] Bscript::BObjectImp* mf_Len();
+  [[nodiscard]] Bscript::BObjectImp* mf_Upper();
+  [[nodiscard]] Bscript::BObjectImp* mf_Lower();
+  [[nodiscard]] Bscript::BObjectImp* mf_SubStr();
+  [[nodiscard]] Bscript::BObjectImp* mf_Trim();
+  [[nodiscard]] Bscript::BObjectImp* mf_StrReplace();
+  [[nodiscard]] Bscript::BObjectImp* mf_SubStrReplace();
+  [[nodiscard]] Bscript::BObjectImp* mf_Compare();
+  [[nodiscard]] Bscript::BObjectImp* mf_CInt();
+  [[nodiscard]] Bscript::BObjectImp* mf_CStr();
+  [[nodiscard]] Bscript::BObjectImp* mf_CDbl();
+  [[nodiscard]] Bscript::BObjectImp* mf_CAsc();
+  [[nodiscard]] Bscript::BObjectImp* mf_CAscZ();
+  [[nodiscard]] Bscript::BObjectImp* mf_CChr();
+  [[nodiscard]] Bscript::BObjectImp* mf_CChrZ();
 
-  Bscript::BObjectImp* mf_Bin();
-  Bscript::BObjectImp* mf_Hex();
-  Bscript::BObjectImp* mf_SplitWords();
+  [[nodiscard]] Bscript::BObjectImp* mf_Bin();
+  [[nodiscard]] Bscript::BObjectImp* mf_Hex();
+  [[nodiscard]] Bscript::BObjectImp* mf_SplitWords();
 
-  Bscript::BObjectImp* mf_Pack();
-  Bscript::BObjectImp* mf_Unpack();
+  [[nodiscard]] Bscript::BObjectImp* mf_Pack();
+  [[nodiscard]] Bscript::BObjectImp* mf_Unpack();
 
-  Bscript::BObjectImp* mf_TypeOf();
-  Bscript::BObjectImp* mf_SizeOf();
-  Bscript::BObjectImp* mf_TypeOfInt();
+  [[nodiscard]] Bscript::BObjectImp* mf_TypeOf();
+  [[nodiscard]] Bscript::BObjectImp* mf_SizeOf();
+  [[nodiscard]] Bscript::BObjectImp* mf_TypeOfInt();
 
-  Bscript::BObjectImp* mf_PackJSON();
-  Bscript::BObjectImp* mf_UnpackJSON();
+  [[nodiscard]] Bscript::BObjectImp* mf_PackJSON();
+  [[nodiscard]] Bscript::BObjectImp* mf_UnpackJSON();
 
-  Bscript::BObjectImp* mf_Boolean();
+  [[nodiscard]] Bscript::BObjectImp* mf_Boolean();
 
-  Bscript::BObjectImp* mf_EncodeBase64();
-  Bscript::BObjectImp* mf_DecodeBase64();
+  [[nodiscard]] Bscript::BObjectImp* mf_EncodeBase64();
+  [[nodiscard]] Bscript::BObjectImp* mf_DecodeBase64();
 
   BasicExecutorModule( Bscript::Executor& exec );
 };

--- a/pol-core/pol/module/boatmod.h
+++ b/pol-core/pol/module/boatmod.h
@@ -29,17 +29,17 @@ class UBoatExecutorModule : public Bscript::TmplExecutorModule<UBoatExecutorModu
 public:
   UBoatExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_MoveBoat();
-  Bscript::BObjectImp* mf_MoveBoatRelative();
-
-  Bscript::BObjectImp* mf_TurnBoat();
-
-  Bscript::BObjectImp* mf_RegisterItemWithBoat();
-  Bscript::BObjectImp* mf_BoatFromItem();
-
-  Bscript::BObjectImp* mf_SystemFindBoatBySerial();
-
-  Bscript::BObjectImp* mf_MoveBoatXY();
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveBoat();
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveBoatRelative();
+   
+  [[nodiscard]] Bscript::BObjectImp* mf_TurnBoat();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_RegisterItemWithBoat();
+  [[nodiscard]] Bscript::BObjectImp* mf_BoatFromItem();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_SystemFindBoatBySerial();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveBoatXY();
 };
 }
 }

--- a/pol-core/pol/module/cfgmod.h
+++ b/pol-core/pol/module/cfgmod.h
@@ -41,24 +41,24 @@ class ConfigFileExecutorModule
 public:
   ConfigFileExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_ReadConfigFile();
-  Bscript::BObjectImp* mf_FindConfigElem();
-  Bscript::BObjectImp* mf_GetElemProperty();
-  Bscript::BObjectImp* mf_GetConfigString();
-  Bscript::BObjectImp* mf_GetConfigStringArray();
-  Bscript::BObjectImp* mf_GetConfigStringDictionary();
-  Bscript::BObjectImp* mf_GetConfigInt();
-  Bscript::BObjectImp* mf_GetConfigIntArray();
-  Bscript::BObjectImp* mf_GetConfigReal();
-  Bscript::BObjectImp* mf_GetConfigMaxIntKey();
-  Bscript::BObjectImp* mf_GetConfigStringKeys();
-  Bscript::BObjectImp* mf_GetConfigIntKeys();
-  Bscript::BObjectImp* mf_ListConfigElemProps();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReadConfigFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindConfigElem();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetElemProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigString();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigStringArray();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigStringDictionary();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigInt();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigIntArray();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigReal();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigMaxIntKey();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigStringKeys();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetConfigIntKeys();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListConfigElemProps();
 
-  Bscript::BObjectImp* mf_AppendConfigFileElem();
-  Bscript::BObjectImp* mf_UnloadConfigFile();
-
-  Bscript::BObjectImp* mf_LoadTusScpFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_AppendConfigFileElem();
+  [[nodiscard]] Bscript::BObjectImp* mf_UnloadConfigFile();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_LoadTusScpFile();
 
 
 protected:

--- a/pol-core/pol/module/clmod.h
+++ b/pol-core/pol/module/clmod.h
@@ -28,9 +28,9 @@ class ClilocExecutorModule
 public:
   ClilocExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_SendSysMessageCL();
-  Bscript::BObjectImp* mf_PrintTextAboveCL();
-  Bscript::BObjectImp* mf_PrintTextAbovePrivateCL();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendSysMessageCL();
+  [[nodiscard]] Bscript::BObjectImp* mf_PrintTextAboveCL();
+  [[nodiscard]] Bscript::BObjectImp* mf_PrintTextAbovePrivateCL();
 };
 }  // namespace Module
 }  // namespace Pol

--- a/pol-core/pol/module/datastore.h
+++ b/pol-core/pol/module/datastore.h
@@ -31,10 +31,10 @@ class DataFileExecutorModule
 {
 public:
   DataFileExecutorModule( Bscript::Executor& exec );
-  Bscript::BObjectImp* mf_ListDataFiles();
-  Bscript::BObjectImp* mf_CreateDataFile();
-  Bscript::BObjectImp* mf_OpenDataFile();
-  Bscript::BObjectImp* mf_UnloadDataFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListDataFiles();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateDataFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenDataFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_UnloadDataFile();
 
 private:
   DataStoreFile* GetDataStoreFile( const std::string& inspec );

--- a/pol-core/pol/module/filemod.h
+++ b/pol-core/pol/module/filemod.h
@@ -34,16 +34,16 @@ class FileAccessExecutorModule
 public:
   FileAccessExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_FileExists();
-  Bscript::BObjectImp* mf_ReadFile();
-  Bscript::BObjectImp* mf_WriteFile();
-  Bscript::BObjectImp* mf_AppendToFile();
-  Bscript::BObjectImp* mf_LogToFile();
-  Bscript::BObjectImp* mf_OpenBinaryFile();
-  Bscript::BObjectImp* mf_CreateDirectory();
-  Bscript::BObjectImp* mf_ListDirectory();
-  Bscript::BObjectImp* mf_OpenXMLFile();
-  Bscript::BObjectImp* mf_CreateXMLFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_FileExists();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReadFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_WriteFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_AppendToFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_LogToFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenBinaryFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateDirectory();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListDirectory();
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenXMLFile();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateXMLFile();
 };
 
 Bscript::ExecutorModule* CreateFileAccessExecutorModule( Bscript::Executor& exec );

--- a/pol-core/pol/module/guildmod.h
+++ b/pol-core/pol/module/guildmod.h
@@ -33,13 +33,13 @@ class GuildExecutorModule : public Bscript::TmplExecutorModule<GuildExecutorModu
 public:
   GuildExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_ListGuilds();
-  Bscript::BObjectImp* mf_CreateGuild();
-  Bscript::BObjectImp* mf_FindGuild();
-  Bscript::BObjectImp* mf_DestroyGuild();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListGuilds();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateGuild();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindGuild();
+  [[nodiscard]] Bscript::BObjectImp* mf_DestroyGuild();
 
   static Bscript::BObjectImp* CreateGuildRefObjImp( Core::Guild* guild );
 };
-}
-}
+}  // namespace Module
+}  // namespace Pol
 #endif

--- a/pol-core/pol/module/httpmod.h
+++ b/pol-core/pol/module/httpmod.h
@@ -9,8 +9,8 @@
 
 #include <string>
 
-#include "../polmodl.h"
 #include "../../clib/network/wnsckt.h"
+#include "../polmodl.h"
 
 namespace Pol
 {
@@ -34,10 +34,10 @@ class HttpExecutorModule : public Bscript::TmplExecutorModule<HttpExecutorModule
 public:
   HttpExecutorModule( Bscript::Executor& exec, Clib::Socket&& isck );
 
-  Bscript::BObjectImp* mf_WriteHtml();
-  Bscript::BObjectImp* mf_WriteHtmlRaw();
-  Bscript::BObjectImp* mf_QueryParam();
-  Bscript::BObjectImp* mf_QueryIP();
+  [[nodiscard]] Bscript::BObjectImp* mf_WriteHtml();
+  [[nodiscard]] Bscript::BObjectImp* mf_WriteHtmlRaw();
+  [[nodiscard]] Bscript::BObjectImp* mf_QueryParam();
+  [[nodiscard]] Bscript::BObjectImp* mf_QueryIP();
 
   void read_query_string( const std::string& query_string );
   void read_query_ip();

--- a/pol-core/pol/module/mathmod.h
+++ b/pol-core/pol/module/mathmod.h
@@ -29,32 +29,32 @@ class MathExecutorModule
 public:
   MathExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_Sin();
-  Bscript::BObjectImp* mf_ASin();
-  Bscript::BObjectImp* mf_Cos();
-  Bscript::BObjectImp* mf_ACos();
-  Bscript::BObjectImp* mf_Tan();
-  Bscript::BObjectImp* mf_ATan();
+  [[nodiscard]] Bscript::BObjectImp* mf_Sin();
+  [[nodiscard]] Bscript::BObjectImp* mf_ASin();
+  [[nodiscard]] Bscript::BObjectImp* mf_Cos();
+  [[nodiscard]] Bscript::BObjectImp* mf_ACos();
+  [[nodiscard]] Bscript::BObjectImp* mf_Tan();
+  [[nodiscard]] Bscript::BObjectImp* mf_ATan();
 
-  Bscript::BObjectImp* mf_Min();
-  Bscript::BObjectImp* mf_Max();
-  Bscript::BObjectImp* mf_Pow();
-  Bscript::BObjectImp* mf_Sqrt();
-  Bscript::BObjectImp* mf_Root();
-  Bscript::BObjectImp* mf_Abs();
-  Bscript::BObjectImp* mf_Log10();
-  Bscript::BObjectImp* mf_LogE();
+  [[nodiscard]] Bscript::BObjectImp* mf_Min();
+  [[nodiscard]] Bscript::BObjectImp* mf_Max();
+  [[nodiscard]] Bscript::BObjectImp* mf_Pow();
+  [[nodiscard]] Bscript::BObjectImp* mf_Sqrt();
+  [[nodiscard]] Bscript::BObjectImp* mf_Root();
+  [[nodiscard]] Bscript::BObjectImp* mf_Abs();
+  [[nodiscard]] Bscript::BObjectImp* mf_Log10();
+  [[nodiscard]] Bscript::BObjectImp* mf_LogE();
 
-  Bscript::BObjectImp* mf_ConstPi();
-  Bscript::BObjectImp* mf_ConstE();
+  [[nodiscard]] Bscript::BObjectImp* mf_ConstPi();
+  [[nodiscard]] Bscript::BObjectImp* mf_ConstE();
 
-  Bscript::BObjectImp* mf_FormatRealToString();
+  [[nodiscard]] Bscript::BObjectImp* mf_FormatRealToString();
 
-  Bscript::BObjectImp* mf_RadToDeg();
-  Bscript::BObjectImp* mf_DegToRad();
+  [[nodiscard]] Bscript::BObjectImp* mf_RadToDeg();
+  [[nodiscard]] Bscript::BObjectImp* mf_DegToRad();
 
-  Bscript::BObjectImp* mf_Ceil();
-  Bscript::BObjectImp* mf_Floor();
+  [[nodiscard]] Bscript::BObjectImp* mf_Ceil();
+  [[nodiscard]] Bscript::BObjectImp* mf_Floor();
 };
 }  // namespace Module
 }  // namespace Pol

--- a/pol-core/pol/module/npcmod.h
+++ b/pol-core/pol/module/npcmod.h
@@ -12,8 +12,8 @@
 
 #include <string>
 
-#include "../polmodl.h"
 #include "../../plib/uconst.h"
+#include "../polmodl.h"
 #include "../reftypes.h"
 
 namespace Pol
@@ -47,44 +47,47 @@ public:
   NPCExecutorModule( Bscript::Executor& ex, Mobile::NPC& npc );
   virtual ~NPCExecutorModule();
 
-  Core::NpcRef npcref;
-  Mobile::NPC& npc;
+  const Mobile::NPC& controlled_npc() const;
 
-  Bscript::BObjectImp* mf_Wander();
-  Bscript::BObjectImp* mf_Self();
-  Bscript::BObjectImp* mf_Face();
-  Bscript::BObjectImp* mf_Move();
-  Bscript::BObjectImp* mf_WalkToward();
-  Bscript::BObjectImp* mf_RunToward();
-  Bscript::BObjectImp* mf_WalkAwayFrom();
-  Bscript::BObjectImp* mf_RunAwayFrom();
-  Bscript::BObjectImp* mf_TurnToward();
-  Bscript::BObjectImp* mf_TurnAwayFrom();
-
-  Bscript::BObjectImp* mf_WalkTowardLocation();
-  Bscript::BObjectImp* mf_RunTowardLocation();
-  Bscript::BObjectImp* mf_WalkAwayFromLocation();
-  Bscript::BObjectImp* mf_RunAwayFromLocation();
-  Bscript::BObjectImp* mf_TurnTowardLocation();
-  Bscript::BObjectImp* mf_TurnAwayFromLocation();
-
-  Bscript::BObjectImp* mf_Say();
-  Bscript::BObjectImp* mf_SayUC();
-  Bscript::BObjectImp* mf_position();
-  Bscript::BObjectImp* mf_Facing();
-  Bscript::BObjectImp* mf_GetProperty( /* propertyname */ );
-  Bscript::BObjectImp* mf_SetProperty( /* propertyname propertyvalue */ );
-  Bscript::BObjectImp* mf_MakeBoundingBox( /* areastring */ );
-  Bscript::BObjectImp* mf_IsLegalMove();
-  Bscript::BObjectImp* mf_CanMove();
-  Bscript::BObjectImp* mf_CreateBackpack();
-  Bscript::BObjectImp* mf_CreateItem();
-  Bscript::BObjectImp* mf_SetOpponent();
-  Bscript::BObjectImp* mf_SetWarMode();
-  Bscript::BObjectImp* mf_SetAnchor();
+public:
+  [[nodiscard]] Bscript::BObjectImp* mf_Wander();
+  [[nodiscard]] Bscript::BObjectImp* mf_Self();
+  [[nodiscard]] Bscript::BObjectImp* mf_Face();
+  [[nodiscard]] Bscript::BObjectImp* mf_Move();
+  [[nodiscard]] Bscript::BObjectImp* mf_WalkToward();
+  [[nodiscard]] Bscript::BObjectImp* mf_RunToward();
+  [[nodiscard]] Bscript::BObjectImp* mf_WalkAwayFrom();
+  [[nodiscard]] Bscript::BObjectImp* mf_RunAwayFrom();
+  [[nodiscard]] Bscript::BObjectImp* mf_TurnToward();
+  [[nodiscard]] Bscript::BObjectImp* mf_TurnAwayFrom();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_WalkTowardLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_RunTowardLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_WalkAwayFromLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_RunAwayFromLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_TurnTowardLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_TurnAwayFromLocation();
+  
+  [[nodiscard]] Bscript::BObjectImp* mf_Say();
+  [[nodiscard]] Bscript::BObjectImp* mf_SayUC();
+  [[nodiscard]] Bscript::BObjectImp* mf_position();
+  [[nodiscard]] Bscript::BObjectImp* mf_Facing();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetProperty( /* propertyname */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetProperty( /* propertyname propertyvalue */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_MakeBoundingBox( /* areastring */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_IsLegalMove();
+  [[nodiscard]] Bscript::BObjectImp* mf_CanMove();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateBackpack();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetOpponent();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetWarMode();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetAnchor();
 
 protected:
   OSExecutorModule* os_module;
+
+  Core::NpcRef npcref;
+  Mobile::NPC& npc;
 
   Bscript::BObjectImp* move_self( Plib::UFACING facing, bool run, bool adjust_ok = false );
 
@@ -93,6 +96,12 @@ protected:
 private:
   bool _internal_move( Plib::UFACING facing, int run );
 };
+
+inline const Mobile::NPC& NPCExecutorModule::controlled_npc() const
+{
+  return const_cast<const Mobile::NPC&>( this->npc );
+}
+
 }  // namespace Module
 }  // namespace Pol
 #endif

--- a/pol-core/pol/module/osmod.cpp
+++ b/pol-core/pol/module/osmod.cpp
@@ -782,8 +782,9 @@ bool OSExecutorModule::signal_event( BObjectImp* imp )
           if ( em )
           {
             NPCExecutorModule* npcemod = static_cast<NPCExecutorModule*>( em );
-            INFO_PRINT << "NPC Serial: " << fmt::hexu( npcemod->npc.serial ) << " ("
-                       << npcemod->npc.x << " " << npcemod->npc.y << " " << npcemod->npc.z << ")\n";
+            INFO_PRINT << "NPC Serial: " << fmt::hexu( npcemod->controlled_npc().serial ) << " ("
+                       << npcemod->controlled_npc().x << " " << npcemod->controlled_npc().y << " "
+                       << npcemod->controlled_npc().z << ")\n";
           }
 
           INFO_PRINT << "Event: " << ob->getStringRep() << "\n";

--- a/pol-core/pol/module/osmod.h
+++ b/pol-core/pol/module/osmod.h
@@ -89,38 +89,36 @@ public:
   void in_hold_list( Core::HoldListType in_hold_list );
 
 
-  Bscript::BObjectImp* mf_Create_Debug_Context();
-  Bscript::BObjectImp* mf_GetPid();
-  Bscript::BObjectImp* mf_GetProcess();
-  Bscript::BObjectImp* mf_Sleep();
-  Bscript::BObjectImp* mf_Sleepms();
-  Bscript::BObjectImp* mf_Wait_For_Event();
-  Bscript::BObjectImp* mf_Events_Waiting();
-  Bscript::BObjectImp* mf_Set_Critical();
-  Bscript::BObjectImp* mf_Is_Critical();
+  [[nodiscard]] Bscript::BObjectImp* mf_Create_Debug_Context();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetPid();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetProcess();
+  [[nodiscard]] Bscript::BObjectImp* mf_Sleep();
+  [[nodiscard]] Bscript::BObjectImp* mf_Sleepms();
+  [[nodiscard]] Bscript::BObjectImp* mf_Wait_For_Event();
+  [[nodiscard]] Bscript::BObjectImp* mf_Events_Waiting();
+  [[nodiscard]] Bscript::BObjectImp* mf_Set_Critical();
+  [[nodiscard]] Bscript::BObjectImp* mf_Is_Critical();
 
-  Bscript::BObjectImp* mf_Start_Script();
-  Bscript::BObjectImp* mf_Start_Skill_Script();
-  Bscript::BObjectImp* mf_Run_Script_To_Completion();
-  Bscript::BObjectImp* mf_Run_Script();
-  Bscript::BObjectImp* mf_Set_Debug();
-  Bscript::BObjectImp* mf_SysLog();
-  Bscript::BObjectImp* mf_System_RPM();
-  Bscript::BObjectImp* mf_Set_Priority();
-  Bscript::BObjectImp* mf_Unload_Scripts();
-  Bscript::BObjectImp* mf_Set_Script_Option();
-  Bscript::BObjectImp* mf_Set_Event_Queue_Size();  // DAVE 11/24
-  Bscript::BObjectImp* mf_OpenURL();
-  Bscript::BObjectImp* mf_OpenConnection();
-  Bscript::BObjectImp* mf_Debugger();
-  Bscript::BObjectImp* mf_HTTPRequest();
+  [[nodiscard]] Bscript::BObjectImp* mf_Start_Script();
+  [[nodiscard]] Bscript::BObjectImp* mf_Start_Skill_Script();
+  [[nodiscard]] Bscript::BObjectImp* mf_Run_Script_To_Completion();
+  [[nodiscard]] Bscript::BObjectImp* mf_Run_Script();
+  [[nodiscard]] Bscript::BObjectImp* mf_Set_Debug();
+  [[nodiscard]] Bscript::BObjectImp* mf_SysLog();
+  [[nodiscard]] Bscript::BObjectImp* mf_Set_Priority();
+  [[nodiscard]] Bscript::BObjectImp* mf_Unload_Scripts();
+  [[nodiscard]] Bscript::BObjectImp* mf_Set_Script_Option();
+  [[nodiscard]] Bscript::BObjectImp* mf_Set_Event_Queue_Size();  // DAVE 11/24
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenURL();
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenConnection();
+  [[nodiscard]] Bscript::BObjectImp* mf_Debugger();
+  [[nodiscard]] Bscript::BObjectImp* mf_HTTPRequest();
 
-  Bscript::BObjectImp* mf_Clear_Event_Queue();  // DAVE
+  [[nodiscard]] Bscript::BObjectImp* mf_Clear_Event_Queue();  // DAVE
 
-  Bscript::BObjectImp* mf_PerformanceMeasure();
+  [[nodiscard]] Bscript::BObjectImp* mf_PerformanceMeasure();
 
 protected:
-
   bool critical_;
   unsigned char priority_;
   bool warn_on_runaway_;
@@ -130,7 +128,6 @@ protected:
   Core::TimeoutHandle hold_itr_;
   Core::HoldListType in_hold_list_;
   Core::WAIT_TYPE wait_type;
-
 
 
   unsigned int pid_;

--- a/pol-core/pol/module/partymod.h
+++ b/pol-core/pol/module/partymod.h
@@ -26,19 +26,18 @@ class Party;
 }
 namespace Module
 {
-
 class PartyExecutorModule : public Bscript::TmplExecutorModule<PartyExecutorModule, Core::PolModule>
 {
 public:
   PartyExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_CreateParty();
-  Bscript::BObjectImp* mf_DisbandParty();
-  Bscript::BObjectImp* mf_SendPartyMsg();
-  Bscript::BObjectImp* mf_SendPrivatePartyMsg();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateParty();
+  [[nodiscard]] Bscript::BObjectImp* mf_DisbandParty();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendPartyMsg();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendPrivatePartyMsg();
 };
 
 Bscript::BObjectImp* CreatePartyRefObjImp( Core::Party* party );
-}
-}
+}  // namespace Module
+}  // namespace Pol
 #endif

--- a/pol-core/pol/module/polsystemmod.h
+++ b/pol-core/pol/module/polsystemmod.h
@@ -60,24 +60,24 @@ class PolSystemExecutorModule
 public:
   PolSystemExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_IncRevision( /* uobject */ );
-  Bscript::BObjectImp* mf_Packages();
-  Bscript::BObjectImp* mf_GetCmdLevelName();
-  Bscript::BObjectImp* mf_GetCmdLevelNumber();
-  Bscript::BObjectImp* mf_GetPackageByName();
-  Bscript::BObjectImp* mf_ListTextCommands();
-  Bscript::BObjectImp* mf_Realms();
-  Bscript::BObjectImp* mf_ReloadConfiguration();
-  Bscript::BObjectImp* mf_ReadMillisecondClock();
-  Bscript::BObjectImp* mf_ListenPoints();
-  Bscript::BObjectImp* mf_SetSysTrayPopupText();
-  Bscript::BObjectImp* mf_GetItemDescriptor();
-  Bscript::BObjectImp* mf_CreatePacket();
-  Bscript::BObjectImp* mf_AddRealm( /*name,base*/ );
-  Bscript::BObjectImp* mf_DeleteRealm( /*name*/ );
-  Bscript::BObjectImp* mf_MD5Encrypt( /*string*/ );
-  Bscript::BObjectImp* mf_FormatItemDescription( /*string,amount,suffix*/ );
-  Bscript::BObjectImp* mf_LogCPropProfile();
+  [[nodiscard]] Bscript::BObjectImp* mf_IncRevision( /* uobject */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_Packages();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetCmdLevelName();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetCmdLevelNumber();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetPackageByName();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListTextCommands();
+  [[nodiscard]] Bscript::BObjectImp* mf_Realms();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReloadConfiguration();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReadMillisecondClock();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListenPoints();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetSysTrayPopupText();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetItemDescriptor();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreatePacket();
+  [[nodiscard]] Bscript::BObjectImp* mf_AddRealm( /*name,base*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_DeleteRealm( /*name*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_MD5Encrypt( /*string*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_FormatItemDescription( /*string,amount,suffix*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_LogCPropProfile();
 };
 }  // namespace Module
 }  // namespace Pol

--- a/pol-core/pol/module/sqlmod.h
+++ b/pol-core/pol/module/sqlmod.h
@@ -41,15 +41,15 @@ class SQLExecutorModule : public Bscript::TmplExecutorModule<SQLExecutorModule, 
 public:
   SQLExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_mysql_connect();
-  Bscript::BObjectImp* mf_mysql_query();
-  Bscript::BObjectImp* mf_mysql_close();
-  Bscript::BObjectImp* mf_mysql_num_fields();
-  Bscript::BObjectImp* mf_mysql_affected_rows();
-  Bscript::BObjectImp* mf_mysql_fetch_row();
-  Bscript::BObjectImp* mf_mysql_num_rows();
-  Bscript::BObjectImp* mf_mysql_select_db();
-  Bscript::BObjectImp* mf_mysql_field_name();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_connect();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_query();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_close();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_num_fields();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_affected_rows();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_fetch_row();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_num_rows();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_select_db();
+  [[nodiscard]] Bscript::BObjectImp* mf_mysql_field_name();
 
   static Bscript::BObjectImp* background_connect( weak_ptr<Core::UOExecutor> uoexec,
                                                   const std::string host,

--- a/pol-core/pol/module/storagemod.h
+++ b/pol-core/pol/module/storagemod.h
@@ -31,13 +31,13 @@ class StorageExecutorModule
 public:
   StorageExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_StorageAreas();
-  Bscript::BObjectImp* mf_DestroyRootItemInStorageArea();
-  Bscript::BObjectImp* mf_FindStorageArea();
-  Bscript::BObjectImp* mf_CreateStorageArea();
-  Bscript::BObjectImp* mf_FindRootItemInStorageArea();
-  Bscript::BObjectImp* mf_CreateRootItemInStorageArea();
+  [[nodiscard]] Bscript::BObjectImp* mf_StorageAreas();
+  [[nodiscard]] Bscript::BObjectImp* mf_DestroyRootItemInStorageArea();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindStorageArea();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateStorageArea();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindRootItemInStorageArea();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateRootItemInStorageArea();
 };
-}
-}
+}  // namespace Module
+}  // namespace Pol
 #endif

--- a/pol-core/pol/module/unimod.h
+++ b/pol-core/pol/module/unimod.h
@@ -52,14 +52,16 @@ public:
   explicit UnicodeExecutorModule( Core::UOExecutor& exec );
   ~UnicodeExecutorModule();
 
-  Bscript::BObjectImp* mf_PrintTextAboveUC();         // OverObject, Text, Font, Color
-  Bscript::BObjectImp* mf_PrintTextAbovePrivateUC();  // OverObject, Text, ToChar, Font, Color
+  [[nodiscard]] Bscript::BObjectImp* mf_PrintTextAboveUC();  // OverObject, Text, Font, Color
+  [[nodiscard]] Bscript::BObjectImp*
+  mf_PrintTextAbovePrivateUC();  // OverObject, Text, ToChar, Font, Color
 
-  Bscript::BObjectImp* mf_BroadcastUC();       // Text
-  Bscript::BObjectImp* mf_SendSysMessageUC();  // Character, Text
+  [[nodiscard]] Bscript::BObjectImp* mf_BroadcastUC();       // Text
+  [[nodiscard]] Bscript::BObjectImp* mf_SendSysMessageUC();  // Character, Text
 
-  Bscript::BObjectImp* mf_RequestInputUC();       // ToChar, Item, TextPrompt
-  Bscript::BObjectImp* mf_SendTextEntryGumpUC();  // ToChar, Text1, Cancel, Style, MaxLen, Text2
+  [[nodiscard]] Bscript::BObjectImp* mf_RequestInputUC();  // ToChar, Item, TextPrompt
+  [[nodiscard]] Bscript::BObjectImp*
+  mf_SendTextEntryGumpUC();  // ToChar, Text1, Cancel, Style, MaxLen, Text2
 
   Mobile::Character* prompt_chr;
 

--- a/pol-core/pol/module/uomod.h
+++ b/pol-core/pol/module/uomod.h
@@ -74,221 +74,231 @@ namespace Module
 class UOExecutorModule : public Bscript::TmplExecutorModule<UOExecutorModule, Core::PolModule>
 {
 public:
-  Bscript::BObjectImp* mf_SendStatus( /* mob */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendStatus( /* mob */ );
 
-  Bscript::BObjectImp* mf_MoveObjectToLocation();
-  Bscript::BObjectImp* mf_SendCharacterRaceChanger( /* Character */ );
-  Bscript::BObjectImp* mf_SendHousingTool();
-  Bscript::BObjectImp* mf_SendOpenBook();
-  Bscript::BObjectImp* mf_SelectColor();
-  Bscript::BObjectImp* mf_AddAmount();
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveObjectToLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendCharacterRaceChanger( /* Character */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendHousingTool();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendOpenBook();
+  [[nodiscard]] Bscript::BObjectImp* mf_SelectColor();
+  [[nodiscard]] Bscript::BObjectImp* mf_AddAmount();
 
-  Bscript::BObjectImp* mf_SendViewContainer();
-  Bscript::BObjectImp* mf_GetObjPropertyNames();
-  Bscript::BObjectImp* mf_CreateItemCopyAtLocation( /* x,y,z,item */ );
-  Bscript::BObjectImp* mf_SendInstaResDialog();
-  Bscript::BObjectImp* mf_FindAccount();
-  Bscript::BObjectImp* mf_ListAccounts();
-  Bscript::BObjectImp* mf_SendStringAsTipWindow();
-  Bscript::BObjectImp* mf_GetCommandHelp();
-  Bscript::BObjectImp* mf_PlaySoundEffectPrivate();
-  Bscript::BObjectImp* mf_ConsumeSubstance();
-  Bscript::BObjectImp* mf_FindSubstance();
-  Bscript::BObjectImp* mf_Shutdown();
-  Bscript::BObjectImp* mf_OpenPaperdoll();
-  Bscript::BObjectImp* mf_SendSkillWindow();
-  Bscript::BObjectImp* mf_ReserveItem();
-  Bscript::BObjectImp* mf_ReleaseItem();
-  Bscript::BObjectImp* mf_GetStandingHeight();
-  Bscript::BObjectImp* mf_GetStandingLayers( /* x, y, flags, realm */ );
-  Bscript::BObjectImp* mf_AssignRectToWeatherRegion();
-  Bscript::BObjectImp* mf_SetRegionWeatherLevel();
-  Bscript::BObjectImp* mf_CreateAccount();
-  Bscript::BObjectImp* mf_SetScriptController();
-  Bscript::BObjectImp* mf_POLCore();
-  Bscript::BObjectImp* mf_GetWorldHeight();
-  Bscript::BObjectImp* mf_StartSpellEffect();
-  Bscript::BObjectImp* mf_GetSpellDifficulty();
-  Bscript::BObjectImp* mf_SpeakPowerWords();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendViewContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetObjPropertyNames();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItemCopyAtLocation( /* x,y,z,item */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendInstaResDialog();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindAccount();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListAccounts();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendStringAsTipWindow();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetCommandHelp();
+  [[nodiscard]] Bscript::BObjectImp* mf_PlaySoundEffectPrivate();
+  [[nodiscard]] Bscript::BObjectImp* mf_ConsumeSubstance();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindSubstance();
+  [[nodiscard]] Bscript::BObjectImp* mf_Shutdown();
+  [[nodiscard]] Bscript::BObjectImp* mf_OpenPaperdoll();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendSkillWindow();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReserveItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReleaseItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetStandingHeight();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetStandingLayers( /* x, y, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_AssignRectToWeatherRegion();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetRegionWeatherLevel();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateAccount();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetScriptController();
+  [[nodiscard]] Bscript::BObjectImp* mf_POLCore();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetWorldHeight();
+  [[nodiscard]] Bscript::BObjectImp* mf_StartSpellEffect();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetSpellDifficulty();
+  [[nodiscard]] Bscript::BObjectImp* mf_SpeakPowerWords();
 
-  Bscript::BObjectImp* mf_GetMultiDimensions();
-  Bscript::BObjectImp* mf_DestroyMulti();
-  Bscript::BObjectImp* mf_SendTextEntryGump();
-  Bscript::BObjectImp* mf_SendDialogGump();
-  Bscript::BObjectImp* mf_CloseGump();
-  Bscript::BObjectImp* mf_CloseWindow( /* chr, type, who */ );
-  Bscript::BObjectImp* mf_SendEvent();
-  Bscript::BObjectImp* mf_PlayMovingEffectXYZ();
-  Bscript::BObjectImp* mf_GetEquipmentByLayer();
-  Bscript::BObjectImp* mf_GetObjtypeByName();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetMultiDimensions();
+  [[nodiscard]] Bscript::BObjectImp* mf_DestroyMulti();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendTextEntryGump();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendDialogGump();
+  [[nodiscard]] Bscript::BObjectImp* mf_CloseGump();
+  [[nodiscard]] Bscript::BObjectImp* mf_CloseWindow( /* chr, type, who */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendEvent();
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayMovingEffectXYZ();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetEquipmentByLayer();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetObjtypeByName();
 
-  Bscript::BObjectImp* mf_ListHostiles();
-  Bscript::BObjectImp* mf_DisconnectClient();
-  Bscript::BObjectImp* mf_GetRegionName( /* objref */ );
-  Bscript::BObjectImp* mf_GetRegionNameAtLocation( /* x, y, realm */ );
-  Bscript::BObjectImp* mf_GetRegionString();
-  Bscript::BObjectImp* mf_GetRegionLightLevelAtLocation( /* x, y, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListHostiles();
+  [[nodiscard]] Bscript::BObjectImp* mf_DisconnectClient();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetRegionName( /* objref */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetRegionNameAtLocation( /* x, y, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetRegionString();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetRegionLightLevelAtLocation( /* x, y, realm */ );
 
-  Bscript::BObjectImp* mf_PlayStationaryEffect();
-  Bscript::BObjectImp* mf_GetMapInfo();
-  Bscript::BObjectImp* mf_ListObjectsInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
-  Bscript::BObjectImp* mf_ListItemsInBoxOfObjType( /* objtype, x1, y1, z1, x2, y2, z2, realm */ );
-  Bscript::BObjectImp* mf_ListObjectsInBoxOfClass( /* POL_Class, x1, y1, z1, x2, y2, z2, realm */ );
-  Bscript::BObjectImp* mf_ListMobilesInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
-  Bscript::BObjectImp* mf_ListMultisInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
-  Bscript::BObjectImp* mf_ListStaticsInBox( /* x1, y1, z1, x2, y2, z2, flags, realm */ );
-  Bscript::BObjectImp* mf_ListEquippedItems();
-  Bscript::BObjectImp* mf_ConsumeReagents();
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayStationaryEffect();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetMapInfo();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListObjectsInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListItemsInBoxOfObjType(
+      /* objtype, x1, y1, z1, x2, y2, z2, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListObjectsInBoxOfClass(
+      /* POL_Class, x1, y1, z1, x2, y2, z2, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListMobilesInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListMultisInBox( /* x1, y1, z1, x2, y2, z2, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListStaticsInBox(
+      /* x1, y1, z1, x2, y2, z2, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListEquippedItems();
+  [[nodiscard]] Bscript::BObjectImp* mf_ConsumeReagents();
 
-  Bscript::BObjectImp* mf_SendPacket();
-  Bscript::BObjectImp* mf_SendQuestArrow();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendPacket();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendQuestArrow();
 
-  Bscript::BObjectImp* mf_RequestInput();
+  [[nodiscard]] Bscript::BObjectImp* mf_RequestInput();
 
-  Bscript::BObjectImp* mf_ReadGameClock();
+  [[nodiscard]] Bscript::BObjectImp* mf_ReadGameClock();
 
-  Bscript::BObjectImp* mf_GrantPrivilege();
-  Bscript::BObjectImp* mf_RevokePrivilege();
+  [[nodiscard]] Bscript::BObjectImp* mf_GrantPrivilege();
+  [[nodiscard]] Bscript::BObjectImp* mf_RevokePrivilege();
 
-  Bscript::BObjectImp* mf_EquipFromTemplate();
+  [[nodiscard]] Bscript::BObjectImp* mf_EquipFromTemplate();
 
-  Bscript::BObjectImp* mf_GetHarvestDifficulty();
-  Bscript::BObjectImp* mf_HarvestResource();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetHarvestDifficulty();
+  [[nodiscard]] Bscript::BObjectImp* mf_HarvestResource();
 
-  Bscript::BObjectImp* mf_RestartScript();
-  Bscript::BObjectImp* mf_EnableEvents();
-  Bscript::BObjectImp* mf_DisableEvents();
-  Bscript::BObjectImp* mf_EquipItem();
-  Bscript::BObjectImp* mf_MoveItemToContainer();
-  Bscript::BObjectImp* mf_MoveItemToSecureTradeWin( /* item, character */ );
-  Bscript::BObjectImp* mf_FindObjtypeInContainer();
-  Bscript::BObjectImp* mf_SendOpenSpecialContainer();
-  Bscript::BObjectImp* mf_SecureTradeWin( /* who, who2 */ );
-  Bscript::BObjectImp* mf_CloseTradeWindow();
+  [[nodiscard]] Bscript::BObjectImp* mf_RestartScript();
+  [[nodiscard]] Bscript::BObjectImp* mf_EnableEvents();
+  [[nodiscard]] Bscript::BObjectImp* mf_DisableEvents();
+  [[nodiscard]] Bscript::BObjectImp* mf_EquipItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveItemToContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_MoveItemToSecureTradeWin( /* item, character */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_FindObjtypeInContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendOpenSpecialContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_SecureTradeWin( /* who, who2 */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_CloseTradeWindow();
 
 
-  Bscript::BObjectImp* mf_SendBuyWindow( /* character, container, vendor, items, flags */ );
-  Bscript::BObjectImp* mf_SendSellWindow( /* character, vendor, i1, i2, i3, flags */ );
-  Bscript::BObjectImp* mf_ListMobilesNearLocationEx( /* x, y, z, range, flags, realm */ );
-  Bscript::BObjectImp* mf_CreateItemInContainer();
-  Bscript::BObjectImp* mf_CreateItemInInventory();
-  Bscript::BObjectImp* mf_SystemFindObjectBySerial();
-  Bscript::BObjectImp* mf_ListItemsNearLocationOfType();
-  Bscript::BObjectImp* mf_ListGhostsNearLocation();
-  Bscript::BObjectImp* mf_ListMobilesInLineOfSight();
-  Bscript::BObjectImp* mf_Distance();
-  Bscript::BObjectImp* mf_DistanceEuclidean();
-  Bscript::BObjectImp* mf_CoordinateDistance();
-  Bscript::BObjectImp* mf_CoordinateDistanceEuclidean();
-  Bscript::BObjectImp* mf_GetCoordsInLine();
-  Bscript::BObjectImp* mf_GetFacing();
-  Bscript::BObjectImp* mf_SetRegionLightLevel();
-  Bscript::BObjectImp* mf_EraseObjProperty();
-  Bscript::BObjectImp* mf_GetGlobalProperty();
-  Bscript::BObjectImp* mf_SetGlobalProperty();
-  Bscript::BObjectImp* mf_EraseGlobalProperty();
-  Bscript::BObjectImp* mf_GetGlobalPropertyNames();
-  Bscript::BObjectImp* mf_SaveWorldState();
-  Bscript::BObjectImp* mf_CreateMultiAtLocation();
-  Bscript::BObjectImp* mf_TargetMultiPlacement();
+  [[nodiscard]] Bscript::BObjectImp* mf_SendBuyWindow(
+      /* character, container, vendor, items, flags */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendSellWindow(
+      /* character, vendor, i1, i2, i3, flags */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListMobilesNearLocationEx(
+      /* x, y, z, range, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItemInContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItemInInventory();
+  [[nodiscard]] Bscript::BObjectImp* mf_SystemFindObjectBySerial();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListItemsNearLocationOfType();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListGhostsNearLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListMobilesInLineOfSight();
+  [[nodiscard]] Bscript::BObjectImp* mf_Distance();
+  [[nodiscard]] Bscript::BObjectImp* mf_DistanceEuclidean();
+  [[nodiscard]] Bscript::BObjectImp* mf_CoordinateDistance();
+  [[nodiscard]] Bscript::BObjectImp* mf_CoordinateDistanceEuclidean();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetCoordsInLine();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetFacing();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetRegionLightLevel();
+  [[nodiscard]] Bscript::BObjectImp* mf_EraseObjProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetGlobalProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetGlobalProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_EraseGlobalProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetGlobalPropertyNames();
+  [[nodiscard]] Bscript::BObjectImp* mf_SaveWorldState();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateMultiAtLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_TargetMultiPlacement();
 
-  Bscript::BObjectImp* mf_Resurrect();
-  Bscript::BObjectImp* mf_CreateNpcFromTemplate();
-  Bscript::BObjectImp* mf_RegisterForSpeechEvents();
-  Bscript::BObjectImp* mf_EnumerateOnlineCharacters();
-  Bscript::BObjectImp* mf_PrintTextAbove();
-  Bscript::BObjectImp* mf_PrintTextAbovePrivate();
+  [[nodiscard]] Bscript::BObjectImp* mf_Resurrect();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateNpcFromTemplate();
+  [[nodiscard]] Bscript::BObjectImp* mf_RegisterForSpeechEvents();
+  [[nodiscard]] Bscript::BObjectImp* mf_EnumerateOnlineCharacters();
+  [[nodiscard]] Bscript::BObjectImp* mf_PrintTextAbove();
+  [[nodiscard]] Bscript::BObjectImp* mf_PrintTextAbovePrivate();
 
-  Bscript::BObjectImp* mf_Attach( /* Character */ );
-  Bscript::BObjectImp* mf_Detach();
+  [[nodiscard]] Bscript::BObjectImp* mf_Attach( /* Character */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_Detach();
 
-  Bscript::BObjectImp* mf_Broadcast();
+  [[nodiscard]] Bscript::BObjectImp* mf_Broadcast();
 
   Bscript::BObjectImp* send_open_special_container();
   Bscript::BObjectImp* create_item_in_container();
   Bscript::BObjectImp* find_objtype_in_container();
 
-  Bscript::BObjectImp* mf_Accessible();       // Character, Item
-  Bscript::BObjectImp* mf_ApplyConstraint();  // ObjArray, ConfigFile, propname, minvalue
+  [[nodiscard]] Bscript::BObjectImp* mf_Accessible();  // Character, Item
+  [[nodiscard]] Bscript::BObjectImp*
+  mf_ApplyConstraint();  // ObjArray, ConfigFile, propname, minvalue
 
-  Bscript::BObjectImp* mf_CheckLineOfSight();  // Character, Object
-  Bscript::BObjectImp* mf_CheckLosAt();
-  Bscript::BObjectImp* mf_CreateItemInBackpack();  // Character, ObjectType, Amount
+  [[nodiscard]] Bscript::BObjectImp* mf_CheckLineOfSight();  // Character, Object
+  [[nodiscard]] Bscript::BObjectImp* mf_CheckLosAt();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItemInBackpack();  // Character, ObjectType, Amount
 
-  Bscript::BObjectImp* mf_CreateItemAtLocation( /* x,y,z,objtype,amount */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateItemAtLocation( /* x,y,z,objtype,amount */ );
 
-  Bscript::BObjectImp* mf_DestroyItem();
-  Bscript::BObjectImp* mf_FindPath();         // x1, y1, z1, x2, y2, z2
-  Bscript::BObjectImp* mf_GetAmount();        // Item
-  Bscript::BObjectImp* mf_GetMenuObjTypes();  // MenuName
-  Bscript::BObjectImp* mf_GetObjProperty();
-  Bscript::BObjectImp* mf_GetObjType();  // Item
-  Bscript::BObjectImp* mf_GetPosition();
-  Bscript::BObjectImp* mf_GetStats();
-  Bscript::BObjectImp* mf_GetStatus();
+  [[nodiscard]] Bscript::BObjectImp* mf_DestroyItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_FindPath();         // x1, y1, z1, x2, y2, z2
+  [[nodiscard]] Bscript::BObjectImp* mf_GetAmount();        // Item
+  [[nodiscard]] Bscript::BObjectImp* mf_GetMenuObjTypes();  // MenuName
+  [[nodiscard]] Bscript::BObjectImp* mf_GetObjProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetObjType();  // Item
+  [[nodiscard]] Bscript::BObjectImp* mf_GetPosition();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetStats();
+  [[nodiscard]] Bscript::BObjectImp* mf_GetStatus();
 
-  Bscript::BObjectImp* mf_ListItemsAtLocation();  // x,y,z
-  Bscript::BObjectImp* mf_ListMobilesNearLocation( /* x, y, z, range, realm */ );
-  Bscript::BObjectImp* mf_ListItemsNearLocationWithFlag();  // DAVE - flag is a tiledata.mul flag
-  Bscript::BObjectImp* mf_ListStaticsAtLocation( /* x, y, flags, realm */ );
-  Bscript::BObjectImp* mf_ListStaticsNearLocation( /* x, y, range, flags, realm */ );
-  Bscript::BObjectImp* mf_ListOfflineMobilesInRealm( /*realm*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListItemsAtLocation();  // x,y,z
+  [[nodiscard]] Bscript::BObjectImp* mf_ListMobilesNearLocation( /* x, y, z, range, realm */ );
+  [[nodiscard]] Bscript::BObjectImp*
+  mf_ListItemsNearLocationWithFlag();  // DAVE - flag is a tiledata.mul flag
+  [[nodiscard]] Bscript::BObjectImp* mf_ListStaticsAtLocation( /* x, y, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListStaticsNearLocation( /* x, y, range, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListOfflineMobilesInRealm( /*realm*/ );
 
-  Bscript::BObjectImp* mf_PerformAction();  // character, action
-  Bscript::BObjectImp* mf_PlayAnimation();
-  Bscript::BObjectImp* mf_PlayLightningBoltEffect();  // center
-  Bscript::BObjectImp* mf_PlayMovingEffect();         // src dst effect speed loop explode
-  Bscript::BObjectImp* mf_PlayObjectCenteredEffect();
-  Bscript::BObjectImp* mf_PlaySoundEffect();
-  Bscript::BObjectImp* mf_Range();  // Object, Object
-  Bscript::BObjectImp* mf_SetName();
-  Bscript::BObjectImp* mf_SetObjProperty();
+  [[nodiscard]] Bscript::BObjectImp* mf_PerformAction();  // character, action
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayAnimation();
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayLightningBoltEffect();  // center
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayMovingEffect();  // src dst effect speed loop explode
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayObjectCenteredEffect();
+  [[nodiscard]] Bscript::BObjectImp* mf_PlaySoundEffect();
+  [[nodiscard]] Bscript::BObjectImp* mf_Range();  // Object, Object
+  [[nodiscard]] Bscript::BObjectImp* mf_SetName();
+  [[nodiscard]] Bscript::BObjectImp* mf_SetObjProperty();
 
-  Bscript::BObjectImp* mf_SelectMenuItem2();  // character, menuname
-  Bscript::BObjectImp* mf_SendSysMessage();   // Character, Text
-  Bscript::BObjectImp* mf_SubtractAmount();   // Item, Amount
-  Bscript::BObjectImp* mf_Target();           // Character to choose
-  Bscript::BObjectImp* mf_CancelTarget();     // Character to cancel for
+  [[nodiscard]] Bscript::BObjectImp* mf_SelectMenuItem2();  // character, menuname
+  [[nodiscard]] Bscript::BObjectImp* mf_SendSysMessage();   // Character, Text
+  [[nodiscard]] Bscript::BObjectImp* mf_SubtractAmount();   // Item, Amount
+  [[nodiscard]] Bscript::BObjectImp* mf_Target();           // Character to choose
+  [[nodiscard]] Bscript::BObjectImp* mf_CancelTarget();     // Character to cancel for
 
-  Bscript::BObjectImp* mf_ListItemsNearLocation();
-  Bscript::BObjectImp* mf_EnumerateItemsInContainer();
-  Bscript::BObjectImp* mf_TargetCoordinates();
+  [[nodiscard]] Bscript::BObjectImp* mf_ListItemsNearLocation();
+  [[nodiscard]] Bscript::BObjectImp* mf_EnumerateItemsInContainer();
+  [[nodiscard]] Bscript::BObjectImp* mf_TargetCoordinates();
 
-  Bscript::BObjectImp* mf_CreateMenu();
-  Bscript::BObjectImp* mf_AddMenuItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_CreateMenu();
+  [[nodiscard]] Bscript::BObjectImp* mf_AddMenuItem();
 
-  Bscript::BObjectImp* mf_UseItem();
+  [[nodiscard]] Bscript::BObjectImp* mf_UseItem();
 
-  Bscript::BObjectImp* mf_IsStackable();  // item1, item2
+  [[nodiscard]] Bscript::BObjectImp* mf_IsStackable();  // item1, item2
 
-  Bscript::BObjectImp* mf_PlayMovingEffectEx(
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayMovingEffectEx(
       /*src,dst,effect,speed,duration,hue,render,direction,explode,effect3d*/ );
-  Bscript::BObjectImp* mf_PlayMovingEffectXYZEx(
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayMovingEffectXYZEx(
       /*sx,sy,sz,dx,dy,dz,realm,effect,speed,duration,hue,render,direction,explode,effect3d*/ );
-  Bscript::BObjectImp* mf_PlayObjectCenteredEffectEx(
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayObjectCenteredEffectEx(
       /*src,effect,speed,duration,hue,render,layer,explode,effect3d*/ );
-  Bscript::BObjectImp* mf_PlayStationaryEffectEx(
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayStationaryEffectEx(
       /*x,y,z,realm,effect,speed,duration,hue,render,layer,explode,effect3d*/ );
 
-  Bscript::BObjectImp* mf_UpdateMobile( /*mob*/ );
-  Bscript::BObjectImp* mf_UpdateItem( /*item*/ );
-  Bscript::BObjectImp* mf_CheckLosBetween( /*x1,y1,z1,x2,y2,z2,realm*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_UpdateMobile( /*mob*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_UpdateItem( /*item*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_CheckLosBetween( /*x1,y1,z1,x2,y2,z2,realm*/ );
 
-  Bscript::BObjectImp* mf_PlaySoundEffectXYZ( /*x,y,z,effect,realm*/ );
-  Bscript::BObjectImp* mf_PlayMusic( /*char, musicid*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_PlaySoundEffectXYZ( /*x,y,z,effect,realm*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_PlayMusic( /*char, musicid*/ );
 
-  Bscript::BObjectImp* mf_CanWalk( /*movemode, x1, y1, z1, x2_or_dir, y2 := -1, realm := DEF*/ );
-  Bscript::BObjectImp* mf_SendCharProfile(
+  [[nodiscard]] Bscript::BObjectImp* mf_CanWalk(
+      /*movemode, x1, y1, z1, x2_or_dir, y2 := -1, realm := DEF*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendCharProfile(
       /*chr, of_who, title, uneditable_text := array, editable_text := array*/ );
-  Bscript::BObjectImp* mf_SendOverallSeason( /*season_id, playsound := 1*/ );
-  Bscript::BObjectImp* mf_GetMidpointCircleCoords( /* xcenter, ycenter, radius */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendOverallSeason( /*season_id, playsound := 1*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetMidpointCircleCoords( /* xcenter, ycenter, radius */ );
 
-  Bscript::BObjectImp* mf_SendPopUpMenu( /* to_whom, above, menu */ );
-  Bscript::BObjectImp* mf_SingleClick( /*who, what*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SendPopUpMenu( /* to_whom, above, menu */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SingleClick( /*who, what*/ );
 
-  Bscript::BObjectImp* mf_ListStaticsNearLocationOfType(
+  [[nodiscard]] Bscript::BObjectImp* mf_ListStaticsNearLocationOfType(
       /* x, y, z, range, objtype, flags, realm */ );
-  Bscript::BObjectImp* mf_ListStaticsNearLocationWithFlag( /* x, y, z, range, flags, realm */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ListStaticsNearLocationWithFlag(
+      /* x, y, z, range, flags, realm */ );
 
   /* If we're asking a character for a target, who is it?
      that character's target_cursor_ex points to us,

--- a/pol-core/pol/module/utilmod.h
+++ b/pol-core/pol/module/utilmod.h
@@ -29,11 +29,11 @@ class UtilExecutorModule
 public:
   UtilExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_RandomInt();
-  Bscript::BObjectImp* mf_RandomFloat();
-  Bscript::BObjectImp* mf_RandomDiceRoll();
-  Bscript::BObjectImp* mf_StrFormatTime();
-  Bscript::BObjectImp* mf_RandomIntMinMax();
+  [[nodiscard]] Bscript::BObjectImp* mf_RandomInt();
+  [[nodiscard]] Bscript::BObjectImp* mf_RandomFloat();
+  [[nodiscard]] Bscript::BObjectImp* mf_RandomDiceRoll();
+  [[nodiscard]] Bscript::BObjectImp* mf_StrFormatTime();
+  [[nodiscard]] Bscript::BObjectImp* mf_RandomIntMinMax();
 };
 }  // namespace Module
 }  // namespace Pol

--- a/pol-core/pol/module/vitalmod.h
+++ b/pol-core/pol/module/vitalmod.h
@@ -40,25 +40,23 @@ class VitalExecutorModule : public Bscript::TmplExecutorModule<VitalExecutorModu
 public:
   VitalExecutorModule( Bscript::Executor& exec );
 
-  Bscript::BObjectImp* mf_ApplyRawDamage();
-  Bscript::BObjectImp* mf_ApplyDamage();
+  [[nodiscard]] Bscript::BObjectImp* mf_ApplyRawDamage();
+  [[nodiscard]] Bscript::BObjectImp* mf_ApplyDamage();
 
-  Bscript::BObjectImp* mf_HealDamage();
+  [[nodiscard]] Bscript::BObjectImp* mf_HealDamage();
 
-  Bscript::BObjectImp* mf_ConsumeMana();
+  [[nodiscard]] Bscript::BObjectImp* mf_ConsumeMana();
 
-  Bscript::BObjectImp* mf_ConsumeVital( /* mob, vital, hundredths */ );
-  Bscript::BObjectImp* mf_RecalcVitals( /* mob, attributes, vitals */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_ConsumeVital( /* mob, vital, hundredths */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_RecalcVitals( /* mob, attributes, vitals */ );
 
-  Bscript::BObjectImp* mf_GetVitalName( /*alias_name*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetVitalName( /*alias_name*/ );
 
-  Bscript::BObjectImp* mf_GetVital( /* mob, vitalid */ );
-  Bscript::BObjectImp* mf_GetVitalMaximumValue( /* mob, vitalid */ );
-  Bscript::BObjectImp* mf_GetVitalRegenRate( /* mob, vitalid */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetVital( /* mob, vitalid */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetVitalMaximumValue( /* mob, vitalid */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetVitalRegenRate( /* mob, vitalid */ );
 
-  Bscript::BObjectImp* mf_SetVitalMaximumValue( /* mob, vitalid, value */ );
-  Bscript::BObjectImp* mf_SetVital( /* mob, vitalid, value */ );
-  Bscript::BObjectImp* mf_SetVitalRegenRate( /* mob, vitalid, rate */ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetVital( /* mob, vitalid, value */ );
 
 private:
   Mobile::Character* GetUOController();
@@ -73,6 +71,6 @@ inline Mobile::Character* VitalExecutorModule::GetUOController()
   else
     return nullptr;
 }
-}
-}
+}  // namespace Module
+}  // namespace Pol
 #endif


### PR DESCRIPTION
1) Made all module methods [[nodiscard]]. Glad to report no leaks were found. We should add the same to BObjects.

2) Protected members of NPCExecutorModule (were public before).
3) Added NPCExecutorModule::controlled_npc() so that osmod can access the npc's name and position.

4) Removed declarations for undefined functions:
- attributemod.h: mf_SetAttributeIntrinsicMod()
- osmod.h: mf_System_RPM()
- vitalmod.h: mf_SetVitalMaximumValue() and mf_SetVitalRegenRate()