### PR TITLE
New compiler: Add support for program parameters and vars in program blocks

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -16,6 +16,10 @@ set (bscript_sources    # sorted !
   compiler/LegacyFunctionOrder.h
   compiler/analyzer/Disambiguator.cpp
   compiler/analyzer/Disambiguator.h
+  compiler/analyzer/LocalVariableScope.cpp
+  compiler/analyzer/LocalVariableScope.h
+  compiler/analyzer/LocalVariableScopes.cpp
+  compiler/analyzer/LocalVariableScopes.h
   compiler/analyzer/SemanticAnalyzer.cpp
   compiler/analyzer/SemanticAnalyzer.h
   compiler/analyzer/Variables.cpp

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
@@ -1,0 +1,61 @@
+#include "LocalVariableScope.h"
+
+#include "compiler/Report.h"
+#include "compiler/analyzer/LocalVariableScopes.h"
+#include "compiler/analyzer/Variables.h"
+#include "compiler/file/SourceLocation.h"
+#include "compiler/model/Variable.h"
+
+namespace Pol::Bscript::Compiler
+{
+LocalVariableScope::LocalVariableScope( LocalVariableScopes& scopes,
+std::vector<std::shared_ptr<Variable>>& debug_variables )
+    : scopes( scopes ),
+      report( scopes.report ),
+      block_depth( scopes.local_variable_scopes.size() ),
+      prev_locals( scopes.local_variables.count() ),
+      debug_variables( debug_variables )
+{
+  scopes.local_variable_scopes.push_back( this );
+}
+
+LocalVariableScope::~LocalVariableScope()
+{
+  scopes.local_variables.remove_all_but( prev_locals );
+
+  for ( auto& variable : shadowing )
+  {
+    scopes.local_variables.restore_shadowed( variable );
+  }
+
+  scopes.local_variable_scopes.pop_back();
+}
+
+std::shared_ptr<Variable> LocalVariableScope::create( const std::string& name, WarnOn warn_on,
+                                                      const SourceLocation& source_location )
+{
+  if ( auto existing = scopes.local_variables.find( name ) )
+  {
+    if ( existing->block_depth == block_depth )
+    {
+      report.error( source_location, "Variable '", name, "' is already in scope.\n",
+                    "  See previous definition at: ",
+                    existing->source_location, "\n" );
+      return existing;
+    }
+    shadowing.push_back( existing );
+  }
+  auto local = scopes.local_variables.create( name, block_depth, warn_on,
+                                              source_location );
+
+  debug_variables.push_back( local );
+
+  return local;
+}
+
+unsigned LocalVariableScope::get_block_locals() const
+{
+  return scopes.local_variables.count() - prev_locals;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
@@ -1,0 +1,38 @@
+#ifndef POLSERVER_LOCALVARIABLESCOPE_H
+#define POLSERVER_LOCALVARIABLESCOPE_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "compiler/model/WarnOn.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Report;
+class LocalVariableScopes;
+class SourceLocation;
+class Variable;
+
+class LocalVariableScope
+{
+public:
+  explicit LocalVariableScope( LocalVariableScopes&,
+                               std::vector<std::shared_ptr<Variable>>& debug_variables );
+  ~LocalVariableScope();
+
+  std::shared_ptr<Variable> create( const std::string& name, WarnOn, const SourceLocation& );
+
+  [[nodiscard]] unsigned get_block_locals() const;
+private:
+  LocalVariableScopes& scopes;
+  Report& report;
+  const unsigned block_depth;
+  const unsigned prev_locals;
+  std::vector<std::shared_ptr<Variable>> shadowing;
+  std::vector<std::shared_ptr<Variable>>& debug_variables;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_LOCALVARIABLESCOPE_H

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScopes.cpp
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScopes.cpp
@@ -1,0 +1,17 @@
+#include "LocalVariableScopes.h"
+
+#include "compiler/analyzer/Variables.h"
+
+namespace Pol::Bscript::Compiler
+{
+LocalVariableScopes::LocalVariableScopes( Variables& local_variables, Report& report )
+    : local_variables( local_variables ), report( report )
+{
+}
+
+LocalVariableScope* LocalVariableScopes::current_local_scope()
+{
+  return local_variable_scopes.empty() ? nullptr : local_variable_scopes.back();
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScopes.h
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScopes.h
@@ -1,0 +1,30 @@
+#ifndef POLSERVER_LOCALVARIABLESCOPES_H
+#define POLSERVER_LOCALVARIABLESCOPES_H
+
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class LocalVariableScope;
+class Report;
+class Variables;
+
+class LocalVariableScopes
+{
+public:
+  LocalVariableScopes( Variables& locals, Report& report );
+
+  LocalVariableScope* current_local_scope();
+
+private:
+  friend class LocalVariableScope;
+
+  Variables& local_variables;
+  std::vector<LocalVariableScope*> local_variable_scopes;
+  Report& report;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_LOCALVARIABLESCOPES_H

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "clib/maputil.h"
+#include "compiler/analyzer/LocalVariableScopes.h"
 #include "compiler/analyzer/Variables.h"
 
 namespace Pol::Bscript::Compiler
@@ -27,12 +28,16 @@ public:
   void analyze( CompilerWorkspace& );
 
   void visit_identifier( Identifier& ) override;
+  void visit_program( Program& program ) override;
+  void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
   void visit_var_statement( VarStatement& ) override;
 
 private:
   Report& report;
 
   Variables globals;
+  Variables locals;
+  LocalVariableScopes local_scopes;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/Variables.h
+++ b/pol-core/bscript/compiler/analyzer/Variables.h
@@ -26,6 +26,10 @@ public:
 
   std::shared_ptr<Variable> find( const std::string& name ) const;
 
+  void restore_shadowed( std::shared_ptr<Variable> );
+
+  void remove_all_but( unsigned count );
+
   const std::vector<std::string>& get_names() const;
   unsigned count() const;
 

--- a/pol-core/bscript/compiler/ast/Program.cpp
+++ b/pol-core/bscript/compiler/ast/Program.cpp
@@ -11,7 +11,8 @@ namespace Pol::Bscript::Compiler
 Program::Program( const SourceLocation& source_location,
                   std::unique_ptr<ProgramParameterList> parameter_list,
                   std::unique_ptr<FunctionBody> body )
-  : Node( source_location )
+  : Node( source_location ),
+    locals_in_block( 0 )
 {
   children.reserve( 2 );
   children.push_back( std::move( parameter_list ) );

--- a/pol-core/bscript/compiler/ast/Program.h
+++ b/pol-core/bscript/compiler/ast/Program.h
@@ -5,21 +5,25 @@
 
 namespace Pol::Bscript::Compiler
 {
-class ProgramParameterList;
 class FunctionBody;
+class ProgramParameterList;
+class Variable;
 
 class Program : public Node
 {
 public:
   Program( const SourceLocation&, std::unique_ptr<ProgramParameterList>,
            std::unique_ptr<FunctionBody> );
-  ~Program();
+  ~Program() override;
 
   void accept( NodeVisitor& ) override;
   void describe_to( fmt::Writer& ) const override;
 
   ProgramParameterList& parameter_list();
   FunctionBody& body();
+
+  std::vector<std::shared_ptr<Variable>> debug_variables;
+  unsigned locals_in_block;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -80,6 +80,17 @@ void InstructionEmitter::declare_variable( const Variable& v )
   emit_token( token_id, TYP_RESERVED, v.index );
 }
 
+void InstructionEmitter::get_arg( const std::string& name )
+{
+  unsigned offset = emit_data( name );
+  emit_token( INS_GET_ARG, TYP_OPERATOR, offset );
+}
+
+void InstructionEmitter::leaveblock( unsigned local_vars_to_remove )
+{
+  emit_token( CTRL_LEAVE_BLOCK, TYP_CONTROL, local_vars_to_remove );
+}
+
 void InstructionEmitter::progend()
 {
   emit_token( CTRL_PROGEND, TYP_CONTROL );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -47,6 +47,8 @@ public:
   void call_modulefunc( const ModuleFunctionDeclaration& );
   void consume();
   void declare_variable( const Variable& );
+  void get_arg( const std::string& name );
+  void leaveblock( unsigned local_vars_to_remove );
   void progend();
   void unary_operator( BTokenId );
   void value( double );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -7,6 +7,8 @@
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/Program.h"
+#include "compiler/ast/ProgramParameterDeclaration.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/UnaryOperator.h"
 #include "compiler/ast/ValueConsumer.h"
@@ -59,6 +61,21 @@ void InstructionGenerator::visit_function_call( FunctionCall& call )
   {
     call.internal_error( "neither a module function nor a user function?" );
   }
+}
+
+void InstructionGenerator::visit_program( Program& program )
+{
+  visit_children( program );
+
+  if ( program.locals_in_block )
+  {
+    emit.leaveblock( program.locals_in_block );
+  }
+}
+
+void InstructionGenerator::visit_program_parameter_declaration( ProgramParameterDeclaration& param )
+{
+  emit.get_arg( param.name );
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -19,6 +19,8 @@ public:
   void visit_function_call( FunctionCall& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_integer_value( IntegerValue& ) override;
+  void visit_program( Program& ) override;
+  void visit_program_parameter_declaration( ProgramParameterDeclaration& );
   void visit_string_value( StringValue& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
   void visit_value_consumer( ValueConsumer& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -58,6 +58,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "progend";
     break;
 
+  case CTRL_LEAVE_BLOCK:
+    w << "leave block (remove " + std::to_string( tkn.offset ) + " locals)";
+    break;
+
   case RSV_GLOBAL:
     w << "declare global #" << tkn.offset;
     break;
@@ -91,6 +95,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 
   case TOK_GLOBALVAR:
     w << "global variable #" << tkn.offset;
+    break;
+
+  case INS_GET_ARG:
+    w << "get arg '" << string_at( tkn.offset ) << "'";
     break;
 
   case TOK_UNPLUSPLUS:

--- a/testsuite/escript/prog/prog06-vars-are-local.out
+++ b/testsuite/escript/prog/prog06-vars-are-local.out
@@ -1,0 +1,3 @@
+the global var
+the global var
+the local var

--- a/testsuite/escript/prog/prog06-vars-are-local.src
+++ b/testsuite/escript/prog/prog06-vars-are-local.src
@@ -1,0 +1,11 @@
+var a := "the global var";
+
+print(a);
+
+program foo()
+   var a := "the local var";
+   print(a);
+endprogram
+
+print(a);
+


### PR DESCRIPTION
Adds:
- [analyzer/LocalVariableScope](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/LocalVariableScope.h): tracks local variables created within a given scope.
  - Instantiated on the stack during semantic analysis, this registers itself with LocalVariableScopes during construction and deregisters itself during destruction.
  - Detects unused variables during deregistration
- [analyzer/LocalVariableScopes](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/LocalVariableScopes.h): this is what LocalVariableScope registers with.
  - keeps track of the stack of local scopes.
  - can provide the current local scope, for `var` statements.

Other notes:
- "Shadowed" variables: this is when a variable in one scope hides a variable in another, like so:
```
var a := 2;
if (a)
    var a := 3;
    a := 4;
endif
print(a); // still 2
```
- "debug_variables": We'll use these later when writing debug files
