### PR TITLE
OG compiler: set module to Mod_Basic when a token is an identifier

### DIFF
--- a/pol-core/bscript/parser.cpp
+++ b/pol-core/bscript/parser.cpp
@@ -1355,6 +1355,7 @@ int Parser::tryLiteral( Token& tok, CompilerContext& ctx )
 
     tok.copyStr( ctx.s, len - 1 );
 
+    tok.module = Mod_Basic;
     tok.id = TOK_IDENT;
     tok.type = TYP_OPERAND;
 

--- a/testsuite/escript/parity/parity001-identifier-module.out
+++ b/testsuite/escript/parity/parity001-identifier-module.out
@@ -1,0 +1,1 @@
+struct{ hex = "y", print = "x" }

--- a/testsuite/escript/parity/parity001-identifier-module.src
+++ b/testsuite/escript/parity/parity001-identifier-module.src
@@ -1,0 +1,5 @@
+var a := struct;
+a.+print := "x";
+a.+hex := "y";
+print(a);
+


### PR DESCRIPTION
The OG compiler looks up function ids for most tokens, even when it doesn't need to.  When this happens, it assigns the module id as the module of the function.

When the token is later found _not_ to be a function call, the parser changes the id to TOK_IDENT and the type to TYP_OPERAND, but leaves the module id.

We can see this in the included script, which adds members, which have names that match module function names, to a struct.

This doesn't cause problems during execution because the executor [ignores the type](https://github.com/polserver/polserver/blob/master/pol-core/bscript/executor.cpp#L1287) for the emitted instructions.

It does cause problems when comparing .ecl output for parity between the old compiler and the new compiler, because the new compiler does not look up every identifier to see if it's a function.

This change assigns `module = Mod_Basic` along with `id` and `type` for tokens that are identifiers.