### PR TITLE
Add support for if-then-else statements

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -26,6 +26,8 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Variables.h
   compiler/ast/Argument.cpp
   compiler/ast/Argument.h
+  compiler/ast/Block.cpp
+  compiler/ast/Block.h
   compiler/ast/Expression.cpp
   compiler/ast/Expression.h
   compiler/ast/FloatValue.cpp
@@ -42,6 +44,8 @@ set (bscript_sources    # sorted !
   compiler/ast/FunctionParameterList.h
   compiler/ast/Identifier.cpp
   compiler/ast/Identifier.h
+  compiler/ast/IfThenElseStatement.cpp
+  compiler/ast/IfThenElseStatement.h
   compiler/ast/IntegerValue.cpp
   compiler/ast/IntegerValue.h
   compiler/ast/ModuleFunctionDeclaration.cpp
@@ -128,6 +132,8 @@ set (bscript_sources    # sorted !
   compiler/format/StoredTokenDecoder.h
   compiler/model/CompilerWorkspace.cpp
   compiler/model/CompilerWorkspace.h
+  compiler/model/FlowControlLabel.cpp
+  compiler/model/FlowControlLabel.h
   compiler/model/FunctionLink.cpp
   compiler/model/FunctionLink.h
   compiler/model/Variable.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -3,6 +3,7 @@
 #include "compiler/Report.h"
 #include "compiler/analyzer/LocalVariableScope.h"
 #include "compiler/ast/Argument.h"
+#include "compiler/ast/Block.h"
 #include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
@@ -42,6 +43,15 @@ void SemanticAnalyzer::analyze( CompilerWorkspace& workspace )
   }
 
   workspace.global_variable_names = globals.get_names();
+}
+
+void SemanticAnalyzer::visit_block( Block& block )
+{
+  LocalVariableScope scope( local_scopes, block.debug_variables );
+
+  visit_children( block );
+
+  block.locals_in_block = scope.get_block_locals();
 }
 
 void SemanticAnalyzer::visit_identifier( Identifier& node )

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -27,6 +27,7 @@ public:
   static void register_const_declarations( CompilerWorkspace& );
   void analyze( CompilerWorkspace& );
 
+  void visit_block( Block& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_program( Program& program ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;

--- a/pol-core/bscript/compiler/ast/Block.cpp
+++ b/pol-core/bscript/compiler/ast/Block.cpp
@@ -1,0 +1,30 @@
+#include "Block.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+Block::Block( const SourceLocation& source_location,
+              std::vector<std::unique_ptr<Statement>> statements )
+    : Statement( source_location ), locals_in_block( 0 )
+{
+  children.reserve( statements.size() );
+  for ( auto& statement : statements )
+  {
+    children.push_back( std::move( statement ) );
+  }
+}
+
+void Block::accept( NodeVisitor& visitor )
+{
+  visitor.visit_block( *this );
+}
+
+void Block::describe_to( fmt::Writer& w ) const
+{
+  w << "block";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Block.h
+++ b/pol-core/bscript/compiler/ast/Block.h
@@ -1,0 +1,28 @@
+#ifndef POLSERVER_BLOCK_H
+#define POLSERVER_BLOCK_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class DebugBlock;
+class NodeVisitor;
+class Statement;
+class Variable;
+
+class Block : public Statement
+{
+public:
+  Block( const SourceLocation&, std::vector<std::unique_ptr<Statement>> statements );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  // set by semantic analyzer:
+  unsigned locals_in_block;
+  std::vector<std::shared_ptr<Variable>> debug_variables;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_BLOCK_H

--- a/pol-core/bscript/compiler/ast/IfThenElseStatement.cpp
+++ b/pol-core/bscript/compiler/ast/IfThenElseStatement.cpp
@@ -1,0 +1,76 @@
+#include "IfThenElseStatement.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Block.h"
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+IfThenElseStatement::IfThenElseStatement( const SourceLocation& source_location,
+                                          std::unique_ptr<Expression> predicate,
+                                          std::unique_ptr<Block> consequent,
+                                          std::unique_ptr<Node> alternative )
+    : Statement( source_location )
+{
+  children.reserve( 3 );
+  children.push_back( std::move( predicate ) );
+  children.push_back( std::move( consequent ) );
+  children.push_back( std::move( alternative ) );
+}
+
+IfThenElseStatement::IfThenElseStatement( const SourceLocation& source_location,
+                                          std::unique_ptr<Expression> predicate,
+                                          std::unique_ptr<Block> consequent )
+    : Statement( source_location )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( predicate ) );
+  children.push_back( std::move( consequent ) );
+}
+
+void IfThenElseStatement::accept( NodeVisitor& visitor )
+{
+  visitor.visit_if_then_else_statement( *this );
+}
+
+void IfThenElseStatement::describe_to( fmt::Writer& w ) const
+{
+  w << "if-then-else-statement";
+}
+
+Expression& IfThenElseStatement::predicate()
+{
+  return child<Expression>( 0 );
+}
+
+Block& IfThenElseStatement::consequent()
+{
+  return child<Block>( 1 );
+}
+
+Node* IfThenElseStatement::alternative()
+{
+  return ( children.size() >= 3 ) ? children.at( 2 ).get() : nullptr;
+}
+
+std::unique_ptr<Expression> IfThenElseStatement::take_predicate()
+{
+  return take_child<Expression>( 0 );
+}
+
+std::unique_ptr<Block> IfThenElseStatement::take_consequent()
+{
+  return take_child<Block>( 1 );
+}
+
+std::unique_ptr<Node> IfThenElseStatement::take_alternative()
+{
+  if ( children.size() >= 3 )
+    return std::move( children[2] );
+  else
+    return {};
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/IfThenElseStatement.h
+++ b/pol-core/bscript/compiler/ast/IfThenElseStatement.h
@@ -1,0 +1,32 @@
+#ifndef POLSERVER_IFTHENELSESTATEMENT_H
+#define POLSERVER_IFTHENELSESTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Block;
+class Expression;
+class IfThenElseStatement : public Statement
+{
+public:
+  IfThenElseStatement( const SourceLocation&, std::unique_ptr<Expression> predicate,
+                       std::unique_ptr<Block> consequent, std::unique_ptr<Node> alternative );
+  IfThenElseStatement( const SourceLocation&, std::unique_ptr<Expression> predicate,
+                       std::unique_ptr<Block> consequent );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Expression& predicate();
+  Block& consequent();
+  Node* alternative();
+
+  std::unique_ptr<Expression> take_predicate();
+  std::unique_ptr<Block> take_consequent();
+  std::unique_ptr<Node> take_alternative();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_IFTHENELSESTATEMENT_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,11 +1,13 @@
 #include "NodeVisitor.h"
 
 #include "compiler/ast/Argument.h"
+#include "compiler/ast/Block.h"
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/IfThenElseStatement.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Node.h"
 #include "compiler/ast/Program.h"
@@ -20,6 +22,11 @@
 namespace Pol::Bscript::Compiler
 {
 void NodeVisitor::visit_argument( Argument& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_block( Block& node )
 {
   visit_children( node );
 }
@@ -55,6 +62,11 @@ void NodeVisitor::visit_identifier( Identifier& )
 
 void NodeVisitor::visit_integer_value( IntegerValue& )
 {
+}
+
+void NodeVisitor::visit_if_then_else_statement( IfThenElseStatement & node )
+{
+  visit_children( node );
 }
 
 void NodeVisitor::visit_module_function_declaration( ModuleFunctionDeclaration& node )

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -4,12 +4,14 @@
 namespace Pol::Bscript::Compiler
 {
 class Argument;
+class Block;
 class FloatValue;
 class FunctionBody;
 class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
 class Identifier;
+class IfThenElseStatement;
 class IntegerValue;
 class ModuleFunctionDeclaration;
 class Node;
@@ -28,12 +30,14 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_argument( Argument& );
+  virtual void visit_block( Block& );
   virtual void visit_float_value( FloatValue& );
   virtual void visit_function_body( FunctionBody& );
   virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
   virtual void visit_identifier( Identifier& );
+  virtual void visit_if_then_else_statement( IfThenElseStatement& );
   virtual void visit_integer_value( IntegerValue& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_program( Program& );

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -1,6 +1,8 @@
 #include "CompoundStatementBuilder.h"
 
+#include "compiler/ast/Block.h"
 #include "compiler/ast/Expression.h"
+#include "compiler/ast/IfThenElseStatement.h"
 
 using EscriptGrammar::EscriptParser;
 
@@ -18,6 +20,10 @@ void CompoundStatementBuilder::add_statements(
   if ( auto expr_ctx = ctx->expression() )
   {
     statements.push_back( consume_statement_result( expression( expr_ctx ) ) );
+  }
+  else if ( auto if_st = ctx->ifStatement() )
+  {
+    statements.push_back( if_statement( if_st ) );
   }
   else if ( auto var_statement = ctx->varStatement() )
   {
@@ -40,6 +46,54 @@ std::vector<std::unique_ptr<Statement>> CompoundStatementBuilder::block_statemen
   }
 
   return statements;
+}
+
+std::unique_ptr<Block> CompoundStatementBuilder::block( EscriptParser::BlockContext* ctx )
+{
+  auto statements = block_statements( ctx );
+  return std::make_unique<Block>( location_for( *ctx ), std::move( statements ) );
+}
+
+std::unique_ptr<Statement> CompoundStatementBuilder::if_statement(
+    EscriptParser::IfStatementContext* ctx )
+{
+  //
+  // if (expr0) block0 elseif (expr1) block1 ... elseif (exprN-1) blockN-1 else blockN
+  //
+
+  auto blocks = ctx->block();
+  auto par_expression = ctx->parExpression();
+
+  auto else_clause =
+      ctx->ELSE() ? block( blocks.at( blocks.size() - 1 ) ) : std::unique_ptr<Node>();
+
+  auto if_statement_ast = std::unique_ptr<Statement>();
+
+  size_t num_expressions = par_expression.size();
+  for ( auto clause_index = num_expressions; clause_index != 0; )
+  {
+    --clause_index;
+    auto expression_ctx = par_expression.at( clause_index );
+    auto expression_ast = expression( expression_ctx->expression() );
+    auto consequent_ast = block( blocks.at( clause_index ) );
+    auto alternative_ast =
+        if_statement_ast ? std::move( if_statement_ast ) : std::move( else_clause );
+    auto source_location = location_for( *expression_ctx );
+
+    if ( alternative_ast )
+    {
+      if_statement_ast = std::make_unique<IfThenElseStatement>(
+          source_location, std::move( expression_ast ), std::move( consequent_ast ),
+          std::move( alternative_ast ) );
+    }
+    else
+    {
+      if_statement_ast = std::make_unique<IfThenElseStatement>(
+          source_location, std::move( expression_ast ), std::move( consequent_ast ) );
+    }
+  }
+
+  return if_statement_ast;
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -5,6 +5,8 @@
 
 namespace Pol::Bscript::Compiler
 {
+class Block;
+class Statement;
 
 class CompoundStatementBuilder : public SimpleStatementBuilder
 {
@@ -14,8 +16,12 @@ public:
   void add_statements( EscriptGrammar::EscriptParser::StatementContext*,
                        std::vector<std::unique_ptr<Statement>>& );
 
+  std::unique_ptr<Block> block( EscriptGrammar::EscriptParser::BlockContext* );
+
   std::vector<std::unique_ptr<Statement>> block_statements(
       EscriptGrammar::EscriptParser::BlockContext* );
+
+  std::unique_ptr<Statement> if_statement( EscriptGrammar::EscriptParser::IfStatementContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -25,6 +25,9 @@ class StoredToken;
 
 namespace Pol::Bscript::Compiler
 {
+class CaseJumpDataBlock;
+class CompiledScript;
+class FlowControlLabel;
 class ModuleDeclarationRegistrar;
 class ModuleFunctionDeclaration;
 class Node;
@@ -48,6 +51,10 @@ public:
   void consume();
   void declare_variable( const Variable& );
   void get_arg( const std::string& name );
+  void jmp_always( FlowControlLabel& );
+  void jmp_if_false( FlowControlLabel& );
+  void jmp_if_true( FlowControlLabel& );
+  void label( FlowControlLabel& );
   void leaveblock( unsigned local_vars_to_remove );
   void progend();
   void unary_operator( BTokenId );
@@ -55,10 +62,13 @@ public:
   void value( int );
   void value( const std::string& );
 
+  void patch_offset( unsigned index, unsigned offset );
+
 private:
   unsigned emit_data( const std::string& );
   unsigned emit_token( BTokenId id, BTokenType type, unsigned offset = 0 );
   unsigned append_token( StoredToken& );
+  void register_with_label( FlowControlLabel&, unsigned offset );
 
   CodeEmitter code_emitter;
   DataEmitter data_emitter;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1,10 +1,12 @@
 #include "InstructionGenerator.h"
 
+#include "compiler/ast/Block.h"
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 #include "compiler/ast/Identifier.h"
+#include "compiler/ast/IfThenElseStatement.h"
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Program.h"
@@ -15,6 +17,7 @@
 #include "compiler/ast/VarStatement.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
+#include "compiler/model/FlowControlLabel.h"
 #include "compiler/model/FunctionLink.h"
 #include "compiler/model/Variable.h"
 #include "symcont.h"
@@ -27,24 +30,23 @@ InstructionGenerator::InstructionGenerator( InstructionEmitter& emitter )
 {
 }
 
-void InstructionGenerator::visit_identifier( Identifier& node )
+void InstructionGenerator::generate( Node& node )
 {
-  if ( auto var = node.variable )
+  // alternative: two identical methods 'evaluate' and 'execute', for readability
+  node.accept( *this );
+}
+
+void InstructionGenerator::visit_block( Block& node )
+{
+  visit_children( node );
+
+  if ( node.locals_in_block )
   {
-    emit.access_variable( *var );
-  }
-  else
-  {
-    node.internal_error( "variable is not set" );
+    emit.leaveblock( node.locals_in_block );
   }
 }
 
 void InstructionGenerator::visit_float_value( FloatValue& node )
-{
-  emit.value( node.value );
-}
-
-void InstructionGenerator::visit_integer_value( IntegerValue& node )
 {
   emit.value( node.value );
 }
@@ -61,6 +63,60 @@ void InstructionGenerator::visit_function_call( FunctionCall& call )
   {
     call.internal_error( "neither a module function nor a user function?" );
   }
+}
+
+void InstructionGenerator::visit_identifier( Identifier& node )
+{
+  if ( auto var = node.variable )
+  {
+    emit.access_variable( *var );
+  }
+  else
+  {
+    node.internal_error( "variable is not set" );
+  }
+}
+
+void InstructionGenerator::visit_if_then_else_statement( IfThenElseStatement& node )
+{
+  bool invert_jump = false;
+  auto predicate = &node.predicate();
+  if ( auto unary_operator = dynamic_cast<UnaryOperator*>( predicate ) )
+  {
+    if ( unary_operator->token_id == TOK_LOG_NOT )
+    {
+      invert_jump = true;
+      predicate = &unary_operator->operand();
+    }
+  }
+  generate( *predicate );
+
+  FlowControlLabel skip_consequent;
+
+  if ( invert_jump )
+    emit.jmp_if_true( skip_consequent );
+  else
+    emit.jmp_if_false( skip_consequent );
+
+  generate( node.consequent() );
+
+  if ( auto alternative = node.alternative() )
+  {
+    FlowControlLabel skip_alternative;
+    emit.jmp_always( skip_alternative );
+    emit.label( skip_consequent );
+    generate( *alternative );
+    emit.label( skip_alternative );
+  }
+  else
+  {
+    emit.label( skip_consequent );
+  }
+}
+
+void InstructionGenerator::visit_integer_value( IntegerValue& node )
+{
+  emit.value( node.value );
 }
 
 void InstructionGenerator::visit_program( Program& program )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -15,9 +15,13 @@ class InstructionGenerator : public NodeVisitor
 public:
   explicit InstructionGenerator( InstructionEmitter& );
 
+  void generate( Node& );
+
+  void visit_block( Block& ) override;
   void visit_float_value( FloatValue& ) override;
   void visit_function_call( FunctionCall& ) override;
   void visit_identifier( Identifier& ) override;
+  void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_integer_value( IntegerValue& ) override;
   void visit_program( Program& ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& );

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -62,6 +62,16 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "leave block (remove " + std::to_string( tkn.offset ) + " locals)";
     break;
 
+   case RSV_JMPIFFALSE:
+     w << "if false goto " + std::to_string( tkn.offset );
+     break;
+   case RSV_JMPIFTRUE:
+     w << "if true goto " + std::to_string( tkn.offset );
+     break;
+   case RSV_GOTO:
+     w << "goto " << tkn.offset;
+     break;
+
   case RSV_GLOBAL:
     w << "declare global #" << tkn.offset;
     break;

--- a/pol-core/bscript/compiler/model/FlowControlLabel.cpp
+++ b/pol-core/bscript/compiler/model/FlowControlLabel.cpp
@@ -1,0 +1,34 @@
+#include "FlowControlLabel.h"
+
+namespace Pol::Bscript::Compiler
+{
+FlowControlLabel::FlowControlLabel() : maybe_address(), referencing_instruction_addresses() {}
+
+bool FlowControlLabel::has_address() const
+{
+  return maybe_address.has_value();
+}
+
+unsigned FlowControlLabel::address() const
+{
+  return maybe_address.value();
+}
+
+const std::vector<unsigned>& FlowControlLabel::get_referencing_instruction_addresses() const
+{
+  return referencing_instruction_addresses;
+}
+
+void FlowControlLabel::assign_address( unsigned address )
+{
+  if ( maybe_address.has_value() )
+    throw std::runtime_error( "Label address assigned twice" );
+  maybe_address = address;
+}
+
+void FlowControlLabel::add_referencing_instruction_address( unsigned address )
+{
+  referencing_instruction_addresses.push_back( address );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/FlowControlLabel.cpp
+++ b/pol-core/bscript/compiler/model/FlowControlLabel.cpp
@@ -1,5 +1,7 @@
 #include "FlowControlLabel.h"
 
+#include <stdexcept>
+
 namespace Pol::Bscript::Compiler
 {
 FlowControlLabel::FlowControlLabel() : maybe_address(), referencing_instruction_addresses() {}

--- a/pol-core/bscript/compiler/model/FlowControlLabel.h
+++ b/pol-core/bscript/compiler/model/FlowControlLabel.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_FLOWCONTROLLABEL_H
+#define POLSERVER_FLOWCONTROLLABEL_H
+
+#include <vector>
+
+#include <optional>
+
+namespace Pol::Bscript::Compiler
+{
+class InstructionEmitter;
+
+class FlowControlLabel
+{
+public:
+  FlowControlLabel();
+
+  bool has_address() const;
+  unsigned address() const;
+  const std::vector<unsigned>& get_referencing_instruction_addresses() const;
+
+  void assign_address( unsigned );
+  void add_referencing_instruction_address( unsigned );
+
+private:
+  std::optional<unsigned> maybe_address;
+  std::vector<unsigned> referencing_instruction_addresses;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FLOWCONTROLLABEL_H


### PR DESCRIPTION
Adds:
- [ast/Block](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/Block.h): a block scope that allows declaring local variables
- [ast/IfThenElseStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/IfThenElseStatement.h): AST node for if..elseif..else..endif statements
- [model/FlowControlLabel](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/model/FlowControlLabel.h): provides an anchor for jumps or calls.
  - Function calls, break statements, continue statements, and loops will all use these.


An single if..elseif..elseif..elseif..endif statement will be represented as 1 or more IfThenElseStatement AST nodes.  Each one handles a single level that looks like this:
```
if (predicate())
    consequent();
else
    alternative();
endif
```

This PR allows the first 15 scripts in the [compiler2/](https://github.com/polserver/polserver/tree/ecompile-antlr/testsuite/escript/compiler2) suite to compile with parity.