### PR TITLE
New compiler: add return and exit statements

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -28,6 +28,8 @@ set (bscript_sources    # sorted !
   compiler/ast/Argument.h
   compiler/ast/Block.cpp
   compiler/ast/Block.h
+  compiler/ast/ExitStatement.cpp
+  compiler/ast/ExitStatement.h
   compiler/ast/Expression.cpp
   compiler/ast/Expression.h
   compiler/ast/FloatValue.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -60,6 +60,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ProgramParameterDeclaration.h
   compiler/ast/ProgramParameterList.cpp
   compiler/ast/ProgramParameterList.h
+  compiler/ast/ReturnStatement.cpp
+  compiler/ast/ReturnStatement.h
   compiler/ast/Statement.cpp
   compiler/ast/Statement.h
   compiler/ast/StringValue.cpp

--- a/pol-core/bscript/compiler/ast/ExitStatement.cpp
+++ b/pol-core/bscript/compiler/ast/ExitStatement.cpp
@@ -1,0 +1,23 @@
+#include "ExitStatement.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ExitStatement::ExitStatement( const SourceLocation& source_location ) : Statement( source_location )
+{
+}
+
+void ExitStatement::accept( NodeVisitor& visitor )
+{
+  visitor.visit_exit_statement( *this );
+}
+
+void ExitStatement::describe_to( fmt::Writer& w ) const
+{
+  w << "exit-statement";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ExitStatement.h
+++ b/pol-core/bscript/compiler/ast/ExitStatement.h
@@ -1,0 +1,20 @@
+#ifndef POLSERVER_EXITSTATEMENT_H
+#define POLSERVER_EXITSTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ExitStatement : public Statement
+{
+public:
+  explicit ExitStatement( const SourceLocation& );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_EXITSTATEMENT_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -13,6 +13,7 @@
 #include "compiler/ast/Program.h"
 #include "compiler/ast/ProgramParameterDeclaration.h"
 #include "compiler/ast/ProgramParameterList.h"
+#include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/UnaryOperator.h"
@@ -85,6 +86,11 @@ void NodeVisitor::visit_program_parameter_declaration( ProgramParameterDeclarati
 }
 
 void NodeVisitor::visit_program_parameter_list( ProgramParameterList& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_return_statement( ReturnStatement& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -32,6 +32,10 @@ void NodeVisitor::visit_block( Block& node )
   visit_children( node );
 }
 
+void NodeVisitor::visit_exit_statement( ExitStatement& )
+{
+}
+
 void NodeVisitor::visit_float_value( FloatValue& node )
 {
   visit_children( node );

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -5,6 +5,7 @@ namespace Pol::Bscript::Compiler
 {
 class Argument;
 class Block;
+class ExitStatement;
 class FloatValue;
 class FunctionBody;
 class FunctionCall;
@@ -32,6 +33,7 @@ public:
 
   virtual void visit_argument( Argument& );
   virtual void visit_block( Block& );
+  virtual void visit_exit_statement( ExitStatement& );
   virtual void visit_float_value( FloatValue& );
   virtual void visit_function_body( FunctionBody& );
   virtual void visit_function_call( FunctionCall& );

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -18,6 +18,7 @@ class Node;
 class Program;
 class ProgramParameterDeclaration;
 class ProgramParameterList;
+class ReturnStatement;
 class StringValue;
 class TopLevelStatements;
 class UnaryOperator;
@@ -43,6 +44,7 @@ public:
   virtual void visit_program( Program& );
   virtual void visit_program_parameter_declaration( ProgramParameterDeclaration& );
   virtual void visit_program_parameter_list( ProgramParameterList& );
+  virtual void visit_return_statement( ReturnStatement& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_unary_operator( UnaryOperator& );

--- a/pol-core/bscript/compiler/ast/ReturnStatement.cpp
+++ b/pol-core/bscript/compiler/ast/ReturnStatement.cpp
@@ -1,0 +1,26 @@
+#include "ReturnStatement.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ReturnStatement::ReturnStatement( const SourceLocation& source_location,
+                                  std::unique_ptr<Expression> expression )
+    : Statement( source_location, std::move( expression ) )
+{
+}
+
+void ReturnStatement::accept( NodeVisitor& visitor )
+{
+  visitor.visit_return_statement( *this );
+}
+
+void ReturnStatement::describe_to( fmt::Writer& w ) const
+{
+  w << "return-statement";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ReturnStatement.h
+++ b/pol-core/bscript/compiler/ast/ReturnStatement.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_RETURNSTATEMENT_H
+#define POLSERVER_RETURNSTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+
+class ReturnStatement : public Statement
+{
+public:
+  ReturnStatement( const SourceLocation& source_location, std::unique_ptr<Expression> expression );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_RETURNSTATEMENT_H

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -1,6 +1,7 @@
 #include "CompoundStatementBuilder.h"
 
 #include "compiler/ast/Block.h"
+#include "compiler/ast/ExitStatement.h"
 #include "compiler/ast/Expression.h"
 #include "compiler/ast/IfThenElseStatement.h"
 #include "compiler/ast/ReturnStatement.h"
@@ -33,6 +34,10 @@ void CompoundStatementBuilder::add_statements(
   else if ( auto return_st = ctx->returnStatement() )
   {
     statements.push_back( return_statement( return_st ) );
+  }
+  else if ( auto exit = ctx->exitStatement() )
+  {
+    statements.push_back( std::make_unique<ExitStatement>( location_for( *exit ) ) );
   }
   else
   {

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -3,6 +3,7 @@
 #include "compiler/ast/Block.h"
 #include "compiler/ast/Expression.h"
 #include "compiler/ast/IfThenElseStatement.h"
+#include "compiler/ast/ReturnStatement.h"
 
 using EscriptGrammar::EscriptParser;
 
@@ -28,6 +29,10 @@ void CompoundStatementBuilder::add_statements(
   else if ( auto var_statement = ctx->varStatement() )
   {
     add_var_statements( var_statement, statements );
+  }
+  else if ( auto return_st = ctx->returnStatement() )
+  {
+    statements.push_back( return_statement( return_st ) );
   }
   else
   {

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -2,6 +2,9 @@
 
 #include "compiler/Report.h"
 #include "compiler/ast/Expression.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/IntegerValue.h"
+#include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
@@ -65,6 +68,20 @@ std::unique_ptr<Expression> SimpleStatementBuilder::variable_initializer(
     return expression( expr );
   else
     return std::unique_ptr<Expression>( new StringValue( location_for( *ctx ), "" ) );
+}
+
+std::unique_ptr<ReturnStatement> SimpleStatementBuilder::return_statement(
+    EscriptParser::ReturnStatementContext* ctx )
+{
+  auto source_location = location_for( *ctx );
+
+  std::unique_ptr<Expression> result;
+  if ( auto expression_ctx = ctx->expression() )
+    result = expression( expression_ctx );
+  else
+    result = std::unique_ptr<Expression>( new StringValue( source_location, "" ) );
+
+  return std::make_unique<ReturnStatement>( source_location, std::move( result ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -6,6 +6,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Statement;
+class ReturnStatement;
 
 class SimpleStatementBuilder : public ExpressionBuilder
 {
@@ -20,6 +21,9 @@ public:
 
   std::unique_ptr<Expression> variable_initializer(
       EscriptGrammar::EscriptParser::VariableDeclarationInitializerContext* );
+
+  std::unique_ptr<ReturnStatement> return_statement(
+      EscriptGrammar::EscriptParser::ReturnStatementContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -82,6 +82,11 @@ void InstructionEmitter::declare_variable( const Variable& v )
   emit_token( token_id, TYP_RESERVED, v.index );
 }
 
+void InstructionEmitter::exit()
+{
+  emit_token( RSV_EXIT, TYP_RESERVED );
+}
+
 void InstructionEmitter::get_arg( const std::string& name )
 {
   unsigned offset = emit_data( name );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -50,6 +50,7 @@ public:
   void call_modulefunc( const ModuleFunctionDeclaration& );
   void consume();
   void declare_variable( const Variable& );
+  void exit();
   void get_arg( const std::string& name );
   void jmp_always( FlowControlLabel& );
   void jmp_if_false( FlowControlLabel& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -47,6 +47,11 @@ void InstructionGenerator::visit_block( Block& node )
   }
 }
 
+void InstructionGenerator::visit_exit_statement( ExitStatement& )
+{
+  emit.exit();
+}
+
 void InstructionGenerator::visit_float_value( FloatValue& node )
 {
   emit.value( node.value );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -11,6 +11,7 @@
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Program.h"
 #include "compiler/ast/ProgramParameterDeclaration.h"
+#include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/UnaryOperator.h"
 #include "compiler/ast/ValueConsumer.h"
@@ -132,6 +133,13 @@ void InstructionGenerator::visit_program( Program& program )
 void InstructionGenerator::visit_program_parameter_declaration( ProgramParameterDeclaration& param )
 {
   emit.get_arg( param.name );
+}
+
+void InstructionGenerator::visit_return_statement( ReturnStatement& ret )
+{
+  visit_children( ret );
+
+  emit.progend();
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -24,7 +24,8 @@ public:
   void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_integer_value( IntegerValue& ) override;
   void visit_program( Program& ) override;
-  void visit_program_parameter_declaration( ProgramParameterDeclaration& );
+  void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
+  void visit_return_statement( ReturnStatement& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
   void visit_value_consumer( ValueConsumer& ) override;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -18,6 +18,7 @@ public:
   void generate( Node& );
 
   void visit_block( Block& ) override;
+  void visit_exit_statement( ExitStatement& ) override;
   void visit_float_value( FloatValue& ) override;
   void visit_function_call( FunctionCall& ) override;
   void visit_identifier( Identifier& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -71,6 +71,9 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
    case RSV_GOTO:
      w << "goto " << tkn.offset;
      break;
+   case RSV_EXIT:
+     w << "exit";
+     break;
 
   case RSV_GLOBAL:
     w << "declare global #" << tkn.offset;


### PR DESCRIPTION
Add:
- [ast/ExitStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ExitStatement.cpp): AST node for the `exit` statement.
- [ast/ReturnStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ReturnStatement.cpp): AST node for the `return` statement.
  - only handles top-level returns and returns inside `program` declarations, which do the same thing: `progend`.
  - the next PR will add user functions, in which `return` operates a little differently.
