### PR TITLE
Add limited support for user functions

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -72,12 +72,15 @@ set (bscript_sources    # sorted !
   compiler/ast/TopLevelStatements.h
   compiler/ast/UnaryOperator.cpp
   compiler/ast/UnaryOperator.h
+  compiler/ast/UserFunction.cpp
+  compiler/ast/UserFunction.h
   compiler/ast/Value.cpp
   compiler/ast/Value.h
   compiler/ast/ValueConsumer.cpp
   compiler/ast/ValueConsumer.h
   compiler/ast/VarStatement.cpp
   compiler/ast/VarStatement.h
+  compiler/astbuilder/AvailableUserFunction.h
   compiler/astbuilder/BuilderWorkspace.cpp
   compiler/astbuilder/BuilderWorkspace.h
   compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -102,6 +105,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/TreeBuilder.h
   compiler/astbuilder/UserFunctionBuilder.cpp
   compiler/astbuilder/UserFunctionBuilder.h
+  compiler/astbuilder/UserFunctionVisitor.cpp
+  compiler/astbuilder/UserFunctionVisitor.h
   compiler/astbuilder/ValueBuilder.cpp
   compiler/astbuilder/ValueBuilder.h
   compiler/codegen/CodeEmitter.cpp

--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -29,6 +29,8 @@ public:
   std::atomic<long long> parse_src_micros;
   std::atomic<long long> ast_src_micros;
 
+  std::atomic<long long> ast_resolve_functions_micros;
+
   std::atomic<long> cache_hits;
   std::atomic<long> cache_misses;
 };

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -28,9 +28,12 @@ public:
   void analyze( CompilerWorkspace& );
 
   void visit_block( Block& ) override;
+  void visit_function_parameter_list( FunctionParameterList& ) override;
+  void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_program( Program& program ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
+  void  visit_user_function( UserFunction& ) override;
   void visit_var_statement( VarStatement& ) override;
 
 private:

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -33,7 +33,7 @@ public:
   void visit_identifier( Identifier& ) override;
   void visit_program( Program& program ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
-  void  visit_user_function( UserFunction& ) override;
+  void visit_user_function( UserFunction& ) override;
   void visit_var_statement( VarStatement& ) override;
 
 private:

--- a/pol-core/bscript/compiler/ast/Function.cpp
+++ b/pol-core/bscript/compiler/ast/Function.cpp
@@ -1,10 +1,21 @@
 #include "Function.h"
 
+#include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
 
 namespace Pol::Bscript::Compiler
 {
+Function::Function( const SourceLocation& source_location, std::string name,
+                    std::unique_ptr<FunctionParameterList> parameter_list,
+                    std::unique_ptr<FunctionBody> body )
+    : Node( source_location ), name( std::move( name ) )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( parameter_list ) );
+  children.push_back( std::move( body ) );
+}
+
 Function::Function( const SourceLocation& source_location, std::string name,
                     std::unique_ptr<FunctionParameterList> parameter_list )
     : Node( source_location, std::move( parameter_list ) ), name( std::move( name ) )

--- a/pol-core/bscript/compiler/ast/Function.h
+++ b/pol-core/bscript/compiler/ast/Function.h
@@ -12,6 +12,8 @@ class FunctionBody;
 class Function : public Node
 {
 public:
+  Function( const SourceLocation&, std::string name, std::unique_ptr<FunctionParameterList>,
+            std::unique_ptr<FunctionBody> );
   Function( const SourceLocation&, std::string name, std::unique_ptr<FunctionParameterList> );
 
   unsigned parameter_count() const;

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -17,6 +17,7 @@
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/TopLevelStatements.h"
 #include "compiler/ast/UnaryOperator.h"
+#include "compiler/ast/UserFunction.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
 
@@ -110,6 +111,11 @@ void NodeVisitor::visit_top_level_statements( TopLevelStatements& node )
 }
 
 void NodeVisitor::visit_unary_operator( UnaryOperator& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_user_function( UserFunction& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -23,6 +23,7 @@ class ReturnStatement;
 class StringValue;
 class TopLevelStatements;
 class UnaryOperator;
+class UserFunction;
 class ValueConsumer;
 class VarStatement;
 
@@ -50,6 +51,7 @@ public:
   virtual void visit_string_value( StringValue& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_unary_operator( UnaryOperator& );
+  virtual void visit_user_function( UserFunction& );
   virtual void visit_value_consumer( ValueConsumer& );
   virtual void visit_var_statement( VarStatement& );
 

--- a/pol-core/bscript/compiler/ast/UserFunction.cpp
+++ b/pol-core/bscript/compiler/ast/UserFunction.cpp
@@ -1,0 +1,38 @@
+#include "UserFunction.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/FunctionBody.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+UserFunction::UserFunction( const SourceLocation& source_location, bool exported, std::string name,
+                            std::unique_ptr<FunctionParameterList> parameter_list,
+                            std::unique_ptr<FunctionBody> body,
+                            const SourceLocation& endfunction_location )
+  : Function( source_location, std::move( name ), std::move( parameter_list ),
+              std::move( body ) ),
+    exported( exported ),
+    endfunction_location( endfunction_location )
+{
+}
+
+void UserFunction::accept( NodeVisitor& visitor )
+{
+  visitor.visit_user_function( *this );
+}
+
+void UserFunction::describe_to( fmt::Writer& w ) const
+{
+  w << "user-function(" << name << ")";
+}
+
+FunctionBody& UserFunction::body()
+{
+  return child<FunctionBody>( 1 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/UserFunction.h
+++ b/pol-core/bscript/compiler/ast/UserFunction.h
@@ -1,0 +1,32 @@
+#ifndef POLSERVER_USERFUNCTION_H
+#define POLSERVER_USERFUNCTION_H
+
+#include "compiler/ast/Function.h"
+
+namespace Pol::Bscript::Compiler
+{
+class FunctionParameterList;
+class FunctionBody;
+class Variable;
+
+class UserFunction : public Function
+{
+public:
+  UserFunction( const SourceLocation&, bool exported, std::string name,
+                std::unique_ptr<FunctionParameterList>, std::unique_ptr<FunctionBody>,
+                const SourceLocation& endfunction_location );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const bool exported;
+  const SourceLocation endfunction_location;
+
+  std::vector<std::shared_ptr<Variable>> debug_variables;
+
+  FunctionBody& body();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_USERFUNCTION_H

--- a/pol-core/bscript/compiler/astbuilder/AvailableUserFunction.h
+++ b/pol-core/bscript/compiler/astbuilder/AvailableUserFunction.h
@@ -1,0 +1,21 @@
+#ifndef POLSERVER_AVAILABLEUSERFUNCTION_H
+#define POLSERVER_AVAILABLEUSERFUNCTION_H
+
+#include "compiler/file/SourceLocation.h"
+
+namespace antlr4
+{
+class ParserRuleContext;
+}
+
+namespace Pol::Bscript::Compiler
+{
+struct AvailableUserFunction
+{
+  SourceLocation source_location;
+  antlr4::ParserRuleContext* const parse_rule_context;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_AVAILABLEUSERFUNCTION_H

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
@@ -6,6 +6,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class BuilderWorkspace;
 struct LegacyFunctionOrder;
 class Profile;
 class Report;
@@ -23,6 +24,7 @@ public:
       const LegacyFunctionOrder* legacy_function_order );
 
 private:
+  void build_referenced_user_functions( BuilderWorkspace& );
 
   SourceFileCache& em_cache;
   SourceFileCache& inc_cache;

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -1,14 +1,18 @@
 #include "FunctionResolver.h"
 
+#include "compiler/Profile.h"
 #include "compiler/Report.h"
 #include "compiler/ast/Function.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/UserFunction.h"
+#include "compiler/astbuilder/AvailableUserFunction.h"
 #include "compiler/file/SourceLocation.h"
 #include "compiler/model/FunctionLink.h"
 
 namespace Pol::Bscript::Compiler
 {
 FunctionResolver::FunctionResolver( Report& report ) : report( report ) {}
+FunctionResolver::~FunctionResolver() = default;
 
 const Function* FunctionResolver::find( const std::string& scoped_name )
 {
@@ -17,6 +21,14 @@ const Function* FunctionResolver::find( const std::string& scoped_name )
     return ( *itr ).second;
   else
     return nullptr;
+}
+
+void FunctionResolver::register_available_user_function(
+    const SourceLocation& source_location,
+    EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx )
+{
+  register_available_user_function_parse_tree( source_location, ctx, ctx->IDENTIFIER(),
+                                               ctx->EXPORTED() );
 }
 
 void FunctionResolver::register_function_link( const std::string& name,
@@ -38,6 +50,70 @@ void FunctionResolver::register_module_function( ModuleFunctionDeclaration* mf )
   resolved_functions_by_name[mf->name] = mf;
   auto scoped_name = mf->module_name + "::" + mf->name;
   resolved_functions_by_name[scoped_name] = mf;
+}
+
+void FunctionResolver::register_user_function( UserFunction* uf )
+{
+  resolved_functions_by_name[uf->name] = uf;
+}
+
+bool FunctionResolver::resolve( std::vector<AvailableUserFunction>& to_build_ast )
+{
+  for ( auto unresolved_itr = unresolved_function_links_by_name.begin();
+        unresolved_itr != unresolved_function_links_by_name.end(); )
+  {
+    const std::string& name = ( *unresolved_itr ).first;
+    const std::vector<std::shared_ptr<FunctionLink>>& function_links = ( *unresolved_itr ).second;
+
+    auto previously_resolved_itr = resolved_functions_by_name.find( name );
+    if ( previously_resolved_itr != resolved_functions_by_name.end() )
+    {
+      Function* resolved_function = ( *previously_resolved_itr ).second;
+      for ( auto& function_link : function_links )
+      {
+        function_link->link_to( resolved_function );
+      }
+
+      unresolved_itr = unresolved_function_links_by_name.erase( unresolved_itr );
+    }
+    else
+    {
+      auto available_itr = available_user_function_parse_trees.find( name );
+      if ( available_itr != available_user_function_parse_trees.end() )
+      {
+        to_build_ast.push_back( ( *available_itr ).second );
+        available_user_function_parse_trees.erase( available_itr );
+        ++unresolved_itr;
+      }
+      else
+      {
+        // complain, super complain
+        const std::shared_ptr<FunctionLink>& function_link = ( function_links )[0];
+        report.error( function_link->source_location, "User Function '", name, "' not found.\n" );
+        unresolved_itr = unresolved_function_links_by_name.erase( unresolved_itr );
+      }
+    }
+  }
+
+  return !to_build_ast.empty();
+}
+
+void FunctionResolver::register_available_user_function_parse_tree(
+    const SourceLocation& source_location, antlr4::ParserRuleContext* ctx,
+    antlr4::tree::TerminalNode* identifier, antlr4::tree::TerminalNode* /*exported*/ )
+{
+  std::string name = identifier->getSymbol()->getText();
+  auto itr = available_user_function_parse_trees.find( name );
+  if ( itr != available_user_function_parse_trees.end() )
+  {
+    AvailableUserFunction& previous = ( *itr ).second;
+
+    report.error( source_location, "Function '", name, "' defined more than once.\n",
+                  "  Previous declaration: ", previous.source_location, "\n" );
+  }
+
+  auto auf = AvailableUserFunction{ source_location, ctx };
+  available_user_function_parse_trees.insert( { name, auf } );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -8,36 +8,51 @@
 #include <EscriptGrammar/EscriptParser.h>
 
 #include "clib/maputil.h"
-
 #include "compiler/file/SourceLocation.h"
 
 namespace Pol::Bscript::Compiler
 {
+struct AvailableUserFunction;
 class Function;
 class FunctionLink;
 class ModuleFunctionDeclaration;
 class Report;
+class UserFunction;
 
 class FunctionResolver
 {
 public:
   explicit FunctionResolver( Report& );
+  ~FunctionResolver();
 
   const Function* find( const std::string& scoped_name );
 
+  void register_available_user_function(
+      const SourceLocation&, EscriptGrammar::EscriptParser::FunctionDeclarationContext* );
   void register_function_link( const std::string& name,
                                std::shared_ptr<FunctionLink> function_link );
   void register_module_function( ModuleFunctionDeclaration* );
+  void register_user_function( UserFunction* );
+
+  bool resolve( std::vector<AvailableUserFunction>& user_functions_to_build );
 
 private:
 
+  void register_available_user_function_parse_tree( const SourceLocation&,
+                                                    antlr4::ParserRuleContext*,
+                                                    antlr4::tree::TerminalNode* identifier,
+                                                    antlr4::tree::TerminalNode* exported );
+
   Report& report;
+
+  using UserFunctionMap = std::map<std::string, AvailableUserFunction, Clib::ci_cmp_pred>;
 
   using FunctionMap = std::map<std::string, Function*, Clib::ci_cmp_pred>;
 
   using FunctionReferenceMap =
       std::map<std::string, std::vector<std::shared_ptr<FunctionLink>>, Clib::ci_cmp_pred>;
 
+  UserFunctionMap available_user_function_parse_trees;
   FunctionMap resolved_functions_by_name;
   FunctionReferenceMap unresolved_function_links_by_name;
 };

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -93,6 +93,13 @@ void SourceFileProcessor::process_source( SourceFile& sf )
   }
 }
 
+antlrcpp::Any SourceFileProcessor::visitFunctionDeclaration(
+    EscriptParser::FunctionDeclarationContext* ctx )
+{
+  workspace.function_resolver.register_available_user_function( location_for( *ctx ), ctx );
+  return antlrcpp::Any();
+}
+
 antlrcpp::Any SourceFileProcessor::visitProgramDeclaration(
     EscriptParser::ProgramDeclarationContext* ctx )
 {

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -24,6 +24,8 @@ public:
                    long long* micros_counted = nullptr );
   void process_source( SourceFile& );
 
+  antlrcpp::Any visitFunctionDeclaration(
+      EscriptGrammar::EscriptParser::FunctionDeclarationContext* ) override;
   antlrcpp::Any visitProgramDeclaration(
       EscriptGrammar::EscriptParser::ProgramDeclarationContext* ) override;
   antlrcpp::Any visitStatement( EscriptGrammar::EscriptParser::StatementContext* ) override;

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -1,11 +1,64 @@
 #include "UserFunctionBuilder.h"
 
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/FunctionBody.h"
+#include "compiler/ast/FunctionParameterDeclaration.h"
+#include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/UserFunction.h"
+
+using EscriptGrammar::EscriptParser;
+
 namespace Pol::Bscript::Compiler
 {
 UserFunctionBuilder::UserFunctionBuilder( const SourceFileIdentifier& source_file_identifier,
                                           BuilderWorkspace& workspace )
   : CompoundStatementBuilder( source_file_identifier, workspace )
 {
+}
+
+std::unique_ptr<UserFunction> UserFunctionBuilder::function_declaration(
+    EscriptParser::FunctionDeclarationContext* ctx )
+{
+  std::string name = text( ctx->IDENTIFIER() );
+  std::vector<std::unique_ptr<FunctionParameterDeclaration>> parameters;
+  if ( auto function_parameters = ctx->functionParameters() )
+  {
+    if ( auto param_list = function_parameters->functionParameterList() )
+    {
+      for ( auto param : param_list->functionParameter() )
+      {
+        std::string parameter_name = text( param->IDENTIFIER() );
+        std::unique_ptr<FunctionParameterDeclaration> parameter_declaration;
+        bool byref = param->BYREF() != nullptr;
+        bool unused = param->UNUSED() != nullptr;
+
+        if ( auto expr_ctx = param->expression() )
+        {
+          auto default_value = expression( expr_ctx );
+          parameter_declaration = std::make_unique<FunctionParameterDeclaration>(
+              location_for( *param ), std::move( parameter_name ), byref, unused,
+              std::move( default_value ) );
+        }
+        else
+        {
+          parameter_declaration = std::make_unique<FunctionParameterDeclaration>(
+              location_for( *param ), std::move( parameter_name ), byref, unused );
+        }
+
+        parameters.push_back( std::move( parameter_declaration ) );
+      }
+    }
+  }
+  auto parameter_list =
+      std::make_unique<FunctionParameterList>( location_for( *ctx ), std::move( parameters ) );
+  auto body =
+      std::make_unique<FunctionBody>( location_for( *ctx ), block_statements( ctx->block() ) );
+
+  bool exported = ctx->EXPORTED() != nullptr;
+  return std::make_unique<UserFunction>( location_for( *ctx ), exported, std::move( name ),
+                                         std::move( parameter_list ), std::move( body ),
+                                         location_for( *ctx->ENDFUNCTION() ) );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
@@ -5,11 +5,15 @@
 
 namespace Pol::Bscript::Compiler
 {
+class UserFunction;
 
 class UserFunctionBuilder : public CompoundStatementBuilder
 {
 public:
   UserFunctionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  std::unique_ptr<UserFunction> function_declaration(
+      EscriptGrammar::EscriptParser::FunctionDeclarationContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
@@ -1,0 +1,23 @@
+#include "UserFunctionVisitor.h"
+
+#include "compiler/ast/UserFunction.h"
+#include "compiler/astbuilder/BuilderWorkspace.h"
+#include "compiler/model/CompilerWorkspace.h"
+
+namespace Pol::Bscript::Compiler
+{
+UserFunctionVisitor::UserFunctionVisitor( const SourceFileIdentifier& sfi, BuilderWorkspace& ws )
+  : workspace( ws ), tree_builder( sfi, ws )
+{
+}
+
+antlrcpp::Any UserFunctionVisitor::visitFunctionDeclaration(
+    EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx )
+{
+  auto uf = tree_builder.function_declaration( ctx );
+  workspace.function_resolver.register_user_function( uf.get() );
+  workspace.compiler_workspace.user_functions.push_back( std::move( uf ) );
+  return antlrcpp::Any();
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.h
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_USERFUNCTIONVISITOR_H
+#define POLSERVER_USERFUNCTIONVISITOR_H
+
+#include <EscriptGrammar/EscriptParserBaseVisitor.h>
+
+#include "compiler/astbuilder/UserFunctionBuilder.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Profile;
+class Report;
+class SourceFileIdentifier;
+class BuilderWorkspace;
+
+class UserFunctionVisitor : public EscriptGrammar::EscriptParserBaseVisitor
+{
+public:
+  UserFunctionVisitor( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  antlrcpp::Any visitFunctionDeclaration(
+      EscriptGrammar::EscriptParser::FunctionDeclarationContext* ) override;
+
+private:
+  BuilderWorkspace& workspace;
+
+  UserFunctionBuilder tree_builder;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_USERFUNCTIONVISITOR_H

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -29,6 +29,10 @@ private:
   static void sort_module_functions_by_module_name( CompilerWorkspace& );
   static void sort_module_functions_alphabetically( CompilerWorkspace& );
 
+  static void sort_user_functions( CompilerWorkspace&, const LegacyFunctionOrder* );
+  static void sort_user_functions_as_legacy( CompilerWorkspace&, const LegacyFunctionOrder& );
+  static void sort_user_functions_alphabetically( CompilerWorkspace& );
+
 private:
   ModuleDeclarationRegistrar& module_declaration_registrar;
 

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -71,6 +71,12 @@ void InstructionEmitter::call_modulefunc(
   append_token( token );
 }
 
+void InstructionEmitter::call_userfunc( FlowControlLabel& label )
+{
+  unsigned addr = emit_token( CTRL_JSR_USERFUNC, TYP_CONTROL );
+  register_with_label( label, addr );
+}
+
 void InstructionEmitter::consume()
 {
   emit_token( TOK_CONSUMER, TYP_UNARY_OPERATOR );
@@ -123,9 +129,31 @@ void InstructionEmitter::leaveblock( unsigned local_vars_to_remove )
   emit_token( CTRL_LEAVE_BLOCK, TYP_CONTROL, local_vars_to_remove );
 }
 
+void InstructionEmitter::makelocal()
+{
+  emit_token( CTRL_MAKELOCAL, TYP_CONTROL );
+}
+
+void InstructionEmitter::pop_param( const std::string& name )
+{
+  unsigned offset = emit_data( name );
+  emit_token( INS_POP_PARAM, TYP_OPERATOR, offset );
+}
+
+void InstructionEmitter::pop_param_byref( const std::string& name )
+{
+  unsigned offset = emit_data( name );
+  emit_token( INS_POP_PARAM_BYREF, TYP_OPERATOR, offset );
+}
+
 void InstructionEmitter::progend()
 {
   emit_token( CTRL_PROGEND, TYP_CONTROL );
+}
+
+void InstructionEmitter::return_from_user_function()
+{
+  emit_token( RSV_RETURN, TYP_RESERVED );
 }
 
 void InstructionEmitter::unary_operator( BTokenId token_id )

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -25,7 +25,6 @@ class StoredToken;
 
 namespace Pol::Bscript::Compiler
 {
-class CaseJumpDataBlock;
 class CompiledScript;
 class FlowControlLabel;
 class ModuleDeclarationRegistrar;
@@ -48,6 +47,7 @@ public:
   void call_method( const std::string& name, unsigned argument_count );
   void call_method_id( MethodID method_id, unsigned argument_count );
   void call_modulefunc( const ModuleFunctionDeclaration& );
+  void call_userfunc( FlowControlLabel& );
   void consume();
   void declare_variable( const Variable& );
   void exit();
@@ -57,7 +57,11 @@ public:
   void jmp_if_true( FlowControlLabel& );
   void label( FlowControlLabel& );
   void leaveblock( unsigned local_vars_to_remove );
+  void makelocal();
+  void pop_param( const std::string& name );
+  void pop_param_byref( const std::string& name );
   void progend();
+  void return_from_user_function();
   void unary_operator( BTokenId );
   void value( double );
   void value( int );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -93,7 +93,8 @@ void InstructionGenerator::visit_function_parameter_list( FunctionParameterList&
   }
 }
 
-void InstructionGenerator::visit_function_parameter_declaration( FunctionParameterDeclaration& node )
+void InstructionGenerator::visit_function_parameter_declaration(
+    FunctionParameterDeclaration& node )
 {
   if ( node.byref )
     emit.pop_param_byref( node.name );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -8,12 +8,15 @@
 
 namespace Pol::Bscript::Compiler
 {
+class FlowControlLabel;
 class InstructionEmitter;
 
 class InstructionGenerator : public NodeVisitor
 {
 public:
-  explicit InstructionGenerator( InstructionEmitter& );
+  explicit InstructionGenerator( InstructionEmitter&,
+                                 std::map<std::string, FlowControlLabel>& user_function_labels,
+                                 bool in_function );
 
   void generate( Node& );
 
@@ -21,6 +24,8 @@ public:
   void visit_exit_statement( ExitStatement& ) override;
   void visit_float_value( FloatValue& ) override;
   void visit_function_call( FunctionCall& ) override;
+  void visit_function_parameter_list( FunctionParameterList& ) override;
+  void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_integer_value( IntegerValue& ) override;
@@ -29,6 +34,7 @@ public:
   void visit_return_statement( ReturnStatement& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
+  void visit_user_function( UserFunction& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
   void visit_var_statement( VarStatement& ) override;
 
@@ -38,6 +44,9 @@ private:
   // and sometimes it reads better as a verb.
   InstructionEmitter& emitter;
   InstructionEmitter& emit;
+
+  std::map<std::string, FlowControlLabel>& user_function_labels;
+  const bool in_function;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -58,6 +58,15 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "progend";
     break;
 
+  case CTRL_MAKELOCAL:
+    w << "makelocal";
+    break;
+  case CTRL_JSR_USERFUNC:
+    w << "jsr userfunc @" << tkn.offset;
+    break;
+  case INS_POP_PARAM:
+    w << "pop param '" << string_at( tkn.offset ) << "'";
+    break;
   case CTRL_LEAVE_BLOCK:
     w << "leave block (remove " + std::to_string( tkn.offset ) + " locals)";
     break;
@@ -70,6 +79,9 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
      break;
    case RSV_GOTO:
      w << "goto " << tkn.offset;
+     break;
+   case RSV_RETURN:
+     w << "return";
      break;
    case RSV_EXIT:
      w << "exit";
@@ -112,6 +124,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
 
   case INS_GET_ARG:
     w << "get arg '" << string_at( tkn.offset ) << "'";
+    break;
+
+  case INS_POP_PARAM_BYREF:
+    w << "pop param byref '" << string_at( tkn.offset ) << "'";
     break;
 
   case TOK_UNPLUSPLUS:

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -3,6 +3,7 @@
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/ast/UserFunction.h"
 #include "compiler/file/SourceFileIdentifier.h"
 
 namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -13,6 +13,7 @@ class Program;
 class SourceFile;
 class SourceFileIdentifier;
 class TopLevelStatements;
+class UserFunction;
 
 class CompilerWorkspace
 {
@@ -22,6 +23,7 @@ public:
 
   std::unique_ptr<TopLevelStatements> top_level_statements;
   std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;
+  std::vector<std::unique_ptr<UserFunction>> user_functions;
   std::unique_ptr<Program> program;
 
   // These reference ModuleFunctionDeclaration objects that are in module_functions

--- a/pol-core/bscript/compiler/model/FunctionLink.cpp
+++ b/pol-core/bscript/compiler/model/FunctionLink.cpp
@@ -1,6 +1,7 @@
 #include "FunctionLink.h"
 
 #include "compiler/ast/ModuleFunctionDeclaration.h"
+#include "compiler/ast/UserFunction.h"
 #include "compiler/file/SourceLocation.h"
 
 namespace Pol::Bscript::Compiler
@@ -18,6 +19,11 @@ Function* FunctionLink::function() const
 ModuleFunctionDeclaration* FunctionLink::module_function_declaration() const
 {
   return dynamic_cast<ModuleFunctionDeclaration*>( linked_function );
+}
+
+UserFunction* FunctionLink::user_function() const
+{
+  return dynamic_cast<UserFunction*>( linked_function );
 }
 
 void FunctionLink::link_to( Function* f )

--- a/pol-core/bscript/compiler/model/FunctionLink.h
+++ b/pol-core/bscript/compiler/model/FunctionLink.h
@@ -7,6 +7,7 @@ namespace Pol::Bscript::Compiler
 {
 class Function;
 class ModuleFunctionDeclaration;
+class UserFunction;
 
 class FunctionLink
 {
@@ -17,6 +18,7 @@ public:
 
   [[nodiscard]] Function* function() const;
   [[nodiscard]] ModuleFunctionDeclaration* module_function_declaration() const;
+  [[nodiscard]] UserFunction* user_function() const;
 
   void link_to( Function* );
 

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -963,6 +963,8 @@ bool run( int argc, char** argv, int* res )
     tmp << "      - parse *.src:   " << (long long)summary.profile.parse_src_micros / 1000 << " ("
         << (long)summary.profile.parse_src_count << ")\n";
     tmp << "        - ast *.src:   " << (long long)summary.profile.ast_src_micros / 1000 << "\n";
+    tmp << "  resolve functions:   "
+        << (long long)summary.profile.ast_resolve_functions_micros / 1000 << "\n";
     tmp << " register constants: "
         << (long long)summary.profile.register_const_declarations_micros / 1000 << "\n";
     tmp << "            analyze: " << (long long)summary.profile.analyze_micros / 1000 << "\n";


### PR DESCRIPTION
"Limited" in this case means:
- default parameter values don't work. (next PR)
- pass-by-name doesn't work. (next PR)
- exported functions are not yet supported

Adds:
- [ast/UserFunction](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/UserFunction.h) AST node for user-defined functions.
- [astbuilder/AvailableUserFunction](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/AvailableUserFunction.h): reference to a parse tree for a user function.
  - The AST builder only generates ASTs for user functions that are actually referenced.
- [astbuilder/UserFunctionVisitor](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.h): visits (builds an AST for) a parse tree for a user function.
  - This happens after the .src or .inc file has been otherwise processed, so this class serves to hook up the correct SourceFileIdentifier to the AST.

The compiler2/ scripts now compile with parity up to [compiler2/compiler2-018-function-call-multi-parameter.src](https://github.com/polserver/polserver/blob/ecompile-antlr/testsuite/escript/compiler2/compiler2-018-function-call-multi-parameter.src), which is:
```
function display(a, b)
    print(a);
    print(b);
endfunction

display("hello", "world");
```
