### PR TITLE
Handle function call parameters, and return statements in functions

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -99,6 +99,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/ProgramBuilder.h
   compiler/astbuilder/SimpleStatementBuilder.cpp
   compiler/astbuilder/SimpleStatementBuilder.h
+  compiler/astbuilder/SimpleValueCloner.cpp
+  compiler/astbuilder/SimpleValueCloner.h
   compiler/astbuilder/SourceFileProcessor.cpp
   compiler/astbuilder/SourceFileProcessor.h
   compiler/astbuilder/TreeBuilder.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -28,6 +28,7 @@ public:
   void analyze( CompilerWorkspace& );
 
   void visit_block( Block& ) override;
+  void visit_function_call( FunctionCall& ) override;
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
   void visit_identifier( Identifier& ) override;

--- a/pol-core/bscript/compiler/astbuilder/SimpleValueCloner.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleValueCloner.cpp
@@ -1,0 +1,62 @@
+#include "SimpleValueCloner.h"
+
+#include "compiler/Report.h"
+#include "compiler/ast/Argument.h"
+#include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/IntegerValue.h"
+#include "compiler/ast/StringValue.h"
+#include "compiler/model/FunctionLink.h"
+
+namespace Pol::Bscript::Compiler
+{
+SimpleValueCloner::SimpleValueCloner( Report& report, const SourceLocation& use_source_location )
+    : report( report ), use_source_location( use_source_location )
+{
+}
+
+std::unique_ptr<Node> SimpleValueCloner::clone( Node& node )
+{
+  node.accept( *this );
+  return std::move( cloned_value );
+}
+
+void SimpleValueCloner::visit_float_value( FloatValue& fv )
+{
+  cloned_value = std::make_unique<FloatValue>( use_source_location, fv.value );
+}
+
+void SimpleValueCloner::visit_function_call( FunctionCall& fc )
+{
+  if ( fc.function_link->module_function_declaration() && fc.children.empty() )
+  {
+    std::vector<std::unique_ptr<Argument>> no_args;
+    auto new_fc = std::make_unique<FunctionCall>( use_source_location, fc.scope, fc.method_name,
+                                                    std::move( no_args ) );
+    new_fc->function_link->link_to( fc.function_link->function() );
+    cloned_value = std::move( new_fc );
+  }
+}
+
+void SimpleValueCloner::visit_identifier( Identifier& ident )
+{
+  report.error( ident, "Cannot clone '", ident.name, "' because it is not a constant.\n" );
+}
+
+void SimpleValueCloner::visit_integer_value( IntegerValue& iv )
+{
+  cloned_value = std::make_unique<IntegerValue>( use_source_location, iv.value );
+}
+
+void SimpleValueCloner::visit_string_value( StringValue& sv )
+{
+  cloned_value = std::make_unique<StringValue>( use_source_location, sv.value );
+}
+
+void SimpleValueCloner::visit_children( Node& parent )
+{
+  report.error( parent, "Cannot optimize this expression:\n", parent, "\n" );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/SimpleValueCloner.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleValueCloner.h
@@ -1,0 +1,37 @@
+#ifndef POLSERVER_SIMPLEVALUECLONER_H
+#define POLSERVER_SIMPLEVALUECLONER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+#include "compiler/file/SourceLocation.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Report;
+
+class SimpleValueCloner : private NodeVisitor
+{
+public:
+  explicit SimpleValueCloner( Report&, const SourceLocation& );
+
+  std::unique_ptr<Node> clone( Node& );
+
+  void visit_float_value( FloatValue& ) override;
+  void visit_function_call( FunctionCall& ) override;
+  void visit_identifier( Identifier& ) override;
+  void visit_integer_value( IntegerValue& ) override;
+  void visit_string_value( StringValue& ) override;
+
+  void visit_children( Node& parent ) override;
+
+private:
+  Report& report;
+  std::unique_ptr<Node> cloned_value;
+  SourceLocation use_source_location;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SIMPLEVALUECLONER_H

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -175,7 +175,14 @@ void InstructionGenerator::visit_return_statement( ReturnStatement& ret )
 {
   visit_children( ret );
 
-  emit.progend();
+  if ( in_function )
+  {
+    emit.return_from_user_function();
+  }
+  else
+  {
+    emit.progend();
+  }
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )


### PR DESCRIPTION
Process function call parameters to account for:
- default parameter values
- passing parameters by name

Also handle `return` within a function (I left this out of the previous PR)

Adds:
- [astbuilder/SimpleValueCloner](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/astbuilder/SimpleValueCloner.cpp): clones values that are valid as constants and parameter default values.