### PR TITLE
New compiler: Add support for const declarations

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -14,6 +14,8 @@ set (bscript_sources    # sorted !
   compiler/Compiler.cpp
   compiler/Compiler.h
   compiler/LegacyFunctionOrder.h
+  compiler/analyzer/Constants.cpp
+  compiler/analyzer/Constants.h
   compiler/analyzer/Disambiguator.cpp
   compiler/analyzer/Disambiguator.h
   compiler/analyzer/LocalVariableScope.cpp
@@ -28,6 +30,8 @@ set (bscript_sources    # sorted !
   compiler/ast/Argument.h
   compiler/ast/Block.cpp
   compiler/ast/Block.h
+  compiler/ast/ConstDeclaration.cpp
+  compiler/ast/ConstDeclaration.h
   compiler/ast/ExitStatement.cpp
   compiler/ast/ExitStatement.h
   compiler/ast/Expression.cpp
@@ -151,6 +155,8 @@ set (bscript_sources    # sorted !
   compiler/model/Variable.h
   compiler/model/VariableScope.h
   compiler/model/WarnOn.h
+  compiler/optimizer/ConstantValidator.cpp
+  compiler/optimizer/ConstantValidator.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
   compiler/optimizer/ReferencedFunctionGatherer.cpp

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -137,7 +137,7 @@ void Compiler::register_constants( CompilerWorkspace& workspace )
 void Compiler::optimize( CompilerWorkspace& workspace, Report& report )
 {
   Pol::Tools::HighPerfTimer timer;
-  Optimizer optimizer( report );
+  Optimizer optimizer( workspace.constants, report );
   optimizer.optimize( workspace );
   profile.optimize_micros += timer.ellapsed().count();
 }
@@ -153,7 +153,7 @@ void Compiler::disambiguate( CompilerWorkspace& workspace, Report& report )
 void Compiler::analyze( CompilerWorkspace& workspace, Report& report )
 {
   Pol::Tools::HighPerfTimer timer;
-  SemanticAnalyzer analyzer( report );
+  SemanticAnalyzer analyzer( workspace.constants, report );
   analyzer.analyze( workspace );
   profile.analyze_micros += timer.ellapsed().count();
 }

--- a/pol-core/bscript/compiler/analyzer/Constants.cpp
+++ b/pol-core/bscript/compiler/analyzer/Constants.cpp
@@ -1,0 +1,40 @@
+#include "Constants.h"
+
+#include "compiler/Report.h"
+#include "compiler/ast/ConstDeclaration.h"
+
+namespace Pol::Bscript::Compiler
+{
+Constants::Constants( Report& report ) : report( report ) {}
+
+ConstDeclaration* Constants::find( const std::string& name )
+{
+  auto itr = constants.find( name );
+  return ( itr != constants.end() ) ? ( *itr ).second : nullptr;
+}
+
+void Constants::create( ConstDeclaration& constant )
+{
+  auto itr = constants.find( constant.identifier );
+  if ( itr != constants.end() )
+  {
+    if ( constant.ignore_overwrite_attempt )
+    {
+      // The OG compiler ignores enum members with the same name as a
+      // constant or enum that was defined earlier.
+
+      report.warning( constant, "Constant '", constant.identifier,
+                      "' definition ignored due to an earlier definition.\n",
+                      "  Previous definition at: ",
+                      ( *itr ).second->source_location, "\n" );
+      return;
+    }
+    report.error( constant, "Constant '", constant.identifier, "' defined more than once.\n",
+                  "  Previous definition at: ",
+                  ( *itr ).second->source_location, "\n" );
+  }
+
+  constants[constant.identifier] = &constant;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/Constants.h
+++ b/pol-core/bscript/compiler/analyzer/Constants.h
@@ -1,0 +1,29 @@
+#ifndef POLSERVER_CONSTANTS_H
+#define POLSERVER_CONSTANTS_H
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class ConstDeclaration;
+class Report;
+
+class Constants
+{
+public:
+  explicit Constants( Report& );
+
+  ConstDeclaration* find( const std::string& name );
+  void create( ConstDeclaration& );
+
+private:
+  std::map<std::string, ConstDeclaration*> constants;
+  Report& report;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_CONSTANTS_H

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -13,6 +13,7 @@
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
+class Constants;
 class Identifier;
 class Report;
 class VarStatement;
@@ -20,7 +21,7 @@ class VarStatement;
 class SemanticAnalyzer : public NodeVisitor
 {
 public:
-  explicit SemanticAnalyzer( Report& );
+  SemanticAnalyzer( Constants&, Report& );
 
   ~SemanticAnalyzer() override;
 
@@ -38,6 +39,7 @@ public:
   void visit_var_statement( VarStatement& ) override;
 
 private:
+  Constants& constants;
   Report& report;
 
   Variables globals;

--- a/pol-core/bscript/compiler/ast/ConstDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ConstDeclaration.cpp
@@ -1,0 +1,35 @@
+#include "ConstDeclaration.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ConstDeclaration::ConstDeclaration( const SourceLocation& source_location, std::string identifier,
+                                    std::unique_ptr<Expression> expression,
+                                    bool ignore_overwrite_attempt )
+    : Node( source_location, std::move( expression ) ),
+      identifier( std::move( identifier ) ),
+      ignore_overwrite_attempt( ignore_overwrite_attempt )
+{
+}
+
+Expression& ConstDeclaration::expression()
+{
+  return child<Expression>( 0 );
+}
+
+void ConstDeclaration::accept( NodeVisitor& visitor )
+{
+  visitor.visit_const_declaration( *this );
+}
+
+void ConstDeclaration::describe_to( fmt::Writer& w ) const
+{
+  w << "const-declaration(" << identifier << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ConstDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ConstDeclaration.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_CONSTDECLARATION_H
+#define POLSERVER_CONSTDECLARATION_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class NodeVisitor;
+class Expression;
+class SourceLocation;
+
+class ConstDeclaration : public Node
+{
+public:
+  const std::string identifier;
+
+  ConstDeclaration( const SourceLocation&, std::string identifier, std::unique_ptr<Expression>,
+                    bool ignore_overwrite_attempt = false );
+
+
+  Expression& expression();
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const bool ignore_overwrite_attempt;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_CONSTDECLARATION_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -2,6 +2,7 @@
 
 #include "compiler/ast/Argument.h"
 #include "compiler/ast/Block.h"
+#include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
@@ -29,6 +30,11 @@ void NodeVisitor::visit_argument( Argument& node )
 }
 
 void NodeVisitor::visit_block( Block& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_const_declaration( ConstDeclaration& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -5,6 +5,7 @@ namespace Pol::Bscript::Compiler
 {
 class Argument;
 class Block;
+class ConstDeclaration;
 class ExitStatement;
 class FloatValue;
 class FunctionBody;
@@ -34,6 +35,7 @@ public:
 
   virtual void visit_argument( Argument& );
   virtual void visit_block( Block& );
+  virtual void visit_const_declaration( ConstDeclaration& );
   virtual void visit_exit_statement( ExitStatement& );
   virtual void visit_float_value( FloatValue& );
   virtual void visit_function_body( FunctionBody& );

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -30,7 +30,7 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileCache& em_cache,
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
     const std::string& pathname, const LegacyFunctionOrder* /*legacy_function_order*/ )
 {
-  auto compiler_workspace = std::make_unique<CompilerWorkspace>();
+  auto compiler_workspace = std::make_unique<CompilerWorkspace>( report );
   BuilderWorkspace workspace( *compiler_workspace, em_cache, inc_cache, profile, report );
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
@@ -1,6 +1,7 @@
 #include "ModuleProcessor.h"
 
 #include "compiler/Profile.h"
+#include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/file/SourceFile.h"
@@ -30,6 +31,11 @@ antlrcpp::Any ModuleProcessor::visitModuleDeclarationStatement(
     workspace.function_resolver.register_module_function( ast.get() );
 
     workspace.compiler_workspace.module_function_declarations.push_back( std::move( ast ) );
+  }
+  else if ( auto constStatement = ctx->constStatement() )
+  {
+    workspace.compiler_workspace.const_declarations.push_back(
+        tree_builder.const_declaration( constStatement ) );
   }
   return antlrcpp::Any();
 }

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -1,6 +1,7 @@
 #include "SimpleStatementBuilder.h"
 
 #include "compiler/Report.h"
+#include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/Expression.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/IntegerValue.h"
@@ -53,6 +54,18 @@ void SimpleStatementBuilder::add_var_statements(
       statements.push_back( std::move( consumed ) );
     }
   }
+}
+
+std::unique_ptr<ConstDeclaration> SimpleStatementBuilder::const_declaration(
+    EscriptParser::ConstStatementContext* ctx )
+{
+  auto variable_declaration = ctx->variableDeclaration();
+  auto identifier = text( variable_declaration->IDENTIFIER() );
+  auto expression_context = variable_declaration->variableDeclarationInitializer()->expression();
+  auto value = expression( expression_context );
+
+  return std::make_unique<ConstDeclaration>( location_for( *ctx ), std::move( identifier ),
+                                               std::move( value ) );
 }
 
 std::unique_ptr<Statement> SimpleStatementBuilder::consume_statement_result(

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -5,6 +5,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class ConstDeclaration;
 class Statement;
 class ReturnStatement;
 
@@ -15,6 +16,9 @@ public:
 
   void add_var_statements( EscriptGrammar::EscriptParser::VarStatementContext*,
                            std::vector<std::unique_ptr<Statement>>& );
+
+  std::unique_ptr<ConstDeclaration> const_declaration(
+      EscriptGrammar::EscriptParser::ConstStatementContext* );
 
   static std::unique_ptr<Statement> consume_statement_result(
       std::unique_ptr<Statement> statement );

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -4,6 +4,7 @@
 #include "clib/timer.h"
 #include "compiler/Profile.h"
 #include "compiler/Report.h"
+#include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/Program.h"
 #include "compiler/ast/Statement.h"
 #include "compiler/ast/TopLevelStatements.h"
@@ -120,6 +121,8 @@ antlrcpp::Any SourceFileProcessor::visitStatement( EscriptParser::StatementConte
 {
   if ( auto constStatement = ctx->constStatement() )
   {
+    workspace.compiler_workspace.const_declarations.push_back(
+        tree_builder.const_declaration( constStatement ) );
   }
   else
   {

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -3,13 +3,45 @@
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Program.h"
 #include "compiler/ast/TopLevelStatements.h"
+#include "compiler/analyzer/Constants.h"
+#include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/UserFunction.h"
 #include "compiler/file/SourceFileIdentifier.h"
 
 namespace Pol::Bscript::Compiler
 {
-CompilerWorkspace::CompilerWorkspace() = default;
+CompilerWorkspace::CompilerWorkspace( Report& report ) : constants( report ) {}
 
 CompilerWorkspace::~CompilerWorkspace() = default;
+
+/*
+ * This method is the main argument for making this class into an ast/Node.
+ * However, it has only one caller: the Optimizer.
+ * Other classes visit parts of the tree or do things in between visiting parts.
+ */
+void CompilerWorkspace::accept( NodeVisitor& visitor )
+{
+  for ( auto& constant : const_declarations )
+  {
+    constant->accept( visitor );
+  }
+
+  for ( auto& module_function : module_function_declarations )
+  {
+    module_function->accept( visitor );
+  }
+
+  top_level_statements->accept( visitor );
+
+  if ( program )
+  {
+    program->accept( visitor );
+  }
+
+  for ( auto& user_function : user_functions )
+  {
+    user_function->accept( visitor );
+  }
+}
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -5,11 +5,16 @@
 #include <string>
 #include <vector>
 
+#include "compiler/analyzer/Constants.h"
+#include "compiler/ast/Node.h"
+
 namespace Pol::Bscript::Compiler
 {
 class Block;
+class ConstDeclaration;
 class ModuleFunctionDeclaration;
 class Program;
+class Report;
 class SourceFile;
 class SourceFileIdentifier;
 class TopLevelStatements;
@@ -18,8 +23,13 @@ class UserFunction;
 class CompilerWorkspace
 {
 public:
-  CompilerWorkspace();
+  explicit CompilerWorkspace( Report& );
   ~CompilerWorkspace();
+
+  void accept( NodeVisitor& );
+
+  std::vector<std::unique_ptr<ConstDeclaration>> const_declarations;
+  Constants constants;
 
   std::unique_ptr<TopLevelStatements> top_level_statements;
   std::vector<std::unique_ptr<ModuleFunctionDeclaration>> module_function_declarations;

--- a/pol-core/bscript/compiler/optimizer/ConstantValidator.cpp
+++ b/pol-core/bscript/compiler/optimizer/ConstantValidator.cpp
@@ -1,0 +1,47 @@
+#include "ConstantValidator.h"
+
+#include "compiler/ast/ConstDeclaration.h"
+#include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/IntegerValue.h"
+#include "compiler/ast/StringValue.h"
+#include "compiler/model/FunctionLink.h"
+
+namespace Pol::Bscript::Compiler
+{
+ConstantValidator::ConstantValidator() : valid( false ) {}
+
+bool ConstantValidator::validate( Node& node )
+{
+  valid = false;
+  node.accept( *this );
+  return valid;
+}
+
+void ConstantValidator::visit_float_value( FloatValue& )
+{
+  valid = true;
+}
+
+void ConstantValidator::visit_function_call( FunctionCall& fc )
+{
+  // this was only allowed by accident.
+  valid = ( fc.function_link->module_function_declaration() && fc.children.empty() );
+}
+
+void ConstantValidator::visit_integer_value( IntegerValue& )
+{
+  valid = true;
+}
+
+void ConstantValidator::visit_string_value( StringValue& )
+{
+  valid = true;
+}
+
+void ConstantValidator::visit_children( Node& )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ConstantValidator.h
+++ b/pol-core/bscript/compiler/optimizer/ConstantValidator.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_CONSTANTVALIDATOR_H
+#define POLSERVER_CONSTANTVALIDATOR_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+
+class ConstantValidator : public NodeVisitor
+{
+public:
+  ConstantValidator();
+
+  bool validate( Node& );
+
+  void visit_float_value( FloatValue& ) override;
+  void visit_function_call( FunctionCall& ) override;
+  void visit_integer_value( IntegerValue& ) override;
+  void visit_string_value( StringValue& ) override;
+
+  void visit_children( Node& parent ) override;
+
+private:
+  bool valid;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_CONSTANTVALIDATOR_H

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -7,22 +7,26 @@
 
 namespace Pol::Bscript::Compiler
 {
-class Report;
 class CompilerWorkspace;
+class Constants;
+class Report;
 
 class Optimizer : public NodeVisitor
 {
 public:
-  explicit Optimizer( Report& );
+  Optimizer( Constants&, Report& );
 
   void optimize( CompilerWorkspace& );
   void visit_children( Node& ) override;
 
+  void visit_const_declaration( ConstDeclaration& ) override;
+  void visit_identifier( Identifier& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
 
   std::unique_ptr<Node> optimized_replacement;
 
 private:
+  Constants& constants;
   Report& report;
 };
 


### PR DESCRIPTION
Adds:
- [analyzer/Constants](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/Constants.cpp): holds constant name -> value for lookup
- [ast/ConstDeclaration](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ConstDeclaration.cpp): AST node for a const declaration
- [optimizer/ConstValidator](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/ConstantValidator.cpp): validates that an optimized expression is valid to use as a constant.

the Optimizer [converts Identifiers](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/Optimizer.cpp#L106) that refer to a constant to the optimized constant value.