### PR TITLE
Optimizations: binary operators

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -157,6 +157,14 @@ set (bscript_sources    # sorted !
   compiler/model/Variable.h
   compiler/model/VariableScope.h
   compiler/model/WarnOn.h
+  compiler/optimizer/BinaryOperatorOptimizer.cpp
+  compiler/optimizer/BinaryOperatorOptimizer.h
+  compiler/optimizer/BinaryOperatorWithFloatOptimizer.cpp
+  compiler/optimizer/BinaryOperatorWithFloatOptimizer.h
+  compiler/optimizer/BinaryOperatorWithIntegerOptimizer.cpp
+  compiler/optimizer/BinaryOperatorWithIntegerOptimizer.h
+  compiler/optimizer/BinaryOperatorWithStringOptimizer.cpp
+  compiler/optimizer/BinaryOperatorWithStringOptimizer.h
   compiler/optimizer/ConstantValidator.cpp
   compiler/optimizer/ConstantValidator.h
   compiler/optimizer/Optimizer.cpp

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorOptimizer.cpp
@@ -1,0 +1,47 @@
+#include "BinaryOperatorOptimizer.h"
+
+#include "compiler/ast/BinaryOperator.h"
+
+#include "BinaryOperatorWithFloatOptimizer.h"
+#include "BinaryOperatorWithIntegerOptimizer.h"
+#include "BinaryOperatorWithStringOptimizer.h"
+
+namespace Pol::Bscript::Compiler
+{
+BinaryOperatorOptimizer::BinaryOperatorOptimizer( BinaryOperator& op, Report& report )
+    : op( op ), report( report )
+{
+}
+
+std::unique_ptr<Expression> BinaryOperatorOptimizer::optimize()
+{
+  op.lhs().accept( *this );
+  return std::move( optimized_result );
+}
+
+void BinaryOperatorOptimizer::visit_children( Node& )
+{
+}
+
+void BinaryOperatorOptimizer::visit_float_value( FloatValue& lhs )
+{
+  BinaryOperatorWithFloatOptimizer optimizer( lhs, op, report );
+  op.rhs().accept( optimizer );
+  optimized_result = std::move( optimizer.optimized_result );
+}
+
+void BinaryOperatorOptimizer::visit_integer_value( IntegerValue& lhs )
+{
+  BinaryOperatorWithIntegerOptimizer optimizer( lhs, op, report );
+  op.rhs().accept( optimizer );
+  optimized_result = std::move( optimizer.optimized_result );
+}
+
+void BinaryOperatorOptimizer::visit_string_value( StringValue& lhs )
+{
+  BinaryOperatorWithStringOptimizer optimizer( lhs, op );
+  op.rhs().accept( optimizer );
+  optimized_result = std::move( optimizer.optimized_result );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorOptimizer.h
@@ -1,0 +1,34 @@
+#ifndef POLSERVER_BINARYOPERATOROPTIMIZER_H
+#define POLSERVER_BINARYOPERATOROPTIMIZER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class Report;
+
+class BinaryOperatorOptimizer : public NodeVisitor
+{
+public:
+  BinaryOperatorOptimizer( BinaryOperator& op, Report& );
+
+  std::unique_ptr<Expression> optimize();
+
+  void visit_children( Node& ) override;
+  void visit_float_value( FloatValue& lhs ) override;
+  void visit_integer_value( IntegerValue& lhs ) override;
+  void visit_string_value( StringValue& lhs ) override;
+
+private:
+  std::unique_ptr<Expression> optimized_result;
+
+  BinaryOperator& op;
+  Report& report;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_BINARYOPERATOROPTIMIZER_H

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithFloatOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithFloatOptimizer.cpp
@@ -1,0 +1,45 @@
+#include "BinaryOperatorWithFloatOptimizer.h"
+
+#include "compiler/Report.h"
+#include "compiler/ast/BinaryOperator.h"
+#include "compiler/ast/FloatValue.h"
+
+namespace Pol::Bscript::Compiler
+{
+BinaryOperatorWithFloatOptimizer::BinaryOperatorWithFloatOptimizer( FloatValue& lhs,
+                                                                    BinaryOperator& op,
+                                                                    Report& report )
+    : lhs( lhs ), op( op ), report( report )
+{
+}
+
+void BinaryOperatorWithFloatOptimizer::visit_children( Node& ) {}
+
+void BinaryOperatorWithFloatOptimizer::visit_float_value( FloatValue& rhs )
+{
+  double dval = 0;
+  switch ( op.token_id )
+  {
+  case TOK_ADD:
+    dval = lhs.value + rhs.value;
+    break;
+  case TOK_SUBTRACT:
+    dval = lhs.value - rhs.value;
+    break;
+  case TOK_MULT:
+    dval = lhs.value * rhs.value;
+    break;
+  case TOK_DIV:
+    if ( rhs.value == 0.0 )
+      report.error( op, "Expression would divide by zero.\n" );
+    dval = lhs.value / rhs.value;
+    break;
+
+  default:
+    return;
+  }
+
+  optimized_result = std::make_unique<FloatValue>( op.source_location, dval );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithFloatOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithFloatOptimizer.h
@@ -1,0 +1,31 @@
+#ifndef POLSERVER_BINARYOPERATORWITHFLOATOPTIMIZER_H
+#define POLSERVER_BINARYOPERATORWITHFLOATOPTIMIZER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class Report;
+
+class BinaryOperatorWithFloatOptimizer : public NodeVisitor
+{
+public:
+  const FloatValue& lhs;
+  const BinaryOperator& op;
+  Report& report;
+
+  std::unique_ptr<Expression> optimized_result;
+
+  BinaryOperatorWithFloatOptimizer( FloatValue& lhs, BinaryOperator& op, Report& );
+
+  void visit_children( Node& parent ) override;
+  void visit_float_value( FloatValue& rhs ) override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_BINARYOPERATORWITHFLOATOPTIMIZER_H

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithIntegerOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithIntegerOptimizer.cpp
@@ -1,0 +1,87 @@
+#include "BinaryOperatorWithIntegerOptimizer.h"
+
+#include "compiler/ast/BinaryOperator.h"
+#include "compiler/ast/IntegerValue.h"
+#include "compiler/Report.h"
+
+namespace Pol::Bscript::Compiler
+{
+BinaryOperatorWithIntegerOptimizer::BinaryOperatorWithIntegerOptimizer( IntegerValue& lhs,
+                                                                        BinaryOperator& op,
+                                                                        Report& report )
+    : lhs( lhs ), op( op ), report( report )
+{
+}
+
+void BinaryOperatorWithIntegerOptimizer::visit_children( Node& ) {}
+
+void BinaryOperatorWithIntegerOptimizer::visit_integer_value( IntegerValue& rhs )
+{
+  int value = 0;
+  switch ( op.token_id )
+  {
+  case TOK_ADD:
+    value = lhs.value + rhs.value;
+    break;
+  case TOK_SUBTRACT:
+    value = lhs.value - rhs.value;
+    break;
+  case TOK_MULT:
+    value = lhs.value * rhs.value;
+    break;
+  case TOK_DIV:
+    if ( rhs.value == 0 )
+      report.error( op, "Program would divide by zero" );
+    value = lhs.value / rhs.value;
+    break;
+
+  case TOK_EQUAL:
+    value = ( lhs.value == rhs.value );
+    break;
+  case TOK_NEQ:
+    value = ( lhs.value != rhs.value );
+    break;
+  case TOK_LESSTHAN:
+    value = ( lhs.value < rhs.value );
+    break;
+  case TOK_LESSEQ:
+    value = ( lhs.value <= rhs.value );
+    break;
+  case TOK_GRTHAN:
+    value = ( lhs.value > rhs.value );
+    break;
+  case TOK_GREQ:
+    value = ( lhs.value >= rhs.value );
+    break;
+
+  case TOK_AND:
+    value = ( lhs.value && rhs.value );
+    break;
+  case TOK_OR:
+    value = ( lhs.value || rhs.value );
+    break;
+
+  case TOK_BSRIGHT:
+    value = ( lhs.value >> rhs.value );
+    break;
+  case TOK_BSLEFT:
+    value = ( lhs.value << rhs.value );
+    break;
+  case TOK_BITAND:
+    value = ( lhs.value & rhs.value );
+    break;
+  case TOK_BITOR:
+    value = ( lhs.value | rhs.value );
+    break;
+  case TOK_BITXOR:
+    value = ( lhs.value ^ rhs.value );
+    break;
+
+  default:
+    return;
+  }
+
+  optimized_result = std::make_unique<IntegerValue>( op.source_location, value );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithIntegerOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithIntegerOptimizer.h
@@ -1,0 +1,30 @@
+#ifndef POLSERVER_BINARYOPERATORWITHINTEGEROPTIMIZER_H
+#define POLSERVER_BINARYOPERATORWITHINTEGEROPTIMIZER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class Report;
+
+class BinaryOperatorWithIntegerOptimizer : public NodeVisitor
+{
+public:
+  const IntegerValue& lhs;
+  const BinaryOperator& op;
+  Report& report;
+
+  std::unique_ptr<Expression> optimized_result;
+
+  BinaryOperatorWithIntegerOptimizer( IntegerValue& lhs, BinaryOperator&, Report& );
+
+  void visit_children( Node& parent ) override;
+  void visit_integer_value( IntegerValue& rhs ) override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_BINARYOPERATORWITHINTEGEROPTIMIZER_H

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithStringOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithStringOptimizer.cpp
@@ -1,0 +1,34 @@
+#include "BinaryOperatorWithStringOptimizer.h"
+
+#include "compiler/ast/BinaryOperator.h"
+#include "compiler/ast/StringValue.h"
+
+namespace Pol::Bscript::Compiler
+{
+BinaryOperatorWithStringOptimizer::BinaryOperatorWithStringOptimizer( StringValue& lhs,
+                                                                      BinaryOperator& op )
+    : lhs( lhs ), op( op )
+{
+}
+
+void BinaryOperatorWithStringOptimizer::visit_children( Node& ) {}
+
+void BinaryOperatorWithStringOptimizer::visit_string_value( StringValue& rhs )
+{
+  std::string value;
+  switch ( op.token_id )
+  {
+  case TOK_ADD:
+  {
+    value = lhs.value + rhs.value;
+    break;
+  }
+
+  default:
+    return;
+  }
+
+  optimized_result = std::make_unique<StringValue>( op.source_location, value );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/BinaryOperatorWithStringOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/BinaryOperatorWithStringOptimizer.h
@@ -1,0 +1,28 @@
+#ifndef POLSERVER_BINARYOPERATORWITHSTRINGOPTIMIZER_H
+#define POLSERVER_BINARYOPERATORWITHSTRINGOPTIMIZER_H
+
+#include "compiler/ast/NodeVisitor.h"
+
+#include <memory>
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+
+class BinaryOperatorWithStringOptimizer : public NodeVisitor
+{
+public:
+  const StringValue& lhs;
+  const BinaryOperator& op;
+
+  std::unique_ptr<Expression> optimized_result;
+
+  BinaryOperatorWithStringOptimizer( StringValue& lhs, BinaryOperator& op );
+
+  void visit_children( Node& parent ) override;
+  void visit_string_value( StringValue& rhs ) override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_BINARYOPERATORWITHSTRINGOPTIMIZER_H

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -1,8 +1,8 @@
 #include "Optimizer.h"
 
-#include "clib/logfacility.h"
 #include "compiler/Report.h"
 #include "compiler/analyzer/Constants.h"
+#include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/Program.h"
@@ -11,6 +11,7 @@
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/astbuilder/SimpleValueCloner.h"
 #include "compiler/model/CompilerWorkspace.h"
+#include "compiler/optimizer/BinaryOperatorOptimizer.h"
 #include "compiler/optimizer/ConstantValidator.h"
 #include "compiler/optimizer/ReferencedFunctionGatherer.h"
 #include "compiler/optimizer/UnaryOperatorOptimizer.h"
@@ -50,6 +51,20 @@ void Optimizer::visit_children( Node& node )
     }
 
     ++i;
+  }
+}
+
+void Optimizer::visit_binary_operator( BinaryOperator& binary_operator )
+{
+  visit_children( binary_operator );
+
+  switch ( binary_operator.token_id )
+  {
+  case TOK_ASSIGN:
+    break;
+  default:
+    optimized_replacement = BinaryOperatorOptimizer( binary_operator, report ).optimize();
+    break;
   }
 }
 

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -19,6 +19,7 @@ public:
   void optimize( CompilerWorkspace& );
   void visit_children( Node& ) override;
 
+  void visit_binary_operator( BinaryOperator& ) override;
   void visit_const_declaration( ConstDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_unary_operator( UnaryOperator& ) override;


### PR DESCRIPTION
Adds:
- [optimizer/BinaryOperatorOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/BinaryOperatorOptimizer.cpp): optimizes expressions with a binary operator
  - assignments will be handled by [optimizer/AssignmentOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/AssignmentOptimizer.cpp)
- [optimizer/BinaryOperatorWithFloatOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/BinaryOperatorWithFloatOptimizer.cpp): optimizes binary operator expressions with a FloatValue left-hand side
- [optimizer/BinaryOperatorWithIntegerOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/BinaryOperatorWithIntegerOptimizer.cpp): optimizes binary operator expressions with an IntegerValue left-hand side
- [optimizer/BinaryOperatorWithStringOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/BinaryOperatorWithStringOptimizer.cpp): optimizes binary operator expressions with a StringValue left-hand side

This allows compilation of:
- [compiler2-023-const-optimized](https://github.com/polserver/polserver/blob/ecompile-antlr/testsuite/escript/compiler2/compiler2-023-const-optimized.src)
```
const VALUE := 4 + 7;

print(VALUE);
```
- [compiler2-024-const-of-const-optimized](https://github.com/polserver/polserver/blob/ecompile-antlr/testsuite/escript/compiler2/compiler2-024-const-of-const-optimized.src)

```
const FIRST_PART := 4;
const SECOND_PART := 7;
const VALUE := FIRST_PART + SECOND_PART;

print(VALUE);
```