### PR TITLE
Optimize if statements, and emit module functions in legacy order

### DIFF
--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -28,7 +28,7 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileCache& em_cache,
 }
 
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
-    const std::string& pathname, const LegacyFunctionOrder* /*legacy_function_order*/ )
+    const std::string& pathname, const LegacyFunctionOrder* legacy_function_order )
 {
   auto compiler_workspace = std::make_unique<CompilerWorkspace>( report );
   BuilderWorkspace workspace( *compiler_workspace, em_cache, inc_cache, profile, report );
@@ -66,7 +66,35 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   if ( report.error_count() == 0 )
     build_referenced_user_functions( workspace );
 
+  if ( legacy_function_order )
+  {
+    compiler_workspace->module_functions_in_legacy_order =
+        get_module_functions_in_order( workspace, *legacy_function_order );
+  }
+
   return compiler_workspace;
+}
+
+std::vector<const ModuleFunctionDeclaration*>
+CompilerWorkspaceBuilder::get_module_functions_in_order( BuilderWorkspace& workspace,
+                                                         const LegacyFunctionOrder& h )
+{
+  std::vector<const ModuleFunctionDeclaration*> ordered;
+
+  for ( auto& scoped_name : h.modulefunc_emit_order )
+  {
+    auto func = workspace.function_resolver.find( scoped_name );
+    if ( !func )
+      throw std::runtime_error( "No modulefunc '" + scoped_name + "' for parity." );
+
+    auto decl = dynamic_cast<const ModuleFunctionDeclaration*>( func );
+    if ( !decl )
+      throw std::runtime_error( "No ModuleFunctionDeclaration for '" + scoped_name +
+                                "' for parity." );
+
+    ordered.push_back( decl );
+  }
+  return ordered;
 }
 
 void CompilerWorkspaceBuilder::build_referenced_user_functions( BuilderWorkspace& workspace )

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
@@ -3,14 +3,16 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace Pol::Bscript::Compiler
 {
 class BuilderWorkspace;
+class CompilerWorkspace;
 struct LegacyFunctionOrder;
+class ModuleFunctionDeclaration;
 class Profile;
 class Report;
-class CompilerWorkspace;
 class SourceFileCache;
 
 class CompilerWorkspaceBuilder
@@ -24,6 +26,8 @@ public:
       const LegacyFunctionOrder* legacy_function_order );
 
 private:
+  std::vector<const ModuleFunctionDeclaration*> get_module_functions_in_order(
+      BuilderWorkspace&, const LegacyFunctionOrder& );
   void build_referenced_user_functions( BuilderWorkspace& );
 
   SourceFileCache& em_cache;

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -22,6 +22,7 @@ public:
   void visit_binary_operator( BinaryOperator& ) override;
   void visit_const_declaration( ConstDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
+  void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
 
   std::unique_ptr<Node> optimized_replacement;


### PR DESCRIPTION
1. Optimize `if` statements (parity with OG compiler):
- discard empty 'alternative' blocks
- optimize to the `consequent` if the predicate is a nonzero integer
- optimize to the `alternative`, or an empty block if there is none, if the predicate is a zero integer.

2. In comparison mode, emit module functions in the same order as the OG compiler.
This is because the OG compiler can emit declarations for module functions that it doesn't actually call, and in a different order than calls to actual module functions.


These changes allow the compiler2/ scripts through [compiler2-034-if-elseif-else-third-optimized.src](https://github.com/polserver/polserver/blob/ecompile-antlr/testsuite/escript/compiler2/compiler2-034-if-elseif-else-third-optimized.src) to compile with parity.