### PR TITLE
Add support for while loops

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -18,6 +18,10 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Constants.h
   compiler/analyzer/Disambiguator.cpp
   compiler/analyzer/Disambiguator.h
+  compiler/analyzer/FlowControlScope.cpp
+  compiler/analyzer/FlowControlScope.cpp
+  compiler/analyzer/FlowControlScopes.cpp
+  compiler/analyzer/FlowControlScopes.cpp
   compiler/analyzer/LocalVariableScope.cpp
   compiler/analyzer/LocalVariableScope.h
   compiler/analyzer/LocalVariableScopes.cpp
@@ -56,6 +60,10 @@ set (bscript_sources    # sorted !
   compiler/ast/IfThenElseStatement.h
   compiler/ast/IntegerValue.cpp
   compiler/ast/IntegerValue.h
+  compiler/ast/LabelableStatement.cpp
+  compiler/ast/LabelableStatement.h
+  compiler/ast/LoopStatement.cpp
+  compiler/ast/LoopStatement.cpp
   compiler/ast/ModuleFunctionDeclaration.cpp
   compiler/ast/ModuleFunctionDeclaration.h
   compiler/ast/Node.cpp
@@ -86,6 +94,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ValueConsumer.h
   compiler/ast/VarStatement.cpp
   compiler/ast/VarStatement.h
+  compiler/ast/WhileLoop.cpp
+  compiler/ast/WhileLoop.h
   compiler/astbuilder/AvailableUserFunction.h
   compiler/astbuilder/BuilderWorkspace.cpp
   compiler/astbuilder/BuilderWorkspace.h

--- a/pol-core/bscript/compiler/analyzer/FlowControlScope.cpp
+++ b/pol-core/bscript/compiler/analyzer/FlowControlScope.cpp
@@ -1,0 +1,27 @@
+#include "FlowControlScope.h"
+
+#include "compiler/analyzer/FlowControlScopes.h"
+#include "compiler/analyzer/Variables.h"
+#include "compiler/model/FlowControlLabel.h"
+
+namespace Pol::Bscript::Compiler
+{
+FlowControlScope::FlowControlScope( FlowControlScopes& flow_control_scopes,
+                                    const SourceLocation& source_location, std::string name,
+                                    std::shared_ptr<FlowControlLabel> flow_control_label )
+  : source_location( source_location ),
+    name( std::move( name ) ),
+    flow_control_label( std::move( flow_control_label ) ),
+    local_variables_size( flow_control_scopes.local_variables.count() ),
+    parent_scope( flow_control_scopes.current_unnamed_scope ),
+    flow_control_scopes( flow_control_scopes )
+{
+  flow_control_scopes.push( this );
+}
+
+FlowControlScope::~FlowControlScope()
+{
+  flow_control_scopes.pop( this );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/FlowControlScope.h
+++ b/pol-core/bscript/compiler/analyzer/FlowControlScope.h
@@ -1,0 +1,34 @@
+#ifndef POLSERVER_FLOWCONTROLSCOPE_H
+#define POLSERVER_FLOWCONTROLSCOPE_H
+
+#include <memory>
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class FlowControlLabel;
+class FlowControlScopes;
+class SourceLocation;
+
+class FlowControlScope
+{
+public:
+  FlowControlScope( FlowControlScopes&, const SourceLocation&, std::string name,
+                    std::shared_ptr<FlowControlLabel> );
+  ~FlowControlScope();
+  FlowControlScope( const FlowControlScope& ) = delete;
+  FlowControlScope& operator=( const FlowControlScope& ) = delete;
+
+  const SourceLocation& source_location;
+  const std::string name;
+  const std::shared_ptr<FlowControlLabel> flow_control_label;
+  const unsigned local_variables_size;
+  const FlowControlScope* const parent_scope;
+
+private:
+  FlowControlScopes& flow_control_scopes;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FLOWCONTROLSCOPE_H

--- a/pol-core/bscript/compiler/analyzer/FlowControlScopes.cpp
+++ b/pol-core/bscript/compiler/analyzer/FlowControlScopes.cpp
@@ -1,0 +1,67 @@
+#include "FlowControlScopes.h"
+
+#include "compiler/analyzer/FlowControlScope.h"
+#include "compiler/Report.h"
+
+namespace Pol::Bscript::Compiler
+{
+FlowControlScopes::FlowControlScopes( const Variables& local_variables, Report& report )
+  : current_unnamed_scope( nullptr ),
+    named_scopes(),
+    local_variables( local_variables ),
+    report( report )
+{
+}
+
+const FlowControlScope* FlowControlScopes::find( const std::string& name )
+{
+  if ( name.empty() )
+  {
+    return current_unnamed_scope;
+  }
+
+  auto itr = named_scopes.find( name );
+  if ( itr != named_scopes.end() )
+  {
+    return ( *itr ).second;
+  }
+
+  return nullptr;
+}
+
+bool FlowControlScopes::any() const
+{
+  return current_unnamed_scope != nullptr;
+}
+
+void FlowControlScopes::push( const FlowControlScope* scope )
+{
+  current_unnamed_scope = scope;
+
+  if ( !scope->name.empty() )
+  {
+    auto ins = named_scopes.insert( { scope->name, scope } );
+    if ( !ins.second )
+    {
+      report.error( scope->source_location, "A statement with label '", scope->name,
+                    "' is already in scope.\n",
+                    "  See also: ", ( *ins.first ).second->source_location, "\n" );
+    }
+  }
+}
+
+void FlowControlScopes::pop( const FlowControlScope* scope )
+{
+  if ( scope != current_unnamed_scope )
+  {
+    scope->source_location.internal_error(
+        "current_unnamed_scope does not match scope being popped" );
+  }
+
+  current_unnamed_scope = scope->parent_scope;
+
+  if ( !scope->name.empty() )
+    named_scopes.erase( scope->name );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/FlowControlScopes.h
+++ b/pol-core/bscript/compiler/analyzer/FlowControlScopes.h
@@ -1,0 +1,36 @@
+#ifndef POLSERVER_FLOWCONTROLSCOPES_H
+#define POLSERVER_FLOWCONTROLSCOPES_H
+
+#include <map>
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class FlowControlScope;
+class Report;
+class Variables;
+
+class FlowControlScopes
+{
+public:
+  FlowControlScopes( const Variables& local_variables, Report& report );
+
+  const FlowControlScope* find( const std::string& name );
+
+  bool any() const;
+
+private:
+  friend class FlowControlScope;
+  void push( const FlowControlScope* );
+  void pop( const FlowControlScope* );
+
+  const FlowControlScope* current_unnamed_scope;
+  std::map<std::string, const FlowControlScope*> named_scopes;
+  const Variables& local_variables;
+  Report& report;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_FLOWCONTROLSCOPES_H

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "clib/maputil.h"
+#include "compiler/analyzer/FlowControlScopes.h"
 #include "compiler/analyzer/LocalVariableScopes.h"
 #include "compiler/analyzer/Variables.h"
 
@@ -14,7 +15,7 @@ namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
 class Constants;
-class Identifier;
+class LoopStatement;
 class Report;
 class VarStatement;
 
@@ -33,10 +34,12 @@ public:
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
-  void visit_program( Program& program ) override;
+  void visit_loop_statement( LoopStatement& );
+  void visit_program( Program& ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
   void visit_user_function( UserFunction& ) override;
   void visit_var_statement( VarStatement& ) override;
+  void visit_while_loop( WhileLoop& ) override;
 
 private:
   Constants& constants;
@@ -44,6 +47,8 @@ private:
 
   Variables globals;
   Variables locals;
+  FlowControlScopes break_scopes;
+  FlowControlScopes continue_scopes;
   LocalVariableScopes local_scopes;
 };
 

--- a/pol-core/bscript/compiler/ast/LabelableStatement.cpp
+++ b/pol-core/bscript/compiler/ast/LabelableStatement.cpp
@@ -1,0 +1,15 @@
+#include "LabelableStatement.h"
+
+namespace Pol::Bscript::Compiler
+{
+LabelableStatement::LabelableStatement( const SourceLocation& source_location, std::string label )
+    : Statement( source_location ), label( std::move( label ) )
+{
+}
+
+void LabelableStatement::relabel( std::string new_label )
+{
+  label = std::move( new_label );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/LabelableStatement.h
+++ b/pol-core/bscript/compiler/ast/LabelableStatement.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_LABELABLESTATEMENT_H
+#define POLSERVER_LABELABLESTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class LabelableStatement : public Statement
+{
+public:
+  LabelableStatement( const SourceLocation&, std::string label );
+
+  const std::string& get_label() const { return label; }
+
+private:
+  friend class Disambiguator;
+  void relabel( std::string new_label );
+  std::string label;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_LABELABLESTATEMENT_H

--- a/pol-core/bscript/compiler/ast/LoopStatement.cpp
+++ b/pol-core/bscript/compiler/ast/LoopStatement.cpp
@@ -1,0 +1,14 @@
+#include "LoopStatement.h"
+
+#include "compiler/model/FlowControlLabel.h"
+
+namespace Pol::Bscript::Compiler
+{
+LoopStatement::LoopStatement( const SourceLocation& source_location, std::string label )
+  : LabelableStatement( source_location, std::move( label ) ),
+    break_label( std::make_shared<FlowControlLabel>() ),
+    continue_label( std::make_shared<FlowControlLabel>() )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/LoopStatement.h
+++ b/pol-core/bscript/compiler/ast/LoopStatement.h
@@ -1,0 +1,21 @@
+#ifndef POLSERVER_LOOPSTATEMENT_H
+#define POLSERVER_LOOPSTATEMENT_H
+
+#include "compiler/ast/LabelableStatement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class FlowControlLabel;
+
+class LoopStatement : public LabelableStatement
+{
+public:
+  LoopStatement( const SourceLocation& source_location, std::string label );
+
+  const std::shared_ptr<FlowControlLabel> break_label;
+  const std::shared_ptr<FlowControlLabel> continue_label;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_LOOPSTATEMENT_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -22,6 +22,7 @@
 #include "compiler/ast/UserFunction.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
+#include "compiler/ast/WhileLoop.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -138,6 +139,11 @@ void NodeVisitor::visit_value_consumer( ValueConsumer& node )
 }
 
 void NodeVisitor::visit_var_statement( VarStatement& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_while_loop( WhileLoop& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -28,6 +28,7 @@ class UnaryOperator;
 class UserFunction;
 class ValueConsumer;
 class VarStatement;
+class WhileLoop;
 
 class NodeVisitor
 {
@@ -58,6 +59,7 @@ public:
   virtual void visit_user_function( UserFunction& );
   virtual void visit_value_consumer( ValueConsumer& );
   virtual void visit_var_statement( VarStatement& );
+  virtual void visit_while_loop( WhileLoop& );
 
   virtual void visit_children( Node& parent );
 };

--- a/pol-core/bscript/compiler/ast/WhileLoop.cpp
+++ b/pol-core/bscript/compiler/ast/WhileLoop.cpp
@@ -1,0 +1,42 @@
+#include "WhileLoop.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Block.h"
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+WhileLoop::WhileLoop( const SourceLocation& source_location, std::string label,
+                      std::unique_ptr<Expression> expression, std::unique_ptr<Block> block )
+    : LoopStatement( source_location, std::move( label ) )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( expression ) );
+  children.push_back( std::move( block ) );
+}
+
+void WhileLoop::accept( NodeVisitor& visitor )
+{
+  visitor.visit_while_loop( *this );
+}
+
+void WhileLoop::describe_to( fmt::Writer& w ) const
+{
+  w << "while-loop";
+  if ( !get_label().empty() )
+    w << "(label:" << get_label() << ")";
+}
+
+Expression& WhileLoop::predicate()
+{
+  return child<Expression>( 0 );
+}
+
+Block& WhileLoop::block()
+{
+  return child<Block>( 1 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/WhileLoop.h
+++ b/pol-core/bscript/compiler/ast/WhileLoop.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_WHILELOOP_H
+#define POLSERVER_WHILELOOP_H
+
+#include "compiler/ast/LoopStatement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Block;
+class Expression;
+
+class WhileLoop : public LoopStatement
+{
+public:
+  WhileLoop( const SourceLocation& source_location, std::string label,
+             std::unique_ptr<Expression> expression, std::unique_ptr<Block> block );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Expression& predicate();
+  Block& block();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_WHILELOOP_H

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -7,6 +7,10 @@ namespace Pol::Bscript::Compiler
 {
 class Block;
 class Statement;
+class ConstDeclaration;
+class RepeatUntilLoop;
+class ReturnStatement;
+class WhileLoop;
 
 class CompoundStatementBuilder : public SimpleStatementBuilder
 {
@@ -22,6 +26,8 @@ public:
       EscriptGrammar::EscriptParser::BlockContext* );
 
   std::unique_ptr<Statement> if_statement( EscriptGrammar::EscriptParser::IfStatementContext* );
+
+  std::unique_ptr<WhileLoop> while_loop( EscriptGrammar::EscriptParser::WhileStatementContext* );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -21,6 +21,7 @@
 #include "compiler/ast/UserFunction.h"
 #include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
+#include "compiler/ast/WhileLoop.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/FlowControlLabel.h"
@@ -240,6 +241,16 @@ void InstructionGenerator::visit_var_statement( VarStatement& node )
 
     emit.assign();
   }
+}
+
+void InstructionGenerator::visit_while_loop( WhileLoop& loop )
+{
+  emit.label( *loop.continue_label );
+  generate( loop.predicate() );
+  emit.jmp_if_false( *loop.break_label );
+  generate( loop.block() );
+  emit.jmp_always( *loop.continue_label );
+  emit.label( *loop.break_label );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -38,6 +38,7 @@ public:
   void visit_user_function( UserFunction& ) override;
   void visit_value_consumer( ValueConsumer& ) override;
   void visit_var_statement( VarStatement& ) override;
+  void visit_while_loop( WhileLoop& ) override;
 
 private:
   // There are two of these because sometimes when calling a method


### PR DESCRIPTION
Adds:
- [analyzer/FlowControlScope](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/FlowControlScope.cpp): Registers a break/continue scope
- [analyzer/FlowControlScopes](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/analyzer/FlowControlScopes.cpp): Registry for break/continue scopes
- [ast/LabelableStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/LabelableStatement.h): Base class for AST nodes that can be labelled (loops and case)
- [ast/LoopStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/LoopStatement.h): Base class for AST nodes for loops (have a break and continue label)
- [ast/WhileLoop](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/WhileLoop.h): AST node for a while loop

This allows the compiler2/ scripts to compile with parity through [compiler2-035-while-is-false.src](/compiler2-035-while-is-false.src).