### PR TITLE
New compiler: assignment to local and global variables.

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -32,6 +32,8 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Variables.h
   compiler/ast/Argument.cpp
   compiler/ast/Argument.h
+  compiler/ast/AssignVariableConsume.cpp
+  compiler/ast/AssignVariableConsume.h
   compiler/ast/BinaryOperator.cpp
   compiler/ast/BinaryOperator.h
   compiler/ast/Block.cpp
@@ -183,6 +185,8 @@ set (bscript_sources    # sorted !
   compiler/optimizer/ReferencedFunctionGatherer.h
   compiler/optimizer/UnaryOperatorOptimizer.cpp
   compiler/optimizer/UnaryOperatorOptimizer.h
+  compiler/optimizer/ValueConsumerOptimizer.cpp
+  compiler/optimizer/ValueConsumerOptimizer.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
   compiler/representation/ExportedFunction.cpp

--- a/pol-core/bscript/compiler/ast/AssignVariableConsume.cpp
+++ b/pol-core/bscript/compiler/ast/AssignVariableConsume.cpp
@@ -1,0 +1,40 @@
+#include "AssignVariableConsume.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+AssignVariableConsume::AssignVariableConsume( const SourceLocation& source_location,
+                                              std::unique_ptr<Identifier> identifier,
+                                              std::unique_ptr<Node> rhs )
+    : Statement( source_location )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( identifier ) );
+  children.push_back( std::move( rhs ) );
+}
+
+void AssignVariableConsume::accept( NodeVisitor& visitor )
+{
+  visitor.visit_assign_variable_consume( *this );
+}
+
+void AssignVariableConsume::describe_to( fmt::Writer& w ) const
+{
+  w << "assign-variable-consume";
+}
+
+Identifier& AssignVariableConsume::identifier()
+{
+  return child<Identifier>( 0 );
+}
+
+Node& AssignVariableConsume::rhs()
+{
+  return child<Node>( 1 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/AssignVariableConsume.h
+++ b/pol-core/bscript/compiler/ast/AssignVariableConsume.h
@@ -1,0 +1,25 @@
+#ifndef POLSERVER_ASSIGNVARIABLECONSUME_H
+#define POLSERVER_ASSIGNVARIABLECONSUME_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Identifier;
+
+class AssignVariableConsume : public Statement
+{
+public:
+  AssignVariableConsume( const SourceLocation&, std::unique_ptr<Identifier> identifier,
+                         std::unique_ptr<Node> rhs );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Identifier& identifier();
+  Node& rhs();
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_ASSIGNVARIABLECONSUME_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,6 +1,7 @@
 #include "NodeVisitor.h"
 
 #include "compiler/ast/Argument.h"
+#include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
 #include "compiler/ast/ConstDeclaration.h"
@@ -27,6 +28,11 @@
 namespace Pol::Bscript::Compiler
 {
 void NodeVisitor::visit_argument( Argument& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_assign_variable_consume( AssignVariableConsume& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -4,6 +4,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Argument;
+class AssignVariableConsume;
 class BinaryOperator;
 class Block;
 class ConstDeclaration;
@@ -36,6 +37,7 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_argument( Argument& );
+  virtual void visit_assign_variable_consume( AssignVariableConsume& );
   virtual void visit_binary_operator( BinaryOperator& );
   virtual void visit_block( Block& );
   virtual void visit_const_declaration( ConstDeclaration& );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -45,6 +45,12 @@ void InstructionEmitter::assign()
   emit_token( TOK_ASSIGN, TYP_OPERATOR );
 }
 
+void InstructionEmitter::assign_variable( const Variable& v )
+{
+  auto token_id = v.scope == VariableScope::Global ? INS_ASSIGN_GLOBALVAR : INS_ASSIGN_LOCALVAR;
+  emit_token( token_id, TYP_UNARY_OPERATOR, v.index );
+}
+
 void InstructionEmitter::binary_operator( BTokenId token_id )
 {
   emit_token( token_id, TYP_OPERATOR );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -44,6 +44,7 @@ public:
   void access_variable( const Variable& );
   void array_declare();
   void assign();
+  void assign_variable( const Variable& );
   void binary_operator( BTokenId token_id );
   void call_method( const std::string& name, unsigned argument_count );
   void call_method_id( MethodID method_id, unsigned argument_count );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
 #include "compiler/ast/FloatValue.h"
@@ -45,6 +46,15 @@ void InstructionGenerator::generate( Node& node )
 {
   // alternative: two identical methods 'evaluate' and 'execute', for readability
   node.accept( *this );
+}
+
+void InstructionGenerator::visit_assign_variable_consume( AssignVariableConsume& node )
+{
+  generate( node.rhs() );
+  auto& identifier = node.identifier();
+  auto& variable = identifier.variable;
+
+  emit.assign_variable( *variable );
 }
 
 void InstructionGenerator::visit_binary_operator( BinaryOperator& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -20,6 +20,7 @@ public:
 
   void generate( Node& );
 
+  void visit_assign_variable_consume( AssignVariableConsume& );
   void visit_binary_operator( BinaryOperator& ) override;
   void visit_block( Block& ) override;
   void visit_exit_statement( ExitStatement& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -219,6 +219,15 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "^";  // bitwise-xor";
     break;
 
+  case INS_ASSIGN_LOCALVAR:
+    w << "local #" << tkn.offset;
+    w << " :=";
+    break;
+  case INS_ASSIGN_GLOBALVAR:
+    w << "global #" << tkn.offset;
+    w << " :=";
+    break;
+
   case TOK_UNPLUSPLUS:
     w << "prefix unary ++";
     break;

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -18,6 +18,7 @@
 #include "compiler/optimizer/ConstantValidator.h"
 #include "compiler/optimizer/ReferencedFunctionGatherer.h"
 #include "compiler/optimizer/UnaryOperatorOptimizer.h"
+#include "compiler/optimizer/ValueConsumerOptimizer.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -129,6 +130,13 @@ void Optimizer::visit_unary_operator( UnaryOperator& unary_operator )
   visit_children( unary_operator );
 
   optimized_replacement = UnaryOperatorOptimizer( unary_operator ).optimize();
+}
+
+void Optimizer::visit_value_consumer( ValueConsumer& consume_value )
+{
+  visit_children( consume_value );
+
+  optimized_replacement = ValueConsumerOptimizer().optimize( consume_value );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -24,6 +24,7 @@ public:
   void visit_identifier( Identifier& ) override;
   void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_unary_operator( UnaryOperator& ) override;
+  void visit_value_consumer( ValueConsumer& ) override;
 
   std::unique_ptr<Node> optimized_replacement;
 

--- a/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.cpp
@@ -1,0 +1,44 @@
+#include "ValueConsumerOptimizer.h"
+
+#include "tokens.h"
+
+#include "compiler/ast/AssignVariableConsume.h"
+#include "compiler/ast/BinaryOperator.h"
+#include "compiler/ast/Identifier.h"
+#include "compiler/ast/ValueConsumer.h"
+
+namespace Pol::Bscript::Compiler
+{
+void ValueConsumerOptimizer::visit_children( Node& ) {}
+
+void ValueConsumerOptimizer::visit_binary_operator( BinaryOperator& binary_operator )
+{
+  BTokenId operator_id = binary_operator.token_id;
+  if ( operator_id == TOK_ASSIGN )
+  {
+    if ( dynamic_cast<Identifier*>( &binary_operator.lhs() ) )
+    {
+      auto lhs = static_unique_pointer_cast<Identifier>( binary_operator.take_lhs() );
+      auto rhs = binary_operator.take_rhs();
+      optimized_result = std::make_unique<AssignVariableConsume>(
+          binary_operator.source_location, std::move( lhs ), std::move( rhs ) );
+    }
+    else
+    {
+      auto lhs = binary_operator.take_lhs();
+      auto rhs = binary_operator.take_rhs();
+      optimized_result =
+          std::make_unique<BinaryOperator>( binary_operator.source_location, std::move( lhs ),
+                                            ":= #", INS_ASSIGN_CONSUME, std::move( rhs ) );
+    }
+  }
+}
+
+std::unique_ptr<Statement> ValueConsumerOptimizer::optimize( ValueConsumer& consume_value )
+{
+  consume_value.children.at( 0 )->accept( *this );
+
+  return std::move( optimized_result );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.h
@@ -1,0 +1,27 @@
+#ifndef POLSERVER_VALUECONSUMEROPTIMIZER_H
+#define POLSERVER_VALUECONSUMEROPTIMIZER_H
+
+#include <memory>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Statement;
+
+class ValueConsumerOptimizer : public NodeVisitor
+{
+public:
+  std::unique_ptr<Statement> optimized_result;
+
+  void visit_children( Node& ) override;
+
+  void visit_binary_operator( BinaryOperator& ) override;
+
+  std::unique_ptr<Statement> optimize( ValueConsumer& );
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_VALUECONSUMEROPTIMIZER_H


### PR DESCRIPTION
Adds:
- [ast/AssignVariableConsume](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/AssignVariableConsume.cpp): AST node for assignment to a variable, while consuming the result
- [optimizer/ValueConsumerOptimizer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.cpp): Optimizes expressions where the resulting value will be consumed

The compiler2/ scripts now compile with parity through [compiler2-039-test-equality](https://github.com/polserver/polserver/blob/ecompile-antlr/testsuite/escript/compiler2/compiler2-039-test-equality.src).