### PR TITLE
New compiler: array initialization

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -32,6 +32,8 @@ set (bscript_sources    # sorted !
   compiler/analyzer/Variables.h
   compiler/ast/Argument.cpp
   compiler/ast/Argument.h
+  compiler/ast/ArrayInitializer.cpp
+  compiler/ast/ArrayInitializer.h
   compiler/ast/AssignVariableConsume.cpp
   compiler/ast/AssignVariableConsume.h
   compiler/ast/BinaryOperator.cpp

--- a/pol-core/bscript/compiler/ast/ArrayInitializer.cpp
+++ b/pol-core/bscript/compiler/ast/ArrayInitializer.cpp
@@ -1,0 +1,25 @@
+#include "ArrayInitializer.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ArrayInitializer::ArrayInitializer( const SourceLocation& source_location,
+                                    std::vector<std::unique_ptr<Expression>> children )
+    : Expression( source_location, std::move( children ) )
+{
+}
+
+void ArrayInitializer::accept( NodeVisitor& visitor )
+{
+  visitor.visit_array_initializer( *this );
+}
+
+void ArrayInitializer::describe_to( fmt::Writer& w ) const
+{
+  w << "array-initializer";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ArrayInitializer.h
+++ b/pol-core/bscript/compiler/ast/ArrayInitializer.h
@@ -1,0 +1,20 @@
+#ifndef POLSERVER_ARRAYINITIALIZER_H
+#define POLSERVER_ARRAYINITIALIZER_H
+
+#include "compiler/ast/Expression.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ArrayInitializer : public Expression
+{
+public:
+  ArrayInitializer( const SourceLocation&, std::vector<std::unique_ptr<Expression>> );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_ARRAYINITIALIZER_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -1,6 +1,7 @@
 #include "NodeVisitor.h"
 
 #include "compiler/ast/Argument.h"
+#include "compiler/ast/ArrayInitializer.h"
 #include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
@@ -34,6 +35,11 @@
 namespace Pol::Bscript::Compiler
 {
 void NodeVisitor::visit_argument( Argument& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_array_initializer( ArrayInitializer& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -4,6 +4,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Argument;
+class ArrayInitializer;
 class AssignVariableConsume;
 class BinaryOperator;
 class Block;
@@ -43,6 +44,7 @@ public:
   virtual ~NodeVisitor() = default;
 
   virtual void visit_argument( Argument& );
+  virtual void visit_array_initializer( ArrayInitializer& );
   virtual void visit_assign_variable_consume( AssignVariableConsume& );
   virtual void visit_binary_operator( BinaryOperator& );
   virtual void visit_block( Block& );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -23,9 +23,6 @@ public:
 
   [[noreturn]] static BTokenId unhandled_operator( const SourceLocation& );
 
-  std::unique_ptr<ArrayElementAccess> array_access(
-      std::unique_ptr<Expression> lhs, EscriptGrammar::EscriptParser::ExpressionListContext* );
-
   std::unique_ptr<ArrayInitializer> array_initializer(
       EscriptGrammar::EscriptParser::ArrayInitializerContext* );
   std::unique_ptr<ArrayInitializer> array_initializer(

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -10,6 +10,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Argument;
+class ArrayInitializer;
 class BinaryOperator;
 class Expression;
 class FunctionCall;
@@ -22,10 +23,25 @@ public:
 
   [[noreturn]] static BTokenId unhandled_operator( const SourceLocation& );
 
+  std::unique_ptr<ArrayElementAccess> array_access(
+      std::unique_ptr<Expression> lhs, EscriptGrammar::EscriptParser::ExpressionListContext* );
+
+  std::unique_ptr<ArrayInitializer> array_initializer(
+      EscriptGrammar::EscriptParser::ArrayInitializerContext* );
+  std::unique_ptr<ArrayInitializer> array_initializer(
+      EscriptGrammar::EscriptParser::BareArrayInitializerContext* );
+  std::unique_ptr<ArrayInitializer> array_initializer(
+      EscriptGrammar::EscriptParser::ExplicitArrayInitializerContext* );
+
   std::unique_ptr<BinaryOperator> binary_operator(
       EscriptGrammar::EscriptParser::ExpressionContext* );
 
   std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
+
+  std::vector<std::unique_ptr<Expression>> expressions(
+      EscriptGrammar::EscriptParser::ArrayInitializerContext* );
+  std::vector<std::unique_ptr<Expression>> expressions(
+      EscriptGrammar::EscriptParser::ExpressionListContext* );
 
   std::unique_ptr<FunctionCall> function_call( EscriptGrammar::EscriptParser::FunctionCallContext*,
                                                const std::string& scope );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -36,6 +36,16 @@ void InstructionEmitter::access_variable( const Variable& v )
   emit_token( token_id, TYP_OPERAND, v.index );
 }
 
+void InstructionEmitter::array_append()
+{
+  emit_token( TOK_INSERTINTO, TYP_OPERATOR );
+}
+
+void InstructionEmitter::array_create()
+{
+  emit_token( TOK_ARRAY, TYP_OPERAND );
+}
+
 void InstructionEmitter::array_declare()
 {
   emit_token( INS_DECLARE_ARRAY, TYP_RESERVED );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -43,6 +43,8 @@ public:
   void initialize_data();
 
   void access_variable( const Variable& );
+  void array_append();
+  void array_create();
   void array_declare();
   void assign();
   void assign_variable( const Variable& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include "compiler/ast/ArrayInitializer.h"
 #include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
@@ -53,6 +54,16 @@ void InstructionGenerator::generate( Node& node )
 {
   // alternative: two identical methods 'evaluate' and 'execute', for readability
   node.accept( *this );
+}
+
+void InstructionGenerator::visit_array_initializer( ArrayInitializer& node )
+{
+  emit.array_create();
+  for ( const auto& child : node.children )
+  {
+    child->accept( *this );
+    emit.array_append();
+  }
 }
 
 void InstructionGenerator::visit_assign_variable_consume( AssignVariableConsume& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -20,6 +20,7 @@ public:
 
   void generate( Node& );
 
+  void visit_array_initializer( ArrayInitializer& ) override;
   void visit_assign_variable_consume( AssignVariableConsume& ) override;
   void visit_case_statement( CaseStatement& ) override;
   void visit_binary_operator( BinaryOperator& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -64,6 +64,9 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
   case TOK_MODULUSEQUAL:
     w << "%=";
     break;
+  case TOK_INSERTINTO:
+    w << "append-array-element (TOK_INSERTINTO)";
+    break;
 
   case TOK_LESSTHAN:
     w << "<";
@@ -202,6 +205,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
   case INS_GET_ARG:
     w << "get arg '" << string_at( tkn.offset ) << "'";
     break;
+  case TOK_ARRAY:
+    w << "create-array (TOK_ARRAY)";
+    break;
+
   case INS_POP_PARAM_BYREF:
     w << "pop param byref '" << string_at( tkn.offset ) << "'";
     break;


### PR DESCRIPTION
Adds:
- ast/ArrayInitializer: AST node for an expression that creates an array

This will compile:
```
var a := { 82, 54, 22, "x" };
print(a);
```
