### PR TITLE
New compiler: Add foreach loops

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -58,6 +58,8 @@ set (bscript_sources    # sorted !
   compiler/ast/Expression.h
   compiler/ast/FloatValue.cpp
   compiler/ast/FloatValue.h
+  compiler/ast/ForeachLoop.cpp
+  compiler/ast/ForeachLoop.h
   compiler/ast/Function.cpp
   compiler/ast/Function.h
   compiler/ast/FunctionBody.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -17,7 +17,6 @@ class CompilerWorkspace;
 class Constants;
 class LoopStatement;
 class Report;
-class VarStatement;
 
 class SemanticAnalyzer : public NodeVisitor
 {
@@ -33,6 +32,7 @@ public:
   void visit_case_statement( CaseStatement& ) override;
   void visit_case_dispatch_group( CaseDispatchGroup& ) override;
   void visit_case_dispatch_selectors( CaseDispatchSelectors& ) override;
+  void visit_foreach_loop( ForeachLoop& ) override;
   void visit_function_call( FunctionCall& ) override;
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;

--- a/pol-core/bscript/compiler/ast/ForeachLoop.cpp
+++ b/pol-core/bscript/compiler/ast/ForeachLoop.cpp
@@ -1,0 +1,45 @@
+#include "ForeachLoop.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/Block.h"
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ForeachLoop::ForeachLoop( const SourceLocation& source_location, std::string label,
+                          std::string iterator_name, std::unique_ptr<Expression> expression,
+                          std::unique_ptr<Block> block )
+    : LoopStatement( source_location, std::move( label ) ),
+      iterator_name( std::move( iterator_name ) )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( expression ) );
+  children.push_back( std::move( block ) );
+}
+
+void ForeachLoop::accept( NodeVisitor& visitor )
+{
+  visitor.visit_foreach_loop( *this );
+}
+
+void ForeachLoop::describe_to( fmt::Writer& w ) const
+{
+  w << "foreach-loop";
+  if ( !get_label().empty() )
+    w << "(label:" << get_label() << ")";
+}
+
+Expression& ForeachLoop::expression()
+{
+  return child<Expression>( 0 );
+}
+
+Block& ForeachLoop::block()
+{
+  return child<Block>( 1 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ForeachLoop.h
+++ b/pol-core/bscript/compiler/ast/ForeachLoop.h
@@ -1,0 +1,30 @@
+#ifndef POLSERVER_FOREACHLOOP_H
+#define POLSERVER_FOREACHLOOP_H
+
+#include "compiler/ast/LoopStatement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Block;
+class Expression;
+class Variable;
+
+class ForeachLoop : public LoopStatement
+{
+public:
+  ForeachLoop( const SourceLocation&, std::string label, std::string iterator_name,
+               std::unique_ptr<Expression>, std::unique_ptr<Block> );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  Expression& expression();
+  Block& block();
+
+  const std::string iterator_name;
+  std::vector<std::shared_ptr<Variable>> debug_variables;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FOREACHLOOP_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -12,6 +12,7 @@
 #include "compiler/ast/CaseStatement.h"
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/ForeachLoop.h"
 #include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
@@ -94,6 +95,10 @@ void NodeVisitor::visit_exit_statement( ExitStatement& )
 }
 
 void NodeVisitor::visit_float_value( FloatValue& node )
+{
+}
+
+void NodeVisitor::visit_foreach_loop( ForeachLoop& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -16,6 +16,7 @@ class CaseDispatchSelectors;
 class ConstDeclaration;
 class ExitStatement;
 class FloatValue;
+class ForeachLoop;
 class FunctionBody;
 class FunctionCall;
 class FunctionParameterDeclaration;
@@ -56,6 +57,7 @@ public:
   virtual void visit_const_declaration( ConstDeclaration& );
   virtual void visit_exit_statement( ExitStatement& );
   virtual void visit_float_value( FloatValue& );
+  virtual void visit_foreach_loop( ForeachLoop& );
   virtual void visit_function_body( FunctionBody& );
   virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.h
@@ -9,6 +9,7 @@ class Block;
 class Statement;
 class CaseStatement;
 class ConstDeclaration;
+class ForeachLoop;
 class ReturnStatement;
 class WhileLoop;
 
@@ -27,6 +28,12 @@ public:
 
   std::unique_ptr<CaseStatement> case_statement(
       EscriptGrammar::EscriptParser::CaseStatementContext* );
+
+  std::unique_ptr<Expression> foreach_iterable_expression(
+      EscriptGrammar::EscriptParser::ForeachIterableExpressionContext* );
+
+  std::unique_ptr<ForeachLoop> foreach_loop(
+      EscriptGrammar::EscriptParser::ForeachStatementContext* );
 
   std::unique_ptr<Statement> if_statement( EscriptGrammar::EscriptParser::IfStatementContext* );
 

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -126,6 +126,16 @@ void InstructionEmitter::exit()
   emit_token( RSV_EXIT, TYP_RESERVED );
 }
 
+void InstructionEmitter::foreach_init( FlowControlLabel& label )
+{
+  register_with_label( label, emit_token( INS_INITFOREACH, TYP_RESERVED ) );
+}
+
+void InstructionEmitter::foreach_step( FlowControlLabel& label )
+{
+  register_with_label( label, emit_token( INS_STEPFOREACH, TYP_RESERVED ) );
+}
+
 void InstructionEmitter::get_arg( const std::string& name )
 {
   unsigned offset = emit_data( name );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -58,6 +58,8 @@ public:
   void consume();
   void declare_variable( const Variable& );
   void exit();
+  void foreach_init( FlowControlLabel& );
+  void foreach_step( FlowControlLabel& );
   void get_arg( const std::string& name );
   void jmp_always( FlowControlLabel& );
   void jmp_if_false( FlowControlLabel& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -11,6 +11,7 @@
 #include "compiler/ast/CaseDispatchSelectors.h"
 #include "compiler/ast/CaseStatement.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/ForeachLoop.h"
 #include "compiler/ast/FunctionBody.h"
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
@@ -137,6 +138,24 @@ void InstructionGenerator::visit_exit_statement( ExitStatement& )
 void InstructionGenerator::visit_float_value( FloatValue& node )
 {
   emit.value( node.value );
+}
+
+void InstructionGenerator::visit_foreach_loop( ForeachLoop& loop )
+{
+  generate( loop.expression() );
+
+  emit.foreach_init( *loop.continue_label );
+
+  FlowControlLabel next;
+  emit.label( next );
+
+  generate( loop.block() );
+
+  emit.label( *loop.continue_label );
+  emit.foreach_step( next );
+
+  emit.label( *loop.break_label );
+  emit.leaveblock( 3 );
 }
 
 void InstructionGenerator::visit_function_call( FunctionCall& call )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -27,6 +27,7 @@ public:
   void visit_block( Block& ) override;
   void visit_exit_statement( ExitStatement& ) override;
   void visit_float_value( FloatValue& ) override;
+  void visit_foreach_loop( ForeachLoop& ) override;
   void visit_function_call( FunctionCall& ) override;
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -196,6 +196,12 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "global variable #" << tkn.offset;
     break;
 
+  case INS_INITFOREACH:
+    w << "initforeach @" << tkn.offset;
+    break;
+  case INS_STEPFOREACH:
+    w << "stepforeach @" << tkn.offset;
+    break;
   case INS_CASEJMP:
   {
     w << "casejmp";


### PR DESCRIPTION
Adds:
- [ast/ForeachLoop](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ForeachLoop.h): AST node

Also removed the visit_children call from the default visit_float_value.

This will compile:
```
var a := { 82, 54, 22, "x" };
foreach i in a
    print(i);
endforeach
```