### PR TITLE
New compiler: add error initializers

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -64,6 +64,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ElementAssignment.h
   compiler/ast/ElementIndexes.cpp
   compiler/ast/ElementIndexes.h
+  compiler/ast/ErrorInitializer.cpp
+  compiler/ast/ErrorInitializer.h
   compiler/ast/ExitStatement.cpp
   compiler/ast/ExitStatement.h
   compiler/ast/Expression.cpp

--- a/pol-core/bscript/compiler/ast/ErrorInitializer.cpp
+++ b/pol-core/bscript/compiler/ast/ErrorInitializer.cpp
@@ -1,0 +1,27 @@
+#include "ErrorInitializer.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ErrorInitializer::ErrorInitializer( const SourceLocation& source_location,
+                                    std::vector<std::string> names,
+                                    std::vector<std::unique_ptr<Expression>> expressions )
+    : Expression( source_location, std::move( expressions ) ), names( std::move( names ) )
+{
+}
+
+void ErrorInitializer::accept( NodeVisitor& visitor )
+{
+  visitor.visit_error_initializer( *this );
+}
+
+void ErrorInitializer::describe_to( fmt::Writer& w ) const
+{
+  w << "error-initializer";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ErrorInitializer.h
+++ b/pol-core/bscript/compiler/ast/ErrorInitializer.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_ERRORINITIALIZER_H
+#define POLSERVER_ERRORINITIALIZER_H
+
+#include "compiler/ast/Expression.h"
+
+namespace Pol::Bscript::Compiler
+{
+class ErrorInitializer : public Expression
+{
+public:
+  ErrorInitializer( const SourceLocation&, std::vector<std::string> names,
+                    std::vector<std::unique_ptr<Expression>> expressions );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::vector<std::string> names;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_ERRORINITIALIZER_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -17,6 +17,8 @@
 #include "compiler/ast/ElementAccess.h"
 #include "compiler/ast/ElementAssignment.h"
 #include "compiler/ast/ElementIndexes.h"
+#include "compiler/ast/ErrorInitializer.h"
+#include "compiler/ast/ExitStatement.h"
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/ForeachLoop.h"
 #include "compiler/ast/FunctionBody.h"
@@ -127,6 +129,11 @@ void NodeVisitor::visit_element_assignment( ElementAssignment& node )
 }
 
 void NodeVisitor::visit_element_indexes( ElementIndexes& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_error_initializer( ErrorInitializer& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -20,6 +20,7 @@ class DoWhileLoop;
 class ElementAccess;
 class ElementAssignment;
 class ElementIndexes;
+class ErrorInitializer;
 class ExitStatement;
 class FloatValue;
 class ForeachLoop;
@@ -72,6 +73,7 @@ public:
   virtual void visit_element_access( ElementAccess& );
   virtual void visit_element_assignment( ElementAssignment& );
   virtual void visit_element_indexes( ElementIndexes& );
+  virtual void visit_error_initializer( ErrorInitializer& );
   virtual void visit_exit_statement( ExitStatement& );
   virtual void visit_float_value( FloatValue& );
   virtual void visit_foreach_loop( ForeachLoop& );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -14,6 +14,7 @@ class ArrayInitializer;
 class BinaryOperator;
 class DictionaryInitializer;
 class ElementAccess;
+class ErrorInitializer;
 class Expression;
 class FunctionCall;
 class GetMember;
@@ -41,6 +42,9 @@ public:
 
   std::unique_ptr<ElementAccess> element_access(
       std::unique_ptr<Expression> lhs, EscriptGrammar::EscriptParser::ExpressionListContext* );
+
+  std::unique_ptr<ErrorInitializer> error(
+      EscriptGrammar::EscriptParser::ExplicitErrorInitializerContext* );
 
   std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
 

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -148,6 +148,11 @@ void InstructionEmitter::dictionary_add_member()
   emit_token( INS_DICTIONARY_ADDMEMBER, TYP_OPERATOR );
 }
 
+void InstructionEmitter::error_create()
+{
+  emit_token( TOK_ERROR, TYP_OPERAND );
+}
+
 void InstructionEmitter::exit()
 {
   emit_token( RSV_EXIT, TYP_RESERVED );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -62,6 +62,7 @@ public:
   void declare_variable( const Variable& );
   void dictionary_create();
   void dictionary_add_member();
+  void error_create();
   void exit();
   void foreach_init( FlowControlLabel& );
   void foreach_step( FlowControlLabel& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -17,6 +17,7 @@
 #include "compiler/ast/ElementAccess.h"
 #include "compiler/ast/ElementAssignment.h"
 #include "compiler/ast/ElementIndexes.h"
+#include "compiler/ast/ErrorInitializer.h"
 #include "compiler/ast/ExitStatement.h"
 #include "compiler/ast/FloatValue.h"
 #include "compiler/ast/ForeachLoop.h"
@@ -190,6 +191,17 @@ void InstructionGenerator::visit_element_assignment( ElementAssignment& node )
       emit.assign_subscript();
     else
       emit.assign_multisubscript( num_indexes );
+  }
+}
+
+void InstructionGenerator::visit_error_initializer( ErrorInitializer& node )
+{
+  emit.error_create();
+  int i = 0;
+  for ( auto& child : node.children )
+  {
+    child->accept( *this );
+    emit.struct_add_member( node.names[i++] );
   }
 }
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -8,8 +8,6 @@
 
 namespace Pol::Bscript::Compiler
 {
-class AssignVariableConsume;
-class ElementAssignment;
 class FlowControlLabel;
 class InstructionEmitter;
 
@@ -32,6 +30,7 @@ public:
   void visit_do_while_loop( DoWhileLoop& ) override;
   void visit_element_access( ElementAccess& ) override;
   void visit_element_assignment( ElementAssignment& ) override;
+  void visit_error_initializer( ErrorInitializer& ) override;
   void visit_exit_statement( ExitStatement& ) override;
   void visit_float_value( FloatValue& ) override;
   void visit_foreach_loop( ForeachLoop& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -193,6 +193,9 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << defn.name;
     break;
   }
+  case TOK_ERROR:
+    w << "error";
+    break;
 
   case TOK_LOCALVAR:
     w << "local variable #" << tkn.offset;


### PR DESCRIPTION
Adds:
- [ast/ErrorInitializer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/ErrorInitializer.h): AST node to create a new error object