### PR TITLE
Add BranchSelector for easier branch optimization

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -40,6 +40,8 @@ set (bscript_sources    # sorted !
   compiler/ast/BinaryOperator.h
   compiler/ast/Block.cpp
   compiler/ast/Block.h
+  compiler/ast/BranchSelector.cpp
+  compiler/ast/BranchSelector.h
   compiler/ast/CaseDispatchDefaultSelector.cpp
   compiler/ast/CaseDispatchDefaultSelector.h
   compiler/ast/CaseDispatchGroup.cpp

--- a/pol-core/bscript/compiler/ast/BranchSelector.cpp
+++ b/pol-core/bscript/compiler/ast/BranchSelector.cpp
@@ -1,0 +1,41 @@
+#include "BranchSelector.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+#include "compiler/model/FlowControlLabel.h"
+
+namespace Pol::Bscript::Compiler
+{
+BranchSelector::BranchSelector( const SourceLocation& source_location, BranchType branch_type,
+                                std::unique_ptr<Expression> predicate )
+    : Node( source_location, std::move( predicate ) ),
+      branch_type( branch_type ),
+      flow_control_label( std::make_shared<FlowControlLabel>() )
+{
+}
+
+BranchSelector::BranchSelector( const SourceLocation& source_location, BranchType branch_type )
+    : Node( source_location ),
+      branch_type( branch_type ),
+      flow_control_label( std::make_shared<FlowControlLabel>() )
+{
+}
+
+void BranchSelector::accept( NodeVisitor& visitor )
+{
+  visitor.visit_branch_selector( *this );
+}
+
+void BranchSelector::describe_to( fmt::Writer& w ) const
+{
+  w << "branch-selector(" << branch_type << ")";
+}
+
+Expression* BranchSelector::predicate()
+{
+  return children.empty() ? nullptr : &child<Expression>( 0 );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/BranchSelector.h
+++ b/pol-core/bscript/compiler/ast/BranchSelector.h
@@ -1,0 +1,35 @@
+#ifndef POLSERVER_BRANCHSELECTOR_H
+#define POLSERVER_BRANCHSELECTOR_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class FlowControlLabel;
+
+class BranchSelector : public Node
+{
+public:
+  enum BranchType {
+    IfTrue,
+    IfFalse,
+    Always,
+    Never
+  };
+
+  BranchSelector( const SourceLocation&, BranchType branch_type, std::unique_ptr<Expression> );
+  BranchSelector( const SourceLocation&, BranchType branch_type );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const BranchType branch_type;
+  std::shared_ptr<FlowControlLabel> flow_control_label;
+
+  Expression* predicate();
+};
+
+}
+
+#endif  // POLSERVER_BRANCHSELECTOR_H

--- a/pol-core/bscript/compiler/ast/IfThenElseStatement.cpp
+++ b/pol-core/bscript/compiler/ast/IfThenElseStatement.cpp
@@ -3,30 +3,31 @@
 #include <format/format.h>
 
 #include "compiler/ast/Block.h"
+#include "compiler/ast/BranchSelector.h"
 #include "compiler/ast/Expression.h"
 #include "compiler/ast/NodeVisitor.h"
 
 namespace Pol::Bscript::Compiler
 {
 IfThenElseStatement::IfThenElseStatement( const SourceLocation& source_location,
-                                          std::unique_ptr<Expression> predicate,
+                                          std::unique_ptr<BranchSelector> branch_selector,
                                           std::unique_ptr<Block> consequent,
                                           std::unique_ptr<Node> alternative )
     : Statement( source_location )
 {
   children.reserve( 3 );
-  children.push_back( std::move( predicate ) );
+  children.push_back( std::move( branch_selector ) );
   children.push_back( std::move( consequent ) );
   children.push_back( std::move( alternative ) );
 }
 
 IfThenElseStatement::IfThenElseStatement( const SourceLocation& source_location,
-                                          std::unique_ptr<Expression> predicate,
+                                          std::unique_ptr<BranchSelector> branch_selector,
                                           std::unique_ptr<Block> consequent )
     : Statement( source_location )
 {
   children.reserve( 2 );
-  children.push_back( std::move( predicate ) );
+  children.push_back( std::move( branch_selector ) );
   children.push_back( std::move( consequent ) );
 }
 
@@ -40,9 +41,9 @@ void IfThenElseStatement::describe_to( fmt::Writer& w ) const
   w << "if-then-else-statement";
 }
 
-Expression& IfThenElseStatement::predicate()
+BranchSelector& IfThenElseStatement::branch_selector()
 {
-  return child<Expression>( 0 );
+  return child<BranchSelector>( 0 );
 }
 
 Block& IfThenElseStatement::consequent()
@@ -53,11 +54,6 @@ Block& IfThenElseStatement::consequent()
 Node* IfThenElseStatement::alternative()
 {
   return ( children.size() >= 3 ) ? children.at( 2 ).get() : nullptr;
-}
-
-std::unique_ptr<Expression> IfThenElseStatement::take_predicate()
-{
-  return take_child<Expression>( 0 );
 }
 
 std::unique_ptr<Block> IfThenElseStatement::take_consequent()

--- a/pol-core/bscript/compiler/ast/IfThenElseStatement.h
+++ b/pol-core/bscript/compiler/ast/IfThenElseStatement.h
@@ -6,23 +6,24 @@
 namespace Pol::Bscript::Compiler
 {
 class Block;
+class BranchSelector;
 class Expression;
+
 class IfThenElseStatement : public Statement
 {
 public:
-  IfThenElseStatement( const SourceLocation&, std::unique_ptr<Expression> predicate,
+  IfThenElseStatement( const SourceLocation&, std::unique_ptr<BranchSelector>,
                        std::unique_ptr<Block> consequent, std::unique_ptr<Node> alternative );
-  IfThenElseStatement( const SourceLocation&, std::unique_ptr<Expression> predicate,
+  IfThenElseStatement( const SourceLocation&, std::unique_ptr<BranchSelector>,
                        std::unique_ptr<Block> consequent );
 
   void accept( NodeVisitor& visitor ) override;
   void describe_to( fmt::Writer& ) const override;
 
-  Expression& predicate();
+  BranchSelector& branch_selector();
   Block& consequent();
   Node* alternative();
 
-  std::unique_ptr<Expression> take_predicate();
   std::unique_ptr<Block> take_consequent();
   std::unique_ptr<Node> take_alternative();
 };

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -5,6 +5,7 @@
 #include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
+#include "compiler/ast/BranchSelector.h"
 #include "compiler/ast/CaseDispatchDefaultSelector.h"
 #include "compiler/ast/CaseDispatchGroup.h"
 #include "compiler/ast/CaseDispatchGroups.h"
@@ -68,6 +69,11 @@ void NodeVisitor::visit_binary_operator( BinaryOperator& node )
 }
 
 void NodeVisitor::visit_block( Block& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_branch_selector( BranchSelector& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -8,6 +8,7 @@ class ArrayInitializer;
 class AssignVariableConsume;
 class BinaryOperator;
 class Block;
+class BranchSelector;
 class CaseStatement;
 class CaseDispatchDefaultSelector;
 class CaseDispatchGroup;
@@ -61,6 +62,7 @@ public:
   virtual void visit_assign_variable_consume( AssignVariableConsume& );
   virtual void visit_binary_operator( BinaryOperator& );
   virtual void visit_block( Block& );
+  virtual void visit_branch_selector( BranchSelector& );
   virtual void visit_case_statement( CaseStatement& );
   virtual void visit_case_dispatch_default_selector( CaseDispatchDefaultSelector& );
   virtual void visit_case_dispatch_group( CaseDispatchGroup& );

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include "compiler/ast/ArrayInitializer.h"
 #include "compiler/ast/Block.h"
+#include "compiler/ast/BranchSelector.h"
 #include "compiler/ast/CaseDispatchDefaultSelector.h"
 #include "compiler/ast/CaseDispatchGroup.h"
 #include "compiler/ast/CaseDispatchGroups.h"
@@ -253,16 +254,19 @@ std::unique_ptr<Statement> CompoundStatementBuilder::if_statement(
         if_statement_ast ? std::move( if_statement_ast ) : std::move( else_clause );
     auto source_location = location_for( *expression_ctx );
 
+    auto branch_selector = std::make_unique<BranchSelector>(
+        source_location, BranchSelector::IfFalse, std::move( expression_ast ) );
+
     if ( alternative_ast )
     {
       if_statement_ast = std::make_unique<IfThenElseStatement>(
-          source_location, std::move( expression_ast ), std::move( consequent_ast ),
+          source_location, std::move( branch_selector ), std::move( consequent_ast ),
           std::move( alternative_ast ) );
     }
     else
     {
       if_statement_ast = std::make_unique<IfThenElseStatement>(
-          source_location, std::move( expression_ast ), std::move( consequent_ast ) );
+          source_location, std::move( branch_selector ), std::move( consequent_ast ) );
     }
   }
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -25,6 +25,7 @@ public:
   void visit_case_statement( CaseStatement& ) override;
   void visit_binary_operator( BinaryOperator& ) override;
   void visit_block( Block& ) override;
+  void visit_branch_selector( BranchSelector& ) override;
   void visit_dictionary_entry( DictionaryEntry& ) override;
   void visit_dictionary_initializer( DictionaryInitializer& ) override;
   void visit_do_while_loop( DoWhileLoop& ) override;

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -20,6 +20,7 @@ public:
   void visit_children( Node& ) override;
 
   void visit_binary_operator( BinaryOperator& ) override;
+  void visit_branch_selector( BranchSelector& ) override;
   void visit_const_declaration( ConstDeclaration& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_if_then_else_statement( IfThenElseStatement& ) override;


### PR DESCRIPTION
The moves the optimization logic out of `InstructionGenerator::visit_if_then_else_statement()` and into the optimizer.  The `BranchSelector` will also be suitable for use with loops, once parity with the OG compiler is no longer a goal.

Adds:
- [ast/BranchSelector](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/BranchSelector.h): AST node for a branch
  - can be conditional, based on a predicate
  - can be unconditional (always / never branch)