### PR TITLE
New compiler: method calls

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -100,6 +100,10 @@ set (bscript_sources    # sorted !
   compiler/ast/LabelableStatement.h
   compiler/ast/LoopStatement.cpp
   compiler/ast/LoopStatement.cpp
+  compiler/ast/MethodCall.cpp
+  compiler/ast/MethodCall.h
+  compiler/ast/MethodCallArgumentList.cpp
+  compiler/ast/MethodCallArgumentList.h
   compiler/ast/ModuleFunctionDeclaration.cpp
   compiler/ast/ModuleFunctionDeclaration.h
   compiler/ast/Node.cpp

--- a/pol-core/bscript/compiler/ast/MethodCall.cpp
+++ b/pol-core/bscript/compiler/ast/MethodCall.cpp
@@ -1,0 +1,41 @@
+#include "MethodCall.h"
+
+#include <format/format.h>
+#include <utility>
+
+#include "compiler/ast/MethodCallArgumentList.h"
+#include "compiler/ast/NodeVisitor.h"
+#include "compilercfg.h"
+
+namespace Pol::Bscript::Compiler
+{
+MethodCall::MethodCall( const SourceLocation& source_location, std::unique_ptr<Expression> lhs,
+                        std::string methodname,
+                        std::unique_ptr<MethodCallArgumentList> argument_list )
+    : Expression( source_location ),
+      methodname( std::move( methodname ) ),
+      known_method( compilercfg.OptimizeObjectMembers
+                        ? getKnownObjMethod( this->methodname.c_str() )
+                        : nullptr )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( lhs ) );
+  children.push_back( std::move( argument_list ) );
+}
+
+void MethodCall::accept( NodeVisitor& visitor )
+{
+  visitor.visit_method_call( *this );
+}
+
+void MethodCall::describe_to( fmt::Writer& w ) const
+{
+  w << "method-call(" << methodname << ")";
+}
+
+unsigned MethodCall::argument_count() const
+{
+  return static_cast<unsigned>(children.at( 1 )->children.size());
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/MethodCall.h
+++ b/pol-core/bscript/compiler/ast/MethodCall.h
@@ -1,0 +1,33 @@
+#ifndef POLSERVER_METHODCALL_H
+#define POLSERVER_METHODCALL_H
+
+#include "compiler/ast/Expression.h"
+
+#ifndef OBJMETHODS_H
+#include "objmethods.h"
+#endif
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+class MethodCallArgumentList;
+
+class MethodCall : public Expression
+{
+public:
+  MethodCall( const SourceLocation&, std::unique_ptr<Expression> lhs,
+              std::string methodname, std::unique_ptr<MethodCallArgumentList> );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  unsigned argument_count() const;
+
+  const std::string methodname;
+  const Pol::Bscript::ObjMethod* const known_method;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+
+#endif  // POLSERVER_METHODCALL_H

--- a/pol-core/bscript/compiler/ast/MethodCallArgumentList.cpp
+++ b/pol-core/bscript/compiler/ast/MethodCallArgumentList.cpp
@@ -1,0 +1,25 @@
+#include "MethodCallArgumentList.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/Expression.h"
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+MethodCallArgumentList::MethodCallArgumentList( const SourceLocation& source_location,
+                                                std::vector<std::unique_ptr<Expression>> arguments )
+    : Node( source_location, std::move( arguments ) )
+{
+}
+
+void MethodCallArgumentList::accept( NodeVisitor& visitor )
+{
+  visitor.visit_method_call_argument_list( *this );
+}
+void MethodCallArgumentList::describe_to( fmt::Writer& w ) const
+{
+  w << "method-call-argument-list";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/MethodCallArgumentList.h
+++ b/pol-core/bscript/compiler/ast/MethodCallArgumentList.h
@@ -1,0 +1,22 @@
+#ifndef POLSERVER_METHODCALLARGUMENTLIST_H
+#define POLSERVER_METHODCALLARGUMENTLIST_H
+
+#include "compiler/ast/Node.h"
+
+namespace Pol::Bscript::Compiler
+{
+class Expression;
+
+class MethodCallArgumentList : public Node
+{
+public:
+  MethodCallArgumentList( const SourceLocation&,
+                          std::vector<std::unique_ptr<Expression>> arguments );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_METHODCALLARGUMENTLIST_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -29,6 +29,8 @@
 #include "compiler/ast/GetMember.h"
 #include "compiler/ast/IfThenElseStatement.h"
 #include "compiler/ast/JumpStatement.h"
+#include "compiler/ast/MethodCall.h"
+#include "compiler/ast/MethodCallArgumentList.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Node.h"
 #include "compiler/ast/Program.h"
@@ -194,6 +196,16 @@ void NodeVisitor::visit_if_then_else_statement( IfThenElseStatement& node )
 
 void NodeVisitor::visit_integer_value( IntegerValue& )
 {
+}
+
+void NodeVisitor::visit_method_call( MethodCall& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_method_call_argument_list( MethodCallArgumentList& node )
+{
+  visit_children( node );
 }
 
 void NodeVisitor::visit_jump_statement( JumpStatement& node )

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -34,6 +34,8 @@ class IfThenElseStatement;
 class IntegerValue;
 class JumpStatement;
 class GetMember;
+class MethodCall;
+class MethodCallArgumentList;
 class ModuleFunctionDeclaration;
 class Node;
 class Program;
@@ -89,6 +91,8 @@ public:
   virtual void visit_if_then_else_statement( IfThenElseStatement& );
   virtual void visit_integer_value( IntegerValue& );
   virtual void visit_jump_statement( JumpStatement& );
+  virtual void visit_method_call( MethodCall& );
+  virtual void visit_method_call_argument_list( MethodCallArgumentList& );
   virtual void visit_module_function_declaration( ModuleFunctionDeclaration& );
   virtual void visit_program( Program& );
   virtual void visit_program_parameter_declaration( ProgramParameterDeclaration& );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -18,6 +18,7 @@ class ErrorInitializer;
 class Expression;
 class FunctionCall;
 class GetMember;
+class MethodCall;
 class UnaryOperator;
 
 class ExpressionBuilder : public ValueBuilder
@@ -55,6 +56,9 @@ public:
 
   std::unique_ptr<FunctionCall> function_call( EscriptGrammar::EscriptParser::FunctionCallContext*,
                                                const std::string& scope );
+
+  std::unique_ptr<MethodCall> method_call(
+      std::unique_ptr<Expression> lhs, EscriptGrammar::EscriptParser::MethodCallSuffixContext* );
 
   std::unique_ptr<BinaryOperator> membership_operator(
       EscriptGrammar::EscriptParser::ExpressionContext* );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -31,6 +31,7 @@
 #include "compiler/ast/IfThenElseStatement.h"
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/JumpStatement.h"
+#include "compiler/ast/MethodCall.h"
 #include "compiler/ast/ModuleFunctionDeclaration.h"
 #include "compiler/ast/Program.h"
 #include "compiler/ast/ProgramParameterDeclaration.h"
@@ -347,6 +348,23 @@ void InstructionGenerator::visit_get_member( GetMember& member_access )
     emit.get_member_id( km->id );
   else
     emit.get_member( member_access.name );
+}
+
+void InstructionGenerator::visit_method_call( MethodCall& method_call )
+{
+  visit_children( method_call );
+
+  auto argument_count = method_call.argument_count();
+  if ( auto km = method_call.known_method )
+  {
+    emit.call_method_id( km->id, argument_count );
+  }
+  else
+  {
+    std::string method_name = method_call.methodname;
+    Clib::mklowerASCII( method_name );
+    emit.call_method( method_name, argument_count );
+  }
 }
 
 void InstructionGenerator::visit_program( Program& program )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -43,6 +43,7 @@ public:
   void visit_if_then_else_statement( IfThenElseStatement& ) override;
   void visit_integer_value( IntegerValue& ) override;
   void visit_jump_statement( JumpStatement& ) override;
+  void visit_method_call( MethodCall& member_call ) override;
   void visit_program( Program& ) override;
   void visit_program_parameter_declaration( ProgramParameterDeclaration& ) override;
   void visit_repeat_until_loop( RepeatUntilLoop& repeat_until ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -4,6 +4,7 @@
 #include "compiler/representation/ModuleDescriptor.h"
 #include "compiler/representation/ModuleFunctionDescriptor.h"
 #include "objmembers.h"
+#include "objmethods.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -223,6 +224,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "create-array (TOK_ARRAY)";
     break;
 
+  case INS_CALL_METHOD:
+    w << "call method '" << string_at( tkn.offset ) << "'";
+    break;
+
   case TOK_DICTIONARY:
     w << "TOK_DICTIONARY";
     break;
@@ -304,6 +309,10 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     break;
   case INS_SET_MEMBER_ID_CONSUME:
     w << "set-member-id-consume '" << getObjMember( tkn.type )->code << "' (" << tkn.type << ")";
+    break;
+  case INS_CALL_METHOD_ID:
+    w << "call-method-id '" << getObjMethod( tkn.offset )->code << "' (#" << tkn.offset << ", "
+      << tkn.type << " arguments)";
     break;
 
   case TOK_UNPLUSPLUS:


### PR DESCRIPTION
Adds:
- [ast/MethodCall](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/MethodCall.h): AST node for an object method call
- [ast/MethodCallArgumentList](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/MethodCallArgumentList.h): AST node for arguments passed to a method