### PR TITLE
New compiler: operators on object members

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -126,6 +126,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ReturnStatement.h
   compiler/ast/SetMember.cpp
   compiler/ast/SetMember.h
+  compiler/ast/SetMemberByOperator.cpp
+  compiler/ast/SetMemberByOperator.h
   compiler/ast/Statement.cpp
   compiler/ast/Statement.h
   compiler/ast/StringValue.cpp

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -41,6 +41,7 @@
 #include "compiler/ast/RepeatUntilLoop.h"
 #include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/SetMember.h"
+#include "compiler/ast/SetMemberByOperator.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/StructInitializer.h"
 #include "compiler/ast/StructMemberInitializer.h"
@@ -255,6 +256,11 @@ void NodeVisitor::visit_return_statement( ReturnStatement& node )
 }
 
 void NodeVisitor::visit_set_member( SetMember& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_set_member_by_operator( SetMemberByOperator& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -46,6 +46,7 @@ class ProgramParameterList;
 class RepeatUntilLoop;
 class ReturnStatement;
 class SetMember;
+class SetMemberByOperator;
 class StringValue;
 class StructInitializer;
 class StructMemberInitializer;
@@ -104,6 +105,7 @@ public:
   virtual void visit_repeat_until_loop( RepeatUntilLoop& );
   virtual void visit_return_statement( ReturnStatement& );
   virtual void visit_set_member( SetMember& );
+  virtual void visit_set_member_by_operator( SetMemberByOperator& );
   virtual void visit_string_value( StringValue& );
   virtual void visit_struct_initializer( StructInitializer& );
   virtual void visit_struct_member_initializer( StructMemberInitializer& );

--- a/pol-core/bscript/compiler/ast/SetMemberByOperator.cpp
+++ b/pol-core/bscript/compiler/ast/SetMemberByOperator.cpp
@@ -1,0 +1,48 @@
+#include "SetMemberByOperator.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+SetMemberByOperator::SetMemberByOperator( const SourceLocation& source_location, bool consume,
+                                          std::unique_ptr<Expression> entity, std::string name,
+                                          BTokenId token_id, std::unique_ptr<Expression> rhs,
+                                          const Pol::Bscript::ObjMember& known_member )
+    : Expression( source_location ),
+      consume( consume ),
+      name( std::move( name ) ),
+      token_id( token_id ),
+      known_member( known_member )
+{
+  children.reserve( 2 );
+  children.push_back( std::move( entity ) );
+  children.push_back( std::move( rhs ) );
+}
+
+SetMemberByOperator::SetMemberByOperator( const SourceLocation& source_location, bool consume,
+                                          std::unique_ptr<Expression> entity, std::string name,
+                                          BTokenId token_id,
+                                          const Pol::Bscript::ObjMember& known_member )
+    : Expression( source_location ),
+      consume( consume ),
+      name( std::move( name ) ),
+      token_id( token_id ),
+      known_member( known_member )
+{
+  children.reserve( 1 );
+  children.push_back( std::move( entity ) );
+}
+
+void SetMemberByOperator::accept( NodeVisitor& visitor )
+{
+  visitor.visit_set_member_by_operator( *this );
+}
+
+void SetMemberByOperator::describe_to( fmt::Writer& w ) const
+{
+  w << "set-member-by-operator(" << name << ", " << token_id << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/SetMemberByOperator.h
+++ b/pol-core/bscript/compiler/ast/SetMemberByOperator.h
@@ -1,0 +1,37 @@
+#ifndef POLSERVER_SETMEMBERBYOPERATOR_H
+#define POLSERVER_SETMEMBERBYOPERATOR_H
+
+#include "compiler/ast/Expression.h"
+
+#ifndef OBJMEMBERS_H
+#include "objmembers.h"
+#endif
+
+#ifndef __TOKENS_H
+#include "tokens.h"
+#endif
+
+namespace Pol::Bscript::Compiler
+{
+class SetMemberByOperator : public Expression
+{
+public:
+  SetMemberByOperator( const SourceLocation&, bool consume, std::unique_ptr<Expression> entity,
+                       std::string name, BTokenId, std::unique_ptr<Expression> rhs,
+                       const Pol::Bscript::ObjMember& );
+  SetMemberByOperator( const SourceLocation&, bool consume, std::unique_ptr<Expression> entity,
+                       std::string name, BTokenId, const Pol::Bscript::ObjMember& );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const bool consume;
+  const std::string name;
+  const BTokenId token_id;
+  // does the semantic analyze known enough to know something is being assigned to?
+  const Pol::Bscript::ObjMember& known_member;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_SETMEMBERBYOPERATOR_H

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -282,6 +282,11 @@ void InstructionEmitter::set_member( const std::string& name )
   emit_token( INS_SET_MEMBER, TYP_UNARY_OPERATOR, offset );
 }
 
+void InstructionEmitter::set_member_by_operator( BTokenId token_id, MemberID member_id )
+{
+  emit_token( token_id, TYP_UNARY_OPERATOR, member_id );
+}
+
 void InstructionEmitter::struct_create()
 {
   emit_token( TOK_STRUCT, TYP_OPERAND );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -88,6 +88,7 @@ public:
   void set_member_id( MemberID member_id );
   void set_member_id_consume( MemberID member_id );
   void set_member_consume( const std::string& name );
+  void set_member_by_operator( BTokenId, MemberID );
   void struct_create();
   void struct_add_uninit_member( const std::string& name );
   void struct_add_member( const std::string& name );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -40,6 +40,7 @@
 #include "compiler/ast/RepeatUntilLoop.h"
 #include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/SetMember.h"
+#include "compiler/ast/SetMemberByOperator.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/ast/StructInitializer.h"
 #include "compiler/ast/StructMemberInitializer.h"
@@ -471,6 +472,13 @@ void InstructionGenerator::visit_set_member( SetMember& node )
     else
       emit.set_member( node.name );
   }
+}
+
+void InstructionGenerator::visit_set_member_by_operator( SetMemberByOperator& node )
+{
+  visit_children( node );
+
+  emit.set_member_by_operator( node.token_id, node.known_member.id );
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -51,6 +51,7 @@ public:
   void visit_repeat_until_loop( RepeatUntilLoop& repeat_until ) override;
   void visit_return_statement( ReturnStatement& ) override;
   void visit_set_member( SetMember& ) override;
+  void visit_set_member_by_operator( SetMemberByOperator& ) override;
   void visit_string_value( StringValue& ) override;
   void visit_struct_initializer( StructInitializer& ) override;
   void visit_struct_member_initializer( StructMemberInitializer& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -321,6 +321,22 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
       << tkn.type << " arguments)";
     break;
 
+  case INS_SET_MEMBER_ID_CONSUME_PLUSEQUAL:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  += #";
+    break;
+  case INS_SET_MEMBER_ID_CONSUME_MINUSEQUAL:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  -= #";
+    break;
+  case INS_SET_MEMBER_ID_CONSUME_TIMESEQUAL:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  *= #";
+    break;
+  case INS_SET_MEMBER_ID_CONSUME_DIVIDEEQUAL:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  /= #";
+    break;
+  case INS_SET_MEMBER_ID_CONSUME_MODULUSEQUAL:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  %= #";
+    break;
+
   case TOK_UNPLUSPLUS:
     w << "prefix unary ++";
     break;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -349,6 +349,18 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
   case TOK_UNMINUSMINUS_POST:
     w << "postfix unary --";
     break;
+  case INS_SET_MEMBER_ID_UNPLUSPLUS:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' unary ++";
+    break;
+  case INS_SET_MEMBER_ID_UNMINUSMINUS:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' unary --";
+    break;
+  case INS_SET_MEMBER_ID_UNPLUSPLUS_POST:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' unary ++ post";
+    break;
+  case INS_SET_MEMBER_ID_UNMINUSMINUS_POST:
+    w << "set member id '" << getObjMember( tkn.offset )->code << "' unary -- post";
+    break;
 
   default:
     w << "id=0x" << fmt::hex( tkn.id ) << " type=" << tkn.type << " offset=" << tkn.offset

--- a/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/UnaryOperatorOptimizer.h
@@ -22,6 +22,7 @@ public:
 
   void visit_children( Node& ) override;
   void visit_float_value( FloatValue& literal ) override;
+  void visit_get_member( GetMember& ) override;
   void visit_integer_value( IntegerValue& literal ) override;
 
 private:


### PR DESCRIPTION
Compile expressions like
```
a.b += 5;
--a.b;
```

Adds:
- [ast/SetMemberByOperator](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/SetMemberByOperator.h)