### PR TITLE
New compiler: add support for function references

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -90,6 +90,8 @@ set (bscript_sources    # sorted !
   compiler/ast/FunctionParameterDeclaration.h
   compiler/ast/FunctionParameterList.cpp
   compiler/ast/FunctionParameterList.h
+  compiler/ast/FunctionReference.cpp
+  compiler/ast/FunctionReference.h
   compiler/ast/GetMember.cpp
   compiler/ast/GetMember.h
   compiler/ast/Identifier.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -24,6 +24,8 @@
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/FunctionReference.h"
+#include "compiler/ast/GetMember.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/JumpStatement.h"
@@ -362,6 +364,19 @@ void SemanticAnalyzer::visit_function_parameter_declaration( FunctionParameterDe
 
   WarnOn warn_on = node.unused ? WarnOn::IfUsed : WarnOn::IfNotUsed;
   local_scopes.current_local_scope()->create( node.name, warn_on, node.source_location );
+}
+
+void SemanticAnalyzer::visit_function_reference( FunctionReference& node )
+{
+  if ( !node.function_link->function() )
+  {
+    report.error( node, "User function '", node.name, "' not found" );
+  }
+}
+
+void SemanticAnalyzer::visit_get_member( GetMember& node )
+{
+  visit_children( node );
 }
 
 void SemanticAnalyzer::visit_identifier( Identifier& node )

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -39,6 +39,8 @@ public:
   void visit_function_call( FunctionCall& ) override;
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
+  void visit_function_reference( FunctionReference& ) override;
+  void visit_get_member( GetMember& ) override;
   void visit_identifier( Identifier& ) override;
   void visit_jump_statement( JumpStatement& ) override;
   void visit_loop_statement( LoopStatement& );

--- a/pol-core/bscript/compiler/ast/FunctionReference.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionReference.cpp
@@ -1,0 +1,25 @@
+#include "FunctionReference.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+FunctionReference::FunctionReference( const SourceLocation& source_location, std::string name,
+                                      std::shared_ptr<FunctionLink> function_link )
+    : Value( source_location ), name( name ), function_link( std::move( function_link ) )
+{
+}
+
+void FunctionReference::accept( NodeVisitor& visitor )
+{
+  visitor.visit_function_reference( *this );
+}
+
+void FunctionReference::describe_to( fmt::Writer& w ) const
+{
+  w << "function-reference(@" << name << ")";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionReference.h
+++ b/pol-core/bscript/compiler/ast/FunctionReference.h
@@ -1,0 +1,24 @@
+#ifndef POLSERVER_FUNCTIONREFERENCE_H
+#define POLSERVER_FUNCTIONREFERENCE_H
+
+#include "compiler/ast/Value.h"
+
+namespace Pol::Bscript::Compiler
+{
+class FunctionLink;
+
+class FunctionReference : public Value
+{
+public:
+  FunctionReference( const SourceLocation&, std::string name, std::shared_ptr<FunctionLink> );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string name;
+  const std::shared_ptr<FunctionLink> function_link;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_FUNCTIONREFERENCE_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -192,6 +192,10 @@ void NodeVisitor::visit_function_parameter_list( FunctionParameterList& node )
   visit_children( node );
 }
 
+void NodeVisitor::visit_function_reference( FunctionReference& )
+{
+}
+
 void NodeVisitor::visit_get_member( GetMember& node )
 {
   visit_children( node );

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -31,6 +31,7 @@ class FunctionBody;
 class FunctionCall;
 class FunctionParameterDeclaration;
 class FunctionParameterList;
+class FunctionReference;
 class Identifier;
 class IfThenElseStatement;
 class IntegerValue;
@@ -91,6 +92,7 @@ public:
   virtual void visit_function_call( FunctionCall& );
   virtual void visit_function_parameter_declaration( FunctionParameterDeclaration& );
   virtual void visit_function_parameter_list( FunctionParameterList& );
+  virtual void visit_function_reference( FunctionReference& );
   virtual void visit_get_member( GetMember& );
   virtual void visit_identifier( Identifier& );
   virtual void visit_if_then_else_statement( IfThenElseStatement& );

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -12,6 +12,7 @@
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/FunctionReference.h"
 #include "compiler/ast/GetMember.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/MethodCall.h"
@@ -430,6 +431,10 @@ std::unique_ptr<Expression> ExpressionBuilder::primary( EscriptParser::PrimaryCo
   else if ( auto struct_init = ctx->explicitStructInitializer() )
   {
     return struct_initializer( struct_init );
+  }
+  else if ( auto fr = ctx->functionReference() )
+  {
+    return function_reference( fr );
   }
   else if ( auto error_init = ctx->explicitErrorInitializer() )
   {

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.cpp
@@ -5,10 +5,12 @@
 #include "clib/strutil.h"
 #include "compiler/Report.h"
 #include "compiler/ast/FloatValue.h"
+#include "compiler/ast/FunctionReference.h"
 #include "compiler/ast/IntegerValue.h"
 #include "compiler/ast/StringValue.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/file/SourceLocation.h"
+#include "compiler/model/FunctionLink.h"
 
 using EscriptGrammar::EscriptParser;
 
@@ -26,6 +28,21 @@ std::unique_ptr<FloatValue> ValueBuilder::float_value(
   auto loc = location_for( *ctx );
   double value = std::stod( text( ctx->FLOAT_LITERAL() ) );
   return std::make_unique<FloatValue>( loc, value );
+}
+
+std::unique_ptr<FunctionReference> ValueBuilder::function_reference(
+    EscriptParser::FunctionReferenceContext* ctx )
+{
+  auto source_location = location_for( *ctx );
+  auto name = ctx->IDENTIFIER()->getSymbol()->getText();
+
+  auto function_link = std::make_shared<FunctionLink>( source_location );
+  auto function_reference =
+      std::make_unique<FunctionReference>( source_location, name, function_link );
+
+  workspace.function_resolver.register_function_link( name, function_link );
+
+  return function_reference;
 }
 
 std::unique_ptr<IntegerValue> ValueBuilder::integer_value(

--- a/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ValueBuilder.h
@@ -9,6 +9,7 @@ namespace Pol::Bscript::Compiler
 {
 class IntegerValue;
 class FloatValue;
+class FunctionReference;
 class StringValue;
 class Value;
 
@@ -19,6 +20,9 @@ public:
 
   std::unique_ptr<FloatValue> float_value(
       EscriptGrammar::EscriptParser::FloatLiteralContext* );
+
+  std::unique_ptr<FunctionReference> function_reference(
+      EscriptGrammar::EscriptParser::FunctionReferenceContext* );
 
   std::unique_ptr<IntegerValue> integer_value(
       EscriptGrammar::EscriptParser::IntegerLiteralContext* );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -186,6 +186,11 @@ void InstructionEmitter::foreach_step( FlowControlLabel& label )
   register_with_label( label, emit_token( INS_STEPFOREACH, TYP_RESERVED ) );
 }
 
+void InstructionEmitter::function_reference( unsigned parameter_count, FlowControlLabel& label )
+{
+  register_with_label( label, emit_token( TOK_FUNCREF, (BTokenType)parameter_count ) );
+}
+
 void InstructionEmitter::get_arg( const std::string& name )
 {
   unsigned offset = emit_data( name );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -71,6 +71,7 @@ public:
   void exit();
   void foreach_init( FlowControlLabel& );
   void foreach_step( FlowControlLabel& );
+  void function_reference( unsigned parameter_count, FlowControlLabel& );
   void get_arg( const std::string& name );
   void get_member( const std::string& name );
   void get_member_id( MemberID );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -28,6 +28,7 @@
 #include "compiler/ast/FunctionCall.h"
 #include "compiler/ast/FunctionParameterDeclaration.h"
 #include "compiler/ast/FunctionParameterList.h"
+#include "compiler/ast/FunctionReference.h"
 #include "compiler/ast/GetMember.h"
 #include "compiler/ast/Identifier.h"
 #include "compiler/ast/IfThenElseStatement.h"
@@ -337,6 +338,19 @@ void InstructionGenerator::visit_function_parameter_declaration(
     emit.pop_param_byref( node.name );
   else
     emit.pop_param( node.name );
+}
+
+void InstructionGenerator::visit_function_reference( FunctionReference& function_reference )
+{
+  if ( auto uf = function_reference.function_link->user_function() )
+  {
+    FlowControlLabel& label = user_function_labels[uf->name];
+    emit.function_reference( uf->parameter_count(), label );
+  }
+  else
+  {
+    function_reference.internal_error( "user function not found" );
+  }
 }
 
 void InstructionGenerator::visit_identifier( Identifier& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -40,6 +40,7 @@ public:
   void visit_function_call( FunctionCall& ) override;
   void visit_function_parameter_list( FunctionParameterList& ) override;
   void visit_function_parameter_declaration( FunctionParameterDeclaration& ) override;
+  void visit_function_reference( FunctionReference& ) override;
   void visit_get_member( GetMember& member_access ) override;
   void visit_identifier( Identifier& ) override;
   void visit_if_then_else_statement( IfThenElseStatement& ) override;

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.cpp
@@ -337,6 +337,14 @@ void StoredTokenDecoder::decode_to( const StoredToken& tkn, fmt::Writer& w )
     w << "set member id '" << getObjMember( tkn.offset )->code << "' (" << tkn.offset << ")  %= #";
     break;
 
+  case TOK_FUNCREF:
+  {
+    w << "Function Ref "
+      << "--function name not available--"
+      << " @" << tkn.offset;
+    break;
+  }
+
   case TOK_UNPLUSPLUS:
     w << "prefix unary ++";
     break;

--- a/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.cpp
+++ b/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.cpp
@@ -1,6 +1,7 @@
 #include "ReferencedFunctionGatherer.h"
 
 #include "compiler/ast/FunctionCall.h"
+#include "compiler/ast/FunctionReference.h"
 #include "compiler/ast/UserFunction.h"
 #include "compiler/model/FunctionLink.h"
 
@@ -26,6 +27,11 @@ void ReferencedFunctionGatherer::visit_function_call( FunctionCall& fc )
   visit_children( fc );
 
   reference( *fc.function_link );
+}
+
+void ReferencedFunctionGatherer::visit_function_reference( FunctionReference& fr )
+{
+  reference( *fr.function_link );
 }
 
 void ReferencedFunctionGatherer::reference( FunctionLink& link )

--- a/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.h
+++ b/pol-core/bscript/compiler/optimizer/ReferencedFunctionGatherer.h
@@ -25,6 +25,7 @@ public:
       std::vector<std::unique_ptr<UserFunction>> all_user_functions );
 
   void visit_function_call( FunctionCall& ) override;
+  void visit_function_reference( FunctionReference& ) override;
 
   void reference( FunctionLink& link );
   void reference( ModuleFunctionDeclaration* );


### PR DESCRIPTION
Adds:
- [ast/FunctionReference](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/FunctionReference.h): AST node for an function reference like `@foo`