### PR TITLE
New compiler: include directives

### DIFF
--- a/pol-core/bscript/compiler/Profile.h
+++ b/pol-core/bscript/compiler/Profile.h
@@ -20,16 +20,18 @@ public:
   std::atomic<long> ambiguities;
 
   std::atomic<long> parse_em_count;
+  std::atomic<long> parse_inc_count;
   std::atomic<long> parse_src_count;
 
   std::atomic<long long> load_em_micros;
   std::atomic<long long> parse_em_micros;
   std::atomic<long long> ast_em_micros;
 
+  std::atomic<long long> parse_inc_micros;
+  std::atomic<long long> ast_inc_micros;
+
   std::atomic<long long> parse_src_micros;
   std::atomic<long long> ast_src_micros;
-
-  std::atomic<long long> ast_inc_micros;
 
   std::atomic<long long> ast_resolve_functions_micros;
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -23,10 +23,18 @@ public:
   void use_module( const std::string& name, SourceLocation& including_location,
                    long long* micros_counted = nullptr );
   void process_source( SourceFile& );
+  void process_include( SourceFile&, long long* micros_counted );
+
+  void handle_include_declaration( EscriptGrammar::EscriptParser::IncludeDeclarationContext*,
+                                   long long* micros_counted );
+  boost::optional<std::string> locate_include_file( const SourceLocation& source_location,
+                                                    const std::string& include_name );
 
   void handle_use_declaration( EscriptGrammar::EscriptParser::UseDeclarationContext*,
                                long long* micros_counted );
 
+  antlrcpp::Any visitIncludeDeclaration(
+      EscriptGrammar::EscriptParser::IncludeDeclarationContext* ) override;
   antlrcpp::Any visitFunctionDeclaration(
       EscriptGrammar::EscriptParser::FunctionDeclarationContext* ) override;
   antlrcpp::Any visitProgramDeclaration(

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -960,6 +960,9 @@ bool run( int argc, char** argv, int* res )
     tmp << "       - parse *.em:   " << (long long)summary.profile.parse_em_micros / 1000 << " ("
         << (long)summary.profile.parse_em_count << ")\n";
     tmp << "         - ast *.em:   " << (long long)summary.profile.ast_em_micros / 1000 << "\n";
+    tmp << "      - parse *.inc:   " << (long long)summary.profile.parse_inc_micros / 1000 << " ("
+        << (long)summary.profile.parse_inc_count << ")\n";
+    tmp << "        - ast *.inc:   " << (long long)summary.profile.ast_inc_micros / 1000 << "\n";
     tmp << "      - parse *.src:   " << (long long)summary.profile.parse_src_micros / 1000 << " ("
         << (long)summary.profile.parse_src_count << ")\n";
     tmp << "        - ast *.src:   " << (long long)summary.profile.ast_src_micros / 1000 << "\n";


### PR DESCRIPTION
The logic in `locate_include_file` is essentially copied from the old compiler.  