### PR TITLE
Handle semicolon (empty statement)

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -72,6 +72,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ElementIndexes.h
   compiler/ast/ElvisOperator.cpp
   compiler/ast/ElvisOperator.h
+  compiler/ast/EmptyStatement.cpp
+  compiler/ast/EmptyStatement.h
   compiler/ast/EnumDeclaration.cpp
   compiler/ast/EnumDeclaration.h
   compiler/ast/ErrorInitializer.cpp

--- a/pol-core/bscript/compiler/ast/EmptyStatement.cpp
+++ b/pol-core/bscript/compiler/ast/EmptyStatement.cpp
@@ -1,0 +1,24 @@
+#include "EmptyStatement.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+EmptyStatement::EmptyStatement( const SourceLocation& source_location )
+    : Statement( source_location )
+{
+}
+
+void EmptyStatement::accept( NodeVisitor& visitor )
+{
+  visitor.visit_empty_statement( *this );
+}
+
+void EmptyStatement::describe_to( fmt::Writer& w ) const
+{
+  w << "empty-statement";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/EmptyStatement.h
+++ b/pol-core/bscript/compiler/ast/EmptyStatement.h
@@ -1,0 +1,18 @@
+#ifndef POLSERVER_EMPTYSTATEMENT_H
+#define POLSERVER_EMPTYSTATEMENT_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class EmptyStatement : public Statement
+{
+public:
+  EmptyStatement( const SourceLocation& );
+
+  void accept( NodeVisitor& ) override;
+  void describe_to( fmt::Writer& ) const override;
+};
+
+}  // namespace Pol::Bscript::Compiler
+#endif  // POLSERVER_EMPTYSTATEMENT_H

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -21,6 +21,7 @@
 #include "compiler/ast/ElementAssignment.h"
 #include "compiler/ast/ElementIndexes.h"
 #include "compiler/ast/ElvisOperator.h"
+#include "compiler/ast/EmptyStatement.h"
 #include "compiler/ast/EnumDeclaration.h"
 #include "compiler/ast/ErrorInitializer.h"
 #include "compiler/ast/ExitStatement.h"
@@ -157,6 +158,11 @@ void NodeVisitor::visit_element_indexes( ElementIndexes& node )
 }
 
 void NodeVisitor::visit_elvis_operator( ElvisOperator& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_empty_statement( EmptyStatement& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -24,6 +24,7 @@ class ElementAccess;
 class ElementAssignment;
 class ElementIndexes;
 class ElvisOperator;
+class EmptyStatement;
 class EnumDeclaration;
 class ErrorInitializer;
 class ExitStatement;
@@ -87,6 +88,7 @@ public:
   virtual void visit_element_assignment( ElementAssignment& );
   virtual void visit_element_indexes( ElementIndexes& );
   virtual void visit_elvis_operator( ElvisOperator& );
+  virtual void visit_empty_statement( EmptyStatement& );
   virtual void visit_enum_declaration( EnumDeclaration& );
   virtual void visit_error_initializer( ErrorInitializer& );
   virtual void visit_exit_statement( ExitStatement& );

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -12,6 +12,7 @@
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/CstyleForLoop.h"
 #include "compiler/ast/DoWhileLoop.h"
+#include "compiler/ast/EmptyStatement.h"
 #include "compiler/ast/EnumDeclaration.h"
 #include "compiler/ast/ExitStatement.h"
 #include "compiler/ast/Expression.h"
@@ -104,6 +105,10 @@ void CompoundStatementBuilder::add_statements(
   else if ( auto do_statement = ctx->doStatement() )
   {
     statements.push_back( do_while_loop( do_statement ) );
+  }
+  else if ( ctx->SEMI() )
+  {
+    statements.push_back( std::make_unique<EmptyStatement>( location_for( *ctx ) ) );
   }
   else
   {


### PR DESCRIPTION
if a function ends in `return something;;` (note two semicolons) the OG compiler adds an extra return instruction at the end of the function.  The `EmptyStatement` allows the new compiler to do the same.

Adds:
- [ast/EmptyStatement](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/EmptyStatement.h)
