### PR TITLE
New compiler: Limit function parameter default value types

### DIFF
--- a/testsuite/escript/func/func011-default-parameter-bare-function-call.err1
+++ b/testsuite/escript/func/func011-default-parameter-bare-function-call.err1
@@ -1,0 +1,1 @@
+[foo]: Only simple operands are allowed as default arguments (:= is not allowed)

--- a/testsuite/escript/func/func011-default-parameter-bare-function-call.err2
+++ b/testsuite/escript/func/func011-default-parameter-bare-function-call.err2
@@ -1,0 +1,1 @@
+func011-default-parameter-bare-function-call.src:5:14: error: Parameter 'x' has a disallowed default.  Only simple operands are allowed as default arguments.

--- a/testsuite/escript/func/func011-default-parameter-bare-function-call.src
+++ b/testsuite/escript/func/func011-default-parameter-bare-function-call.src
@@ -1,0 +1,9 @@
+use math;
+
+// "Only simple operands..."
+
+function foo(x := ConstPi())
+    print(x);
+endfunction
+
+foo();


### PR DESCRIPTION
There is one part that differs from `const` declarations: 0-parameter function calls are allowed (by accident) as `const` values, but not for default parameter values.

With this change, the new compiler compiles https://github.com/polserver/ModernDistro with parity.