### PR TITLE
Disallow function names as variable, argument, and const names

### DIFF
--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -97,7 +97,7 @@ void Compiler::compile_file_steps( const std::string& pathname,
   if ( report.error_count() )
     return;
 
-  register_constants( *workspace );
+  register_constants( *workspace, report );
   if ( report.error_count() )
     return;
 
@@ -127,10 +127,10 @@ std::unique_ptr<CompilerWorkspace> Compiler::build_workspace(
   return workspace;
 }
 
-void Compiler::register_constants( CompilerWorkspace& workspace )
+void Compiler::register_constants( CompilerWorkspace& workspace, Report& report )
 {
   Pol::Tools::HighPerfTimer timer;
-  SemanticAnalyzer::register_const_declarations( workspace );
+  SemanticAnalyzer::register_const_declarations( workspace, report );
   profile.register_const_declarations_micros += timer.ellapsed().count();
 }
 
@@ -153,8 +153,8 @@ void Compiler::disambiguate( CompilerWorkspace& workspace, Report& report )
 void Compiler::analyze( CompilerWorkspace& workspace, Report& report )
 {
   Pol::Tools::HighPerfTimer timer;
-  SemanticAnalyzer analyzer( workspace.constants, report );
-  analyzer.analyze( workspace );
+  SemanticAnalyzer analyzer( workspace, report );
+  analyzer.analyze();
   profile.analyze_micros += timer.ellapsed().count();
 }
 

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -35,7 +35,7 @@ private:
   std::unique_ptr<CompilerWorkspace> build_workspace( const std::string&,
                                                       const LegacyFunctionOrder*,
                                                       Report& );
-  void register_constants( CompilerWorkspace& );
+  void register_constants( CompilerWorkspace&, Report& );
   void optimize( CompilerWorkspace&, Report& );
   void disambiguate( CompilerWorkspace&, Report& );
   void analyze( CompilerWorkspace&, Report& );

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -241,7 +241,8 @@ void SemanticAnalyzer::visit_do_while_loop( DoWhileLoop& do_while )
 
 void SemanticAnalyzer::visit_foreach_loop( ForeachLoop& node )
 {
-  if ( report_function_name_conflict( node.source_location, node.iterator_name, "foreach iterator" ) )
+  if ( report_function_name_conflict( node.source_location, node.iterator_name,
+                                      "foreach iterator" ) )
   {
     return;
   }

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -21,12 +21,12 @@ class Report;
 class SemanticAnalyzer : public NodeVisitor
 {
 public:
-  SemanticAnalyzer( Constants&, Report& );
+  SemanticAnalyzer( CompilerWorkspace&, Report& );
 
   ~SemanticAnalyzer() override;
 
-  static void register_const_declarations( CompilerWorkspace& );
-  void analyze( CompilerWorkspace& );
+  static void register_const_declarations( CompilerWorkspace&, Report& );
+  void analyze();
 
   void visit_basic_for_loop( BasicForLoop& ) override;
   void visit_block( Block& ) override;
@@ -52,7 +52,14 @@ public:
   void visit_while_loop( WhileLoop& ) override;
 
 private:
-  Constants& constants;
+  bool report_function_name_conflict( const SourceLocation&, const std::string& function_name,
+                                      const std::string& element_description );
+  static bool report_function_name_conflict( const CompilerWorkspace&, Report&,
+                                             const SourceLocation&,
+                                             const std::string& function_name,
+                                             const std::string& element_description );
+
+  CompilerWorkspace& workspace;
   Report& report;
 
   Variables globals;

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
@@ -29,7 +29,7 @@ antlrcpp::Any ModuleProcessor::visitModuleDeclarationStatement(
         tree_builder.module_function_declaration( moduleFunctionDeclaration, modulename );
 
     workspace.function_resolver.register_module_function( ast.get() );
-
+    workspace.compiler_workspace.all_function_locations.emplace(ast->name, ast->source_location);
     workspace.compiler_workspace.module_function_declarations.push_back( std::move( ast ) );
   }
   else if ( auto constStatement = ctx->constStatement() )

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
@@ -16,6 +16,7 @@ antlrcpp::Any UserFunctionVisitor::visitFunctionDeclaration(
 {
   auto uf = tree_builder.function_declaration( ctx );
   workspace.function_resolver.register_user_function( uf.get() );
+  workspace.compiler_workspace.all_function_locations.emplace(uf->name, uf->source_location);
   workspace.compiler_workspace.user_functions.push_back( std::move( uf ) );
   return antlrcpp::Any();
 }

--- a/pol-core/bscript/compiler/file/SourceLocation.h
+++ b/pol-core/bscript/compiler/file/SourceLocation.h
@@ -26,6 +26,11 @@ public:
   SourceLocation( const SourceFileIdentifier*, antlr4::ParserRuleContext& );
   SourceLocation( const SourceFileIdentifier*, antlr4::tree::TerminalNode& );
 
+  SourceLocation( const SourceLocation& ) = default;
+  SourceLocation( SourceLocation&& ) = default;
+  SourceLocation& operator=( const SourceLocation& ) = delete;
+  ~SourceLocation() = default;
+
   void debug( const std::string& msg ) const;
 
   [[noreturn]] void internal_error( const std::string& msg ) const;

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -1,10 +1,12 @@
 #ifndef POLSERVER_COMPILERWORKSPACE_H
 #define POLSERVER_COMPILERWORKSPACE_H
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "clib/maputil.h"
 #include "compiler/analyzer/Constants.h"
 #include "compiler/ast/Node.h"
 
@@ -41,6 +43,8 @@ public:
   std::vector<const ModuleFunctionDeclaration*> module_functions_in_legacy_order;
 
   std::vector<std::unique_ptr<SourceFileIdentifier>> referenced_source_file_identifiers;
+
+  std::map<std::string, SourceLocation, Clib::ci_cmp_pred> all_function_locations;
 
   std::vector<std::string> global_variable_names;
 };

--- a/testsuite/escript/errors/errors002-var-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors002-var-same-name-as-function.err1
@@ -1,0 +1,1 @@
+Non-identifier declared as a variable: 'print'

--- a/testsuite/escript/errors/errors002-var-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors002-var-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors002-var-same-name-as-function.src:4:9: error: Cannot define a variable with the same name as function 'print'

--- a/testsuite/escript/errors/errors002-var-same-name-as-function.src
+++ b/testsuite/escript/errors/errors002-var-same-name-as-function.src
@@ -1,0 +1,6 @@
+// reported in https://forums.polserver.com/viewtopic.php?f=54&t=6140
+// variable with the same name as a system function:
+if (1)
+    var print := 3;
+    print( print );
+endif

--- a/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.err1
@@ -1,0 +1,1 @@
+Variable not_defined has not been declared on line 3.

--- a/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors003-function_parameter-same-name-as-function.src:2:14: error: Cannot define a function parameter with the same name as function 'print'.

--- a/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.src
+++ b/testsuite/escript/errors/errors003-function-parameter-same-name-as-function.src
@@ -1,0 +1,6 @@
+// reported in https://forums.polserver.com/viewtopic.php?f=54&t=6140
+function foo(print)
+    not_defined;
+endfunction
+
+foo(4);

--- a/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.err1
@@ -1,0 +1,1 @@
+Expected arguments or right-paren in program arglist, got 'Func(1,0): print'

--- a/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors004-program_parameter-same-name-as-function.src:2:13: error: Cannot define a program parameter with the same name as function 'print'.

--- a/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.src
+++ b/testsuite/escript/errors/errors004-program-parameter-same-name-as-function.src
@@ -1,0 +1,4 @@
+// reported in https://forums.polserver.com/viewtopic.php?f=54&t=6140
+program foo(print)
+
+endprogram

--- a/testsuite/escript/errors/errors005-const-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors005-const-same-name-as-function.err1
@@ -1,0 +1,1 @@
+Expected identifier after const declaration

--- a/testsuite/escript/errors/errors005-const-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors005-const-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors005-const-same-name-as-function.src:1:1: error: Cannot define a constant with the same name as function 'print'.

--- a/testsuite/escript/errors/errors005-const-same-name-as-function.src
+++ b/testsuite/escript/errors/errors005-const-same-name-as-function.src
@@ -1,0 +1,2 @@
+const print := 5;
+print(print);

--- a/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.err1
@@ -1,0 +1,1 @@
+FOR iterator must be an identifier, got Func(0,0): len

--- a/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors006-for-loop-iterator-same-name-as-function.src:1:5: error: Cannot define a for loop iterator with the same name as function 'len'.

--- a/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.src
+++ b/testsuite/escript/errors/errors006-for-loop-iterator-same-name-as-function.src
@@ -1,0 +1,3 @@
+for len := 1 to 5
+    print(len);
+endfor

--- a/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.err1
+++ b/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.err1
@@ -1,0 +1,1 @@
+FOREACH iterator must be an identifier, got Func(0,0): len

--- a/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.err2
+++ b/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.err2
@@ -1,0 +1,1 @@
+errors007-foreach-iterator-same-name-as-function.src:1:1: error: Cannot define a foreach iterator with the same name as function 'len'.

--- a/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.src
+++ b/testsuite/escript/errors/errors007-foreach-iterator-same-name-as-function.src
@@ -1,0 +1,3 @@
+foreach len in { 1, 3, 5, 7 }
+    print(len);
+endforeach


### PR DESCRIPTION
Report as an error if a variable, parameter, or const name is the same as a function name (user or system).