### PR TITLE
Disallow var names that match an unreferenced function.

### DIFF
--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -278,7 +278,10 @@ void SourceFileProcessor::handle_use_declaration( EscriptParser::UseDeclarationC
 antlrcpp::Any SourceFileProcessor::visitFunctionDeclaration(
     EscriptParser::FunctionDeclarationContext* ctx )
 {
-  workspace.function_resolver.register_available_user_function( location_for( *ctx ), ctx );
+  auto loc = location_for( *ctx );
+  workspace.function_resolver.register_available_user_function( loc, ctx );
+  workspace.compiler_workspace.all_function_locations.emplace(
+      tree_builder.text( ctx->IDENTIFIER() ), loc );
   return antlrcpp::Any();
 }
 

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
@@ -16,7 +16,6 @@ antlrcpp::Any UserFunctionVisitor::visitFunctionDeclaration(
 {
   auto uf = tree_builder.function_declaration( ctx );
   workspace.function_resolver.register_user_function( uf.get() );
-  workspace.compiler_workspace.all_function_locations.emplace(uf->name, uf->source_location);
   workspace.compiler_workspace.user_functions.push_back( std::move( uf ) );
   return antlrcpp::Any();
 }

--- a/testsuite/escript/errors/errors008-var-same-name-as-user-function.err1
+++ b/testsuite/escript/errors/errors008-var-same-name-as-user-function.err1
@@ -1,0 +1,1 @@
+Non-identifier declared as a variable: 'xyz'

--- a/testsuite/escript/errors/errors008-var-same-name-as-user-function.err2
+++ b/testsuite/escript/errors/errors008-var-same-name-as-user-function.err2
@@ -1,0 +1,1 @@
+errors008-var-same-name-as-user-function.src:6:9: error: Cannot define a variable with the same name as function 'xyz'.

--- a/testsuite/escript/errors/errors008-var-same-name-as-user-function.src
+++ b/testsuite/escript/errors/errors008-var-same-name-as-user-function.src
@@ -1,0 +1,8 @@
+// reported in https://forums.polserver.com/viewtopic.php?f=54&t=6140
+function xyz()
+endfunction
+
+if (1)
+    var xyz := 3;
+    print( xyz );
+endif


### PR DESCRIPTION
Remember known user function names when they are declared, rather than when they are referenced.