### PR TITLE
Consolidate local variable scope information

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -231,6 +231,7 @@ set (bscript_sources    # sorted !
   compiler/model/FlowControlLabel.h
   compiler/model/FunctionLink.cpp
   compiler/model/FunctionLink.h
+  compiler/model/LocalVariableScopeInfo.h
   compiler/model/Variable.cpp
   compiler/model/Variable.h
   compiler/model/VariableScope.h

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
@@ -4,18 +4,20 @@
 #include "compiler/analyzer/LocalVariableScopes.h"
 #include "compiler/analyzer/Variables.h"
 #include "compiler/file/SourceLocation.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 #include "compiler/model/Variable.h"
 
 namespace Pol::Bscript::Compiler
 {
 LocalVariableScope::LocalVariableScope( LocalVariableScopes& scopes,
-std::vector<std::shared_ptr<Variable>>& debug_variables )
+                                        LocalVariableScopeInfo& local_variable_scope_info )
     : scopes( scopes ),
       report( scopes.report ),
       block_depth( scopes.local_variable_scopes.size() ),
       prev_locals( scopes.local_variables.count() ),
-      debug_variables( debug_variables )
+      local_variable_scope_info( local_variable_scope_info )
 {
+  local_variable_scope_info.base_index = prev_locals;
   scopes.local_variable_scopes.push_back( this );
 }
 
@@ -48,14 +50,9 @@ std::shared_ptr<Variable> LocalVariableScope::create( const std::string& name, W
   auto local = scopes.local_variables.create( name, block_depth, warn_on,
                                               source_location );
 
-  debug_variables.push_back( local );
+  local_variable_scope_info.variables.push_back( local );
 
   return local;
-}
-
-unsigned LocalVariableScope::get_block_locals() const
-{
-  return scopes.local_variables.count() - prev_locals;
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
@@ -10,6 +10,7 @@
 namespace Pol::Bscript::Compiler
 {
 class Report;
+class LocalVariableScopeInfo;
 class LocalVariableScopes;
 class SourceLocation;
 class Variable;
@@ -18,19 +19,18 @@ class LocalVariableScope
 {
 public:
   explicit LocalVariableScope( LocalVariableScopes&,
-                               std::vector<std::shared_ptr<Variable>>& debug_variables );
+                               LocalVariableScopeInfo& );
   ~LocalVariableScope();
 
   std::shared_ptr<Variable> create( const std::string& name, WarnOn, const SourceLocation& );
 
-  [[nodiscard]] unsigned get_block_locals() const;
 private:
   LocalVariableScopes& scopes;
   Report& report;
   const unsigned block_depth;
   const unsigned prev_locals;
   std::vector<std::shared_ptr<Variable>> shadowing;
-  std::vector<std::shared_ptr<Variable>>& debug_variables;
+  LocalVariableScopeInfo& local_variable_scope_info;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -101,7 +101,7 @@ void SemanticAnalyzer::visit_basic_for_loop( BasicForLoop& node )
   node.first().accept( *this );
   node.last().accept( *this );
 
-  LocalVariableScope scope( local_scopes, node.debug_variables );
+  LocalVariableScope scope( local_scopes, node.local_variable_scope_info );
   scope.create( node.identifier, WarnOn::Never, node.source_location );
   scope.create( "_" + node.identifier + "_end", WarnOn::Never, node.source_location );
 
@@ -115,11 +115,9 @@ void SemanticAnalyzer::visit_basic_for_loop( BasicForLoop& node )
 
 void SemanticAnalyzer::visit_block( Block& block )
 {
-  LocalVariableScope scope( local_scopes, block.debug_variables );
+  LocalVariableScope scope( local_scopes, block.local_variable_scope_info );
 
   visit_children( block );
-
-  block.locals_in_block = scope.get_block_locals();
 }
 
 class CaseDispatchDuplicateSelectorAnalyzer : public NodeVisitor
@@ -249,7 +247,7 @@ void SemanticAnalyzer::visit_foreach_loop( ForeachLoop& node )
 
   node.expression().accept( *this );
 
-  LocalVariableScope scope( local_scopes, node.debug_variables );
+  LocalVariableScope scope( local_scopes, node.local_variable_scope_info );
   scope.create( node.iterator_name, WarnOn::Never, node.source_location );
   scope.create( "_" + node.iterator_name + "_expr", WarnOn::Never, node.source_location );
   scope.create( "_" + node.iterator_name + "_iter", WarnOn::Never, node.source_location );
@@ -461,11 +459,9 @@ void SemanticAnalyzer::visit_loop_statement( LoopStatement& loop )
 
 void SemanticAnalyzer::visit_program( Program& program )
 {
-  LocalVariableScope scope( local_scopes, program.debug_variables );
+  LocalVariableScope scope( local_scopes, program.local_variable_scope_info );
 
   visit_children( program );
-
-  program.locals_in_block = scope.get_block_locals();
 }
 
 void SemanticAnalyzer::visit_program_parameter_declaration( ProgramParameterDeclaration& node )
@@ -502,7 +498,7 @@ void SemanticAnalyzer::visit_user_function( UserFunction& node )
                     max_name_length, "\n" );
     }
   }
-  LocalVariableScope scope( local_scopes, node.debug_variables );
+  LocalVariableScope scope( local_scopes, node.local_variable_scope_info );
 
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/BasicForLoop.h
+++ b/pol-core/bscript/compiler/ast/BasicForLoop.h
@@ -2,6 +2,7 @@
 #define POLSERVER_BASICFORLOOP_H
 
 #include "compiler/ast/LoopStatement.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -24,7 +25,7 @@ public:
   Block& block();
 
   const std::string identifier;
-  std::vector<std::shared_ptr<Variable>> debug_variables;
+  LocalVariableScopeInfo local_variable_scope_info;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Block.cpp
+++ b/pol-core/bscript/compiler/ast/Block.cpp
@@ -8,7 +8,7 @@ namespace Pol::Bscript::Compiler
 {
 Block::Block( const SourceLocation& source_location,
               std::vector<std::unique_ptr<Statement>> statements )
-    : Statement( source_location ), locals_in_block( 0 )
+    : Statement( source_location )
 {
   children.reserve( statements.size() );
   for ( auto& statement : statements )

--- a/pol-core/bscript/compiler/ast/Block.h
+++ b/pol-core/bscript/compiler/ast/Block.h
@@ -2,10 +2,10 @@
 #define POLSERVER_BLOCK_H
 
 #include "compiler/ast/Statement.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 
 namespace Pol::Bscript::Compiler
 {
-class DebugBlock;
 class NodeVisitor;
 class Statement;
 class Variable;
@@ -19,8 +19,7 @@ public:
   void describe_to( fmt::Writer& ) const override;
 
   // set by semantic analyzer:
-  unsigned locals_in_block;
-  std::vector<std::shared_ptr<Variable>> debug_variables;
+  LocalVariableScopeInfo local_variable_scope_info;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ForeachLoop.h
+++ b/pol-core/bscript/compiler/ast/ForeachLoop.h
@@ -2,6 +2,7 @@
 #define POLSERVER_FOREACHLOOP_H
 
 #include "compiler/ast/LoopStatement.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -22,7 +23,7 @@ public:
   Block& block();
 
   const std::string iterator_name;
-  std::vector<std::shared_ptr<Variable>> debug_variables;
+  LocalVariableScopeInfo local_variable_scope_info;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/Program.cpp
+++ b/pol-core/bscript/compiler/ast/Program.cpp
@@ -11,8 +11,7 @@ namespace Pol::Bscript::Compiler
 Program::Program( const SourceLocation& source_location,
                   std::unique_ptr<ProgramParameterList> parameter_list,
                   std::unique_ptr<FunctionBody> body )
-  : Node( source_location ),
-    locals_in_block( 0 )
+  : Node( source_location )
 {
   children.reserve( 2 );
   children.push_back( std::move( parameter_list ) );

--- a/pol-core/bscript/compiler/ast/Program.h
+++ b/pol-core/bscript/compiler/ast/Program.h
@@ -2,6 +2,7 @@
 #define POLSERVER_PROGRAM_H
 
 #include "compiler/ast/Node.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -22,8 +23,7 @@ public:
   ProgramParameterList& parameter_list();
   FunctionBody& body();
 
-  std::vector<std::shared_ptr<Variable>> debug_variables;
-  unsigned locals_in_block;
+  LocalVariableScopeInfo local_variable_scope_info;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/UserFunction.h
+++ b/pol-core/bscript/compiler/ast/UserFunction.h
@@ -2,6 +2,7 @@
 #define POLSERVER_USERFUNCTION_H
 
 #include "compiler/ast/Function.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -22,7 +23,7 @@ public:
   const bool exported;
   const SourceLocation endfunction_location;
 
-  std::vector<std::shared_ptr<Variable>> debug_variables;
+  LocalVariableScopeInfo local_variable_scope_info;
 
   FunctionBody& body();
 };

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -189,9 +189,9 @@ void InstructionGenerator::visit_block( Block& node )
 {
   visit_children( node );
 
-  if ( node.locals_in_block )
+  if ( !node.local_variable_scope_info.variables.empty() )
   {
-    emit.leaveblock( node.locals_in_block );
+    emit.leaveblock( node.local_variable_scope_info.variables.size() );
   }
 }
 
@@ -449,9 +449,9 @@ void InstructionGenerator::visit_program( Program& program )
 {
   visit_children( program );
 
-  if ( program.locals_in_block )
+  if ( !program.local_variable_scope_info.variables.empty() )
   {
-    emit.leaveblock( program.locals_in_block );
+    emit.leaveblock( program.local_variable_scope_info.variables.size() );
   }
 }
 

--- a/pol-core/bscript/compiler/model/LocalVariableScopeInfo.h
+++ b/pol-core/bscript/compiler/model/LocalVariableScopeInfo.h
@@ -1,0 +1,19 @@
+#ifndef POLSERVER_LOCALVARIABLESCOPEINFO_H
+#define POLSERVER_LOCALVARIABLESCOPEINFO_H
+
+#include <memory>
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class Variable;
+
+class LocalVariableScopeInfo
+{
+public:
+  unsigned base_index = 0;
+  std::vector<std::shared_ptr<Variable>> variables;
+};
+
+}  // namespace Pol::Bscript::Compiler
+#endif  // POLSERVER_LOCALVARIABLESCOPEINFO_H


### PR DESCRIPTION
Adds:
- [model/LocalVariableScopeInfo.h](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/model/LocalVariableScopeInfo.h)

Stores, for local variable blocks:
- the names of the local variables in the block
- the "base index" of those local variables within the current scope

The code generator uses these to clean up local variables as they go out of scope.

We also need this when writing debug information.