### PR TITLE
New compiler: write debug info (.dbg and .dbg.txt)

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -58,6 +58,8 @@ set (bscript_sources    # sorted !
   compiler/ast/ConstDeclaration.h
   compiler/ast/CstyleForLoop.cpp
   compiler/ast/CstyleForLoop.h
+  compiler/ast/DebugStatementMarker.cpp
+  compiler/ast/DebugStatementMarker.h
   compiler/ast/DictionaryEntry.cpp
   compiler/ast/DictionaryEntry.h
   compiler/ast/DictionaryInitializer.cpp
@@ -201,6 +203,8 @@ set (bscript_sources    # sorted !
   compiler/codegen/CodeGenerator.h
   compiler/codegen/DataEmitter.cpp
   compiler/codegen/DataEmitter.h
+  compiler/codegen/DebugBlockGuard.cpp
+  compiler/codegen/DebugBlockGuard.h
   compiler/codegen/InstructionEmitter.cpp
   compiler/codegen/InstructionEmitter.h
   compiler/codegen/InstructionGenerator.cpp
@@ -221,6 +225,8 @@ set (bscript_sources    # sorted !
   compiler/file/SourceLocation.h
   compiler/format/CompiledScriptSerializer.cpp
   compiler/format/CompiledScriptSerializer.h
+  compiler/format/DebugStoreSerializer.cpp
+  compiler/format/DebugStoreSerializer.h
   compiler/format/ListingWriter.cpp
   compiler/format/ListingWriter.h
   compiler/format/StoredTokenDecoder.cpp
@@ -258,6 +264,10 @@ set (bscript_sources    # sorted !
   compiler/optimizer/ValueConsumerOptimizer.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
+  compiler/representation/DebugBlock.cpp
+  compiler/representation/DebugBlock.h
+  compiler/representation/DebugStore.cpp
+  compiler/representation/DebugStore.h
   compiler/representation/ExportedFunction.cpp
   compiler/representation/ExportedFunction.h
   compiler/representation/ModuleDescriptor.cpp

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -1592,7 +1592,7 @@ int Compiler::handleForEach( CompilerContext& ctx, int level )
   localscope.addvar( itrvar.tokval(), foreach_ctx );
   program->addlocalvar( "_" + std::string( itrvar.tokval() ) + "_expr" );
   localscope.addvar( "_" + std::string( itrvar.tokval() ) + "_expr", foreach_ctx, false );
-  program->addlocalvar( "_" + std::string( itrvar.tokval() ) + "_counter" );
+  program->addlocalvar( "_" + std::string( itrvar.tokval() ) + "_iter" );
   localscope.addvar( "_" + std::string( itrvar.tokval() ) + "_iter", foreach_ctx, false );
 
 

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -11,6 +11,7 @@
 #include "compiler/codegen/CodeGenerator.h"
 #include "compiler/file/SourceFileCache.h"
 #include "compiler/format/CompiledScriptSerializer.h"
+#include "compiler/format/DebugStoreSerializer.h"
 #include "compiler/format/ListingWriter.h"
 #include "compiler/model/CompilerWorkspace.h"
 #include "compiler/optimizer/Optimizer.h"
@@ -56,8 +57,16 @@ void Compiler::write_listing( const std::string& pathname )
   }
 }
 
-void Compiler::write_dbg( const std::string& /*pathname*/, bool /*include_debug_text*/ )
+void Compiler::write_dbg( const std::string& pathname, bool include_debug_text )
 {
+  if ( output )
+  {
+    std::ofstream ofs( pathname, std::ofstream::binary );
+    auto text_ofs = include_debug_text ? std::make_unique<std::ofstream>( pathname + ".txt" )
+                                       : std::unique_ptr<std::ofstream>();
+
+    DebugStoreSerializer(*output).write( ofs, text_ofs.get() );
+  }
 }
 
 void Compiler::write_included_filenames( const std::string& /*pathname*/ )

--- a/pol-core/bscript/compiler/ast/DebugStatementMarker.cpp
+++ b/pol-core/bscript/compiler/ast/DebugStatementMarker.cpp
@@ -6,11 +6,9 @@
 
 namespace Pol::Bscript::Compiler
 {
-DebugStatementMarker::DebugStatementMarker( const SourceLocation& location,
-                                              std::string text,
-                                              unsigned start_index )
-    : Statement( location ), text( std::move( text ) ),
-      start_index( start_index )
+DebugStatementMarker::DebugStatementMarker( const SourceLocation& location, std::string text,
+                                            unsigned start_index )
+    : Statement( location ), text( std::move( text ) ), start_index( start_index )
 {
 }
 
@@ -19,7 +17,8 @@ void DebugStatementMarker::accept( NodeVisitor& visitor )
   visitor.visit_debug_statement_marker( *this );
 }
 
-void DebugStatementMarker::describe_to( fmt::Writer& w ) const {
+void DebugStatementMarker::describe_to( fmt::Writer& w ) const
+{
   w << "debug-statement-marker";
 }
 

--- a/pol-core/bscript/compiler/ast/DebugStatementMarker.cpp
+++ b/pol-core/bscript/compiler/ast/DebugStatementMarker.cpp
@@ -1,0 +1,26 @@
+#include "DebugStatementMarker.h"
+
+#include <format/format.h>
+
+#include "compiler/ast/NodeVisitor.h"
+
+namespace Pol::Bscript::Compiler
+{
+DebugStatementMarker::DebugStatementMarker( const SourceLocation& location,
+                                              std::string text,
+                                              unsigned start_index )
+    : Statement( location ), text( std::move( text ) ),
+      start_index( start_index )
+{
+}
+
+void DebugStatementMarker::accept( NodeVisitor& visitor )
+{
+  visitor.visit_debug_statement_marker( *this );
+}
+
+void DebugStatementMarker::describe_to( fmt::Writer& w ) const {
+  w << "debug-statement-marker";
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/DebugStatementMarker.h
+++ b/pol-core/bscript/compiler/ast/DebugStatementMarker.h
@@ -1,0 +1,23 @@
+#ifndef POLSERVER_DEBUGSTATEMENTMARKER_H
+#define POLSERVER_DEBUGSTATEMENTMARKER_H
+
+#include "compiler/ast/Statement.h"
+
+namespace Pol::Bscript::Compiler
+{
+class DebugStatementMarker : public Statement
+{
+public:
+  DebugStatementMarker( const SourceLocation&, std::string text,
+                         unsigned start_index );
+
+  void accept( NodeVisitor& visitor ) override;
+  void describe_to( fmt::Writer& ) const override;
+
+  const std::string text;
+  const unsigned start_index;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DEBUGSTATEMENTMARKER_H

--- a/pol-core/bscript/compiler/ast/DebugStatementMarker.h
+++ b/pol-core/bscript/compiler/ast/DebugStatementMarker.h
@@ -8,8 +8,7 @@ namespace Pol::Bscript::Compiler
 class DebugStatementMarker : public Statement
 {
 public:
-  DebugStatementMarker( const SourceLocation&, std::string text,
-                         unsigned start_index );
+  DebugStatementMarker( const SourceLocation&, std::string text, unsigned start_index );
 
   void accept( NodeVisitor& visitor ) override;
   void describe_to( fmt::Writer& ) const override;

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -14,6 +14,7 @@
 #include "compiler/ast/CaseStatement.h"
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/CstyleForLoop.h"
+#include "compiler/ast/DebugStatementMarker.h"
 #include "compiler/ast/DictionaryEntry.h"
 #include "compiler/ast/DictionaryInitializer.h"
 #include "compiler/ast/DoWhileLoop.h"
@@ -123,6 +124,11 @@ void NodeVisitor::visit_const_declaration( ConstDeclaration& node )
 }
 
 void NodeVisitor::visit_cstyle_for_loop( CstyleForLoop& node )
+{
+  visit_children( node );
+}
+
+void NodeVisitor::visit_debug_statement_marker( DebugStatementMarker& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -17,6 +17,7 @@ class CaseDispatchGroups;
 class CaseDispatchSelectors;
 class ConstDeclaration;
 class CstyleForLoop;
+class DebugStatementMarker;
 class DictionaryEntry;
 class DictionaryInitializer;
 class DoWhileLoop;
@@ -81,6 +82,7 @@ public:
   virtual void visit_case_dispatch_selectors( CaseDispatchSelectors& );
   virtual void visit_const_declaration( ConstDeclaration& );
   virtual void visit_cstyle_for_loop( CstyleForLoop& );
+  virtual void visit_debug_statement_marker( DebugStatementMarker& );
   virtual void visit_dictionary_entry( DictionaryEntry& );
   virtual void visit_dictionary_initializer( DictionaryInitializer& );
   virtual void visit_do_while_loop( DoWhileLoop& );

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -11,6 +11,7 @@
 #include "compiler/ast/CaseStatement.h"
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/CstyleForLoop.h"
+#include "compiler/ast/DebugStatementMarker.h"
 #include "compiler/ast/DoWhileLoop.h"
 #include "compiler/ast/EmptyStatement.h"
 #include "compiler/ast/EnumDeclaration.h"
@@ -31,6 +32,11 @@
 
 using EscriptGrammar::EscriptParser;
 
+namespace Pol::Bscript
+{
+extern int include_debug;
+}
+
 namespace Pol::Bscript::Compiler
 {
 CompoundStatementBuilder::CompoundStatementBuilder(
@@ -39,9 +45,14 @@ CompoundStatementBuilder::CompoundStatementBuilder(
 {
 }
 
-void CompoundStatementBuilder::add_statements(
-    EscriptParser::StatementContext* ctx, std::vector<std::unique_ptr<Statement>>& statements )
+void CompoundStatementBuilder::add_statements( EscriptParser::StatementContext* ctx,
+                                               std::vector<std::unique_ptr<Statement>>& statements )
 {
+  if ( include_debug )
+  {
+    add_intrusive_debug_marker( ctx, statements );
+  }
+
   if ( auto expr_ctx = ctx->expression() )
   {
     statements.push_back( consume_statement_result( expression( expr_ctx ) ) );

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -3,6 +3,7 @@
 #include "compiler/Report.h"
 #include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/ConstDeclaration.h"
+#include "compiler/ast/DebugStatementMarker.h"
 #include "compiler/ast/EnumDeclaration.h"
 #include "compiler/ast/Expression.h"
 #include "compiler/ast/Identifier.h"
@@ -23,6 +24,13 @@ SimpleStatementBuilder::SimpleStatementBuilder( const SourceFileIdentifier& sour
                                     BuilderWorkspace& workspace )
   : ExpressionBuilder( source_file_identifier, workspace )
 {
+}
+
+void SimpleStatementBuilder::add_intrusive_debug_marker(
+    antlr4::ParserRuleContext* ctx, std::vector<std::unique_ptr<Statement>>& statements )
+{
+  statements.push_back( std::make_unique<DebugStatementMarker>(
+      location_for( *ctx ), ctx->getText(), ctx->start->getStartIndex() ) );
 }
 
 void SimpleStatementBuilder::add_var_statements(

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -16,6 +16,9 @@ class SimpleStatementBuilder : public ExpressionBuilder
 public:
   SimpleStatementBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
 
+  void add_intrusive_debug_marker( antlr4::ParserRuleContext*,
+                                   std::vector<std::unique_ptr<Statement>>& );
+
   void add_var_statements( EscriptGrammar::EscriptParser::VarStatementContext*,
                            std::vector<std::unique_ptr<Statement>>& );
 

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -34,11 +34,20 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
   CodeSection code;
   DataSection data;
 
+  std::vector<std::string> debug_filenames;
+  // For parity with OG compiler, debug file #0 is always empty.
+  debug_filenames.emplace_back( "" );
+  for ( auto& ident : workspace->referenced_source_file_identifiers )
+  {
+    debug_filenames.push_back( ident->pathname );
+  }
+  DebugStore debug( std::move( debug_filenames ) );
+
   ExportedFunctions exported_functions;
 
   ModuleDeclarationRegistrar module_declaration_registrar;
 
-  InstructionEmitter instruction_emitter( code, data, exported_functions,
+  InstructionEmitter instruction_emitter( code, data, debug, exported_functions,
                                           module_declaration_registrar );
   CodeGenerator generator( instruction_emitter, module_declaration_registrar );
 
@@ -52,7 +61,7 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
       module_declaration_registrar.take_module_descriptors();
 
   return std::make_unique<CompiledScript>(
-      std::move( code ), std::move( data ), std::move( exported_functions ),
+      std::move( code ), std::move( data ), std::move( debug ), std::move( exported_functions ),
       std::move( workspace->global_variable_names ), std::move( module_descriptors ),
       std::move( program_info ), std::move( workspace->referenced_source_file_identifiers ) );
 }
@@ -67,6 +76,9 @@ CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
 
 void CodeGenerator::generate_instructions( CompilerWorkspace& workspace )
 {
+  emitter.debug_statementbegin();
+  emitter.debug_file_line( 1, 1 );
+
   std::map<std::string, FlowControlLabel> user_function_labels;
   InstructionGenerator outer_instruction_generator( emitter, user_function_labels, false );
   InstructionGenerator function_instruction_generator( emitter, user_function_labels, true );

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -77,7 +77,7 @@ CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
 void CodeGenerator::generate_instructions( CompilerWorkspace& workspace )
 {
   emitter.debug_statementbegin();
-  emitter.debug_file_line( 1, 1 );
+  emitter.debug_file_line( 0, 1 );
 
   std::map<std::string, FlowControlLabel> user_function_labels;
   InstructionGenerator outer_instruction_generator( emitter, user_function_labels, false );

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
@@ -1,13 +1,14 @@
 #include "DebugBlockGuard.h"
 
 #include "compiler/codegen/InstructionEmitter.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 #include "compiler/model/Variable.h"
 
 namespace Pol::Bscript::Compiler
 {
 DebugBlockGuard::DebugBlockGuard( InstructionEmitter& emitter,
-                                  const std::vector<std::shared_ptr<Variable>>& debug_variables )
-    : emitter( emitter ), previous_block_id( emitter.enter_debug_block( debug_variables ) )
+                                  LocalVariableScopeInfo& local_variable_scope_info )
+    : emitter( emitter ), previous_block_id( emitter.enter_debug_block( local_variable_scope_info ) )
 {
 }
 DebugBlockGuard::~DebugBlockGuard()

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
@@ -8,7 +8,8 @@ namespace Pol::Bscript::Compiler
 {
 DebugBlockGuard::DebugBlockGuard( InstructionEmitter& emitter,
                                   LocalVariableScopeInfo& local_variable_scope_info )
-    : emitter( emitter ), previous_block_id( emitter.enter_debug_block( local_variable_scope_info ) )
+    : emitter( emitter ),
+      previous_block_id( emitter.enter_debug_block( local_variable_scope_info ) )
 {
 }
 DebugBlockGuard::~DebugBlockGuard()

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.cpp
@@ -1,0 +1,18 @@
+#include "DebugBlockGuard.h"
+
+#include "compiler/codegen/InstructionEmitter.h"
+#include "compiler/model/Variable.h"
+
+namespace Pol::Bscript::Compiler
+{
+DebugBlockGuard::DebugBlockGuard( InstructionEmitter& emitter,
+                                  const std::vector<std::shared_ptr<Variable>>& debug_variables )
+    : emitter( emitter ), previous_block_id( emitter.enter_debug_block( debug_variables ) )
+{
+}
+DebugBlockGuard::~DebugBlockGuard()
+{
+  emitter.set_debug_block( previous_block_id );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
@@ -13,8 +13,7 @@ class Variable;
 class DebugBlockGuard
 {
 public:
-  DebugBlockGuard( InstructionEmitter&,
-                   LocalVariableScopeInfo& );
+  DebugBlockGuard( InstructionEmitter&, LocalVariableScopeInfo& );
   ~DebugBlockGuard();
 
 private:

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_DEBUGBLOCKGUARD_H
+#define POLSERVER_DEBUGBLOCKGUARD_H
+
+#include <memory>
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class InstructionEmitter;
+class Variable;
+
+class DebugBlockGuard
+{
+public:
+  DebugBlockGuard( InstructionEmitter&,
+                   const std::vector<std::shared_ptr<Variable>>& debug_variables );
+  ~DebugBlockGuard();
+
+private:
+  InstructionEmitter& emitter;
+  const unsigned previous_block_id;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DEBUGBLOCKGUARD_H

--- a/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
+++ b/pol-core/bscript/compiler/codegen/DebugBlockGuard.h
@@ -7,13 +7,14 @@
 namespace Pol::Bscript::Compiler
 {
 class InstructionEmitter;
+class LocalVariableScopeInfo;
 class Variable;
 
 class DebugBlockGuard
 {
 public:
   DebugBlockGuard( InstructionEmitter&,
-                   const std::vector<std::shared_ptr<Variable>>& debug_variables );
+                   LocalVariableScopeInfo& );
   ~DebugBlockGuard();
 
 private:

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -43,7 +43,7 @@ void InstructionEmitter::register_exported_function( FlowControlLabel& label,
 unsigned InstructionEmitter::enter_debug_block(
     const LocalVariableScopeInfo& local_variable_scope_info )
 {
-  unsigned previous_debug_block_id = debug_instruction_info.block_index;
+  unsigned previous_debug_block_index = debug_instruction_info.block_index;
 
   if ( !local_variable_scope_info.variables.empty() )
   {
@@ -51,12 +51,12 @@ unsigned InstructionEmitter::enter_debug_block(
         debug.add_block( debug_instruction_info.block_index, local_variable_scope_info );
   }
 
-  return previous_debug_block_id;
+  return previous_debug_block_index;
 }
 
-void InstructionEmitter::set_debug_block( unsigned block_id )
+void InstructionEmitter::set_debug_block( unsigned block_index )
 {
-  debug_instruction_info.block_index = block_id;
+  debug_instruction_info.block_index = block_index;
 }
 
 void InstructionEmitter::access_variable( const Variable& v )
@@ -176,7 +176,7 @@ void InstructionEmitter::ctrl_statementbegin( unsigned file_index, unsigned file
 {
   unsigned source_offset = emit_data( source_text );
   Pol::Bscript::DebugToken debug_token;
-  debug_token.sourceFile = file_index;
+  debug_token.sourceFile = file_index + 1;
   debug_token.offset = file_offset;
   debug_token.strOffset = source_offset;
   unsigned offset =

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -43,15 +43,13 @@ void InstructionEmitter::register_exported_function( FlowControlLabel& label,
 unsigned InstructionEmitter::enter_debug_block(
     const LocalVariableScopeInfo& local_variable_scope_info )
 {
-  if ( local_variable_scope_info.variables.empty() )
-  {
-    return debug_instruction_info.block_index;
-  }
-
   unsigned previous_debug_block_id = debug_instruction_info.block_index;
 
-  debug_instruction_info.block_index =
-      debug.add_block( debug_instruction_info.block_index, local_variable_scope_info );
+  if ( !local_variable_scope_info.variables.empty() )
+  {
+    debug_instruction_info.block_index =
+        debug.add_block( debug_instruction_info.block_index, local_variable_scope_info );
+  }
 
   return previous_debug_block_id;
 }

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -5,6 +5,7 @@
 #include "compiler/codegen/CaseJumpDataBlock.h"
 #include "compiler/codegen/ModuleDeclarationRegistrar.h"
 #include "compiler/model/FlowControlLabel.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
 #include "compiler/model/Variable.h"
 #include "compiler/representation/CompiledScript.h"
 #include "compiler/representation/ExportedFunction.h"
@@ -40,23 +41,17 @@ void InstructionEmitter::register_exported_function( FlowControlLabel& label,
 }
 
 unsigned InstructionEmitter::enter_debug_block(
-    const std::vector<std::shared_ptr<Variable>>& block_local_variables )
+    const LocalVariableScopeInfo& local_variable_scope_info )
 {
-  if ( block_local_variables.empty() )
+  if ( local_variable_scope_info.variables.empty() )
   {
     return debug_instruction_info.block_index;
   }
 
   unsigned previous_debug_block_id = debug_instruction_info.block_index;
 
-  std::vector<std::string> local_variable_names;
-  local_variable_names.reserve( block_local_variables.size() );
-  for ( auto& var : block_local_variables )
-  {
-    local_variable_names.push_back( var->name );
-  }
   debug_instruction_info.block_index =
-      debug.add_block( debug_instruction_info.block_index, std::move( local_variable_names ) );
+      debug.add_block( debug_instruction_info.block_index, local_variable_scope_info );
 
   return previous_debug_block_id;
 }

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -109,7 +109,7 @@ public:
   void value( int );
   void value( const std::string& );
 
-  void debug_file_line( unsigned, unsigned );
+  void debug_file_line( unsigned file_index, unsigned line_number );
   void debug_statementbegin();
   unsigned next_instruction_address();
   void debug_user_function( const std::string& name, unsigned first_address,

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -17,6 +17,7 @@
 #include "compiler/codegen/CodeEmitter.h"
 #include "compiler/codegen/DataEmitter.h"
 #include "compiler/representation/CompiledScript.h"
+#include "compiler/representation/DebugStore.h"
 
 namespace Pol::Bscript
 {
@@ -37,13 +38,16 @@ class SourceLocation;
 class InstructionEmitter
 {
 public:
-  InstructionEmitter( CodeSection& code, DataSection& data, ExportedFunctions& exported_functions,
-                      ModuleDeclarationRegistrar& );
+  InstructionEmitter( CodeSection& code, DataSection& data, DebugStore& debug,
+                      ExportedFunctions& exported_functions, ModuleDeclarationRegistrar& );
 
   void initialize_data();
 
   void register_exported_function( FlowControlLabel& label, const std::string& name,
                                    unsigned arguments );
+
+  unsigned enter_debug_block( const std::vector<std::shared_ptr<Variable>>& );
+  void set_debug_block( unsigned );
 
   void access_variable( const Variable& );
   void array_append();
@@ -64,6 +68,8 @@ public:
   unsigned casejmp();
   unsigned case_dispatch_table( const CaseJumpDataBlock& );
   void consume();
+  void ctrl_statementbegin( unsigned file_index, unsigned file_offset,
+                            const std::string& source_text );
   void declare_variable( const Variable& );
   void dictionary_create();
   void dictionary_add_member();
@@ -102,7 +108,12 @@ public:
   void value( int );
   void value( const std::string& );
 
+  void debug_file_line( unsigned, unsigned );
+  void debug_statementbegin();
   unsigned next_instruction_address();
+  void debug_user_function( const std::string& name, unsigned first_address,
+                            unsigned last_address );
+
   void patch_offset( unsigned index, unsigned offset );
 
 private:
@@ -113,8 +124,11 @@ private:
 
   CodeEmitter code_emitter;
   DataEmitter data_emitter;
+  DebugStore& debug;
   ExportedFunctions& exported_functions;
   ModuleDeclarationRegistrar& module_declaration_registrar;
+
+  DebugStore::InstructionInfo debug_instruction_info{};
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -29,6 +29,7 @@ namespace Pol::Bscript::Compiler
 class CaseJumpDataBlock;
 class CompiledScript;
 class FlowControlLabel;
+class LocalVariableScopeInfo;
 class ModuleDeclarationRegistrar;
 class ModuleFunctionDeclaration;
 class Node;
@@ -46,7 +47,7 @@ public:
   void register_exported_function( FlowControlLabel& label, const std::string& name,
                                    unsigned arguments );
 
-  unsigned enter_debug_block( const std::vector<std::shared_ptr<Variable>>& );
+  unsigned enter_debug_block( const LocalVariableScopeInfo& );
   void set_debug_block( unsigned );
 
   void access_variable( const Variable& );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -122,7 +122,7 @@ void InstructionGenerator::visit_basic_for_loop( BasicForLoop& loop )
   generate( loop.first() );
   generate( loop.last() );
 
-  DebugBlockGuard debug_block_guard( emitter, loop.debug_variables );
+  DebugBlockGuard debug_block_guard( emitter, loop.local_variable_scope_info );
 
   emit.basic_for_init( skip );
 
@@ -211,7 +211,7 @@ void InstructionGenerator::visit_binary_operator( BinaryOperator& node )
 
 void InstructionGenerator::visit_block( Block& node )
 {
-  DebugBlockGuard debug_block_guard( emitter, node.debug_variables );
+  DebugBlockGuard debug_block_guard( emitter, node.local_variable_scope_info );
 
   visit_children( node );
 
@@ -356,7 +356,7 @@ void InstructionGenerator::visit_foreach_loop( ForeachLoop& loop )
 {
   generate( loop.expression() );
 
-  DebugBlockGuard debug_block_guard( emitter, loop.debug_variables );
+  DebugBlockGuard debug_block_guard( emitter, loop.local_variable_scope_info );
 
   emit.foreach_init( *loop.continue_label );
 
@@ -509,7 +509,7 @@ void InstructionGenerator::visit_method_call( MethodCall& method_call )
 
 void InstructionGenerator::visit_program( Program& program )
 {
-  DebugBlockGuard debug_block_guard( emitter, program.debug_variables );
+  DebugBlockGuard debug_block_guard( emitter, program.local_variable_scope_info );
 
   update_debug_location( program );
 
@@ -625,7 +625,7 @@ void InstructionGenerator::visit_uninitialized_value( UninitializedValue& node )
 void InstructionGenerator::visit_user_function( UserFunction& user_function )
 {
   unsigned first_instruction_address = emitter.next_instruction_address();
-  DebugBlockGuard debug_block_guard( emitter, user_function.debug_variables );
+  DebugBlockGuard debug_block_guard( emitter, user_function.local_variable_scope_info );
 
   emit.debug_statementbegin();
   update_debug_location( user_function );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -246,7 +246,7 @@ void InstructionGenerator::visit_debug_statement_marker( DebugStatementMarker& m
   emit.debug_statementbegin();
   update_debug_location( marker );
 
-  // OG always puts 0.. wrapper.source_location.source_file_identifier->index
+  // OG always puts 0.. marker.source_location.source_file_identifier->index
   unsigned source_file = 0;
   emit.ctrl_statementbegin( source_file, marker.start_index, marker.text );
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -105,6 +105,7 @@ void InstructionGenerator::visit_array_initializer( ArrayInitializer& node )
 
 void InstructionGenerator::visit_assign_variable_consume( AssignVariableConsume& node )
 {
+  emitter.debug_statementbegin();
   generate( node.rhs() );
   update_debug_location( node );
   auto& identifier = node.identifier();
@@ -246,8 +247,7 @@ void InstructionGenerator::visit_debug_statement_marker( DebugStatementMarker& m
   emit.debug_statementbegin();
   update_debug_location( marker );
 
-  // OG always puts 0.. marker.source_location.source_file_identifier->index
-  unsigned source_file = 0;
+  unsigned source_file = marker.source_location.source_file_identifier->index;
   emit.ctrl_statementbegin( source_file, marker.start_index, marker.text );
 
   visit_children( marker );
@@ -354,6 +354,9 @@ void InstructionGenerator::visit_float_value( FloatValue& node )
 
 void InstructionGenerator::visit_foreach_loop( ForeachLoop& loop )
 {
+  emit.debug_statementbegin();
+  update_debug_location( loop );
+
   generate( loop.expression() );
 
   DebugBlockGuard debug_block_guard( emitter, loop.local_variable_scope_info );
@@ -472,6 +475,7 @@ void InstructionGenerator::visit_integer_value( IntegerValue& node )
 
 void InstructionGenerator::visit_jump_statement( JumpStatement& jump )
 {
+  emit.debug_statementbegin();
   update_debug_location( jump );
   if ( jump.local_variables_to_remove )
     emit.leaveblock( jump.local_variables_to_remove );
@@ -511,6 +515,7 @@ void InstructionGenerator::visit_program( Program& program )
 {
   DebugBlockGuard debug_block_guard( emitter, program.local_variable_scope_info );
 
+  emit.debug_statementbegin();
   update_debug_location( program );
 
   visit_children( program );
@@ -544,6 +549,8 @@ void InstructionGenerator::visit_repeat_until_loop( RepeatUntilLoop& loop )
 
 void InstructionGenerator::visit_return_statement( ReturnStatement& ret )
 {
+  emit.debug_statementbegin();
+
   visit_children( ret );
 
   update_debug_location( ret );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -14,6 +14,7 @@
 #include "compiler/ast/CaseStatement.h"
 #include "compiler/ast/ConstDeclaration.h"
 #include "compiler/ast/CstyleForLoop.h"
+#include "compiler/ast/DebugStatementMarker.h"
 #include "compiler/ast/DictionaryEntry.h"
 #include "compiler/ast/DictionaryInitializer.h"
 #include "compiler/ast/DoWhileLoop.h"
@@ -54,6 +55,7 @@
 #include "compiler/ast/WhileLoop.h"
 #include "compiler/codegen/CaseDispatchGroupVisitor.h"
 #include "compiler/codegen/CaseJumpDataBlock.h"
+#include "compiler/codegen/DebugBlockGuard.h"
 #include "compiler/codegen/InstructionEmitter.h"
 #include "compiler/file/SourceFileIdentifier.h"
 #include "compiler/model/FlowControlLabel.h"
@@ -76,11 +78,23 @@ InstructionGenerator::InstructionGenerator(
 void InstructionGenerator::generate( Node& node )
 {
   // alternative: two identical methods 'evaluate' and 'execute', for readability
+  update_debug_location( node );
   node.accept( *this );
+}
+
+void InstructionGenerator::update_debug_location( const Node& node )
+{
+  update_debug_location( node.source_location );
+}
+
+void InstructionGenerator::update_debug_location( const SourceLocation& loc )
+{
+  emit.debug_file_line( loc.source_file_identifier->index, loc.line_number );
 }
 
 void InstructionGenerator::visit_array_initializer( ArrayInitializer& node )
 {
+  update_debug_location( node );
   emit.array_create();
   for ( const auto& child : node.children )
   {
@@ -92,6 +106,7 @@ void InstructionGenerator::visit_array_initializer( ArrayInitializer& node )
 void InstructionGenerator::visit_assign_variable_consume( AssignVariableConsume& node )
 {
   generate( node.rhs() );
+  update_debug_location( node );
   auto& identifier = node.identifier();
   auto& variable = identifier.variable;
 
@@ -100,10 +115,14 @@ void InstructionGenerator::visit_assign_variable_consume( AssignVariableConsume&
 
 void InstructionGenerator::visit_basic_for_loop( BasicForLoop& loop )
 {
+  emit.debug_statementbegin();
+  update_debug_location( loop );
   FlowControlLabel skip, next;
 
   generate( loop.first() );
   generate( loop.last() );
+
+  DebugBlockGuard debug_block_guard( emitter, loop.debug_variables );
 
   emit.basic_for_init( skip );
 
@@ -121,7 +140,9 @@ void InstructionGenerator::visit_basic_for_loop( BasicForLoop& loop )
 
 void InstructionGenerator::visit_case_statement( CaseStatement& node )
 {
+  emit.debug_statementbegin();
   generate( node.expression() );
+  update_debug_location( node );
   const unsigned casejmp = emit.casejmp();
 
   CaseJumpDataBlock data_block;
@@ -158,6 +179,8 @@ void InstructionGenerator::visit_case_statement( CaseStatement& node )
 
 void InstructionGenerator::visit_cstyle_for_loop( CstyleForLoop& loop )
 {
+  emit.debug_statementbegin();
+  update_debug_location( loop );
   generate( loop.initializer() );
   emit.consume();
 
@@ -182,11 +205,14 @@ void InstructionGenerator::visit_binary_operator( BinaryOperator& node )
 {
   visit_children( node );
 
+  update_debug_location( node );
   emit.binary_operator( node.token_id );
 }
 
 void InstructionGenerator::visit_block( Block& node )
 {
+  DebugBlockGuard debug_block_guard( emitter, node.debug_variables );
+
   visit_children( node );
 
   if ( !node.local_variable_scope_info.variables.empty() )
@@ -215,20 +241,36 @@ void InstructionGenerator::visit_branch_selector( BranchSelector& node )
   }
 }
 
+void InstructionGenerator::visit_debug_statement_marker( DebugStatementMarker& marker )
+{
+  emit.debug_statementbegin();
+  update_debug_location( marker );
+
+  // OG always puts 0.. wrapper.source_location.source_file_identifier->index
+  unsigned source_file = 0;
+  emit.ctrl_statementbegin( source_file, marker.start_index, marker.text );
+
+  visit_children( marker );
+}
+
 void InstructionGenerator::visit_dictionary_initializer( DictionaryInitializer& node )
 {
+  update_debug_location( node );
   emit.dictionary_create();
   visit_children( node );
 }
 
 void InstructionGenerator::visit_dictionary_entry( DictionaryEntry& entry )
 {
+  update_debug_location( entry );
   visit_children( entry );
   emit.dictionary_add_member();
 }
 
 void InstructionGenerator::visit_do_while_loop( DoWhileLoop& node )
 {
+  emit.debug_statementbegin();
+  update_debug_location( node );
   FlowControlLabel next;
   emit.label( next );
   generate( node.block() );
@@ -241,6 +283,7 @@ void InstructionGenerator::visit_do_while_loop( DoWhileLoop& node )
 void InstructionGenerator::visit_element_access( ElementAccess& acc )
 {
   visit_children( acc );
+  update_debug_location( acc );
   int indexes = acc.indexes().children.size();
   if ( indexes == 1 )
     emit.subscript_single();
@@ -251,6 +294,7 @@ void InstructionGenerator::visit_element_access( ElementAccess& acc )
 void InstructionGenerator::visit_element_assignment( ElementAssignment& node )
 {
   visit_children( node );
+  update_debug_location( node );
   if ( node.consume )
   {
     emit.assign_subscript_consume();
@@ -269,6 +313,7 @@ void InstructionGenerator::visit_elvis_operator( ElvisOperator& elvis )
 {
   FlowControlLabel skip_instruction, after_rhs;
 
+  update_debug_location( elvis );
   generate( elvis.lhs() );
 
   unsigned address = emit.skip_if_true_else_consume();
@@ -284,6 +329,7 @@ void InstructionGenerator::visit_elvis_operator( ElvisOperator& elvis )
 
 void InstructionGenerator::visit_error_initializer( ErrorInitializer& node )
 {
+  update_debug_location( node );
   emit.error_create();
   int i = 0;
   for ( auto& child : node.children )
@@ -293,19 +339,24 @@ void InstructionGenerator::visit_error_initializer( ErrorInitializer& node )
   }
 }
 
-void InstructionGenerator::visit_exit_statement( ExitStatement& )
+void InstructionGenerator::visit_exit_statement( ExitStatement& node )
 {
+  emit.debug_statementbegin();
+  update_debug_location( node );
   emit.exit();
 }
 
 void InstructionGenerator::visit_float_value( FloatValue& node )
 {
+  update_debug_location( node );
   emit.value( node.value );
 }
 
 void InstructionGenerator::visit_foreach_loop( ForeachLoop& loop )
 {
   generate( loop.expression() );
+
+  DebugBlockGuard debug_block_guard( emitter, loop.debug_variables );
 
   emit.foreach_init( *loop.continue_label );
 
@@ -325,6 +376,7 @@ void InstructionGenerator::visit_function_call( FunctionCall& call )
 {
   visit_children( call );
 
+  update_debug_location( call );
   if ( auto mf = call.function_link->module_function_declaration() )
   {
     emit.call_modulefunc( *mf );
@@ -352,6 +404,7 @@ void InstructionGenerator::visit_function_parameter_list( FunctionParameterList&
 void InstructionGenerator::visit_function_parameter_declaration(
     FunctionParameterDeclaration& node )
 {
+  update_debug_location( node );
   if ( node.byref )
     emit.pop_param_byref( node.name );
   else
@@ -362,6 +415,7 @@ void InstructionGenerator::visit_function_reference( FunctionReference& function
 {
   if ( auto uf = function_reference.function_link->user_function() )
   {
+    update_debug_location( function_reference );
     FlowControlLabel& label = user_function_labels[uf->name];
     emit.function_reference( uf->parameter_count(), label );
   }
@@ -373,6 +427,7 @@ void InstructionGenerator::visit_function_reference( FunctionReference& function
 
 void InstructionGenerator::visit_identifier( Identifier& node )
 {
+  update_debug_location( node );
   if ( auto var = node.variable )
   {
     emit.access_variable( *var );
@@ -385,6 +440,9 @@ void InstructionGenerator::visit_identifier( Identifier& node )
 
 void InstructionGenerator::visit_if_then_else_statement( IfThenElseStatement& node )
 {
+  emit.debug_statementbegin();
+  update_debug_location( node );
+
   auto branch_selector = &node.branch_selector();
   generate( *branch_selector );
 
@@ -408,11 +466,13 @@ void InstructionGenerator::visit_if_then_else_statement( IfThenElseStatement& no
 
 void InstructionGenerator::visit_integer_value( IntegerValue& node )
 {
+  update_debug_location( node );
   emit.value( node.value );
 }
 
 void InstructionGenerator::visit_jump_statement( JumpStatement& jump )
 {
+  update_debug_location( jump );
   if ( jump.local_variables_to_remove )
     emit.leaveblock( jump.local_variables_to_remove );
   emit.jmp_always( *jump.flow_control_label );
@@ -422,6 +482,7 @@ void InstructionGenerator::visit_get_member( GetMember& member_access )
 {
   visit_children( member_access );
 
+  update_debug_location( member_access );
   if ( auto km = member_access.known_member )
     emit.get_member_id( km->id );
   else
@@ -432,6 +493,7 @@ void InstructionGenerator::visit_method_call( MethodCall& method_call )
 {
   visit_children( method_call );
 
+  update_debug_location( method_call );
   auto argument_count = method_call.argument_count();
   if ( auto km = method_call.known_method )
   {
@@ -447,6 +509,10 @@ void InstructionGenerator::visit_method_call( MethodCall& method_call )
 
 void InstructionGenerator::visit_program( Program& program )
 {
+  DebugBlockGuard debug_block_guard( emitter, program.debug_variables );
+
+  update_debug_location( program );
+
   visit_children( program );
 
   if ( !program.local_variable_scope_info.variables.empty() )
@@ -457,11 +523,15 @@ void InstructionGenerator::visit_program( Program& program )
 
 void InstructionGenerator::visit_program_parameter_declaration( ProgramParameterDeclaration& param )
 {
+  update_debug_location( param );
   emit.get_arg( param.name );
 }
 
 void InstructionGenerator::visit_repeat_until_loop( RepeatUntilLoop& loop )
 {
+  emit.debug_statementbegin();
+  update_debug_location( loop );
+
   FlowControlLabel top;
 
   emit.label( top );
@@ -476,6 +546,7 @@ void InstructionGenerator::visit_return_statement( ReturnStatement& ret )
 {
   visit_children( ret );
 
+  update_debug_location( ret );
   if ( in_function )
   {
     emit.return_from_user_function();
@@ -490,6 +561,7 @@ void InstructionGenerator::visit_set_member( SetMember& node )
 {
   visit_children( node );
 
+  update_debug_location( node );
   if ( auto known_member = node.known_member )
   {
     if ( node.consume )
@@ -510,16 +582,19 @@ void InstructionGenerator::visit_set_member_by_operator( SetMemberByOperator& no
 {
   visit_children( node );
 
+  update_debug_location( node );
   emit.set_member_by_operator( node.token_id, node.known_member.id );
 }
 
 void InstructionGenerator::visit_string_value( StringValue& lit )
 {
+  update_debug_location( lit );
   emit.value( lit.value );
 }
 
 void InstructionGenerator::visit_struct_initializer( StructInitializer& node )
 {
+  update_debug_location( node );
   emit.struct_create();
   visit_children( node );
 }
@@ -528,6 +603,7 @@ void InstructionGenerator::visit_struct_member_initializer( StructMemberInitiali
 {
   visit_children( node );
 
+  update_debug_location( node );
   if ( node.children.empty() )
     emit.struct_add_uninit_member( node.name );
   else
@@ -540,13 +616,19 @@ void InstructionGenerator::visit_unary_operator( UnaryOperator& unary_operator )
   emit.unary_operator( unary_operator.token_id );
 }
 
-void InstructionGenerator::visit_uninitialized_value( UninitializedValue& )
+void InstructionGenerator::visit_uninitialized_value( UninitializedValue& node )
 {
+  update_debug_location( node );
   emit.uninit();
 }
 
 void InstructionGenerator::visit_user_function( UserFunction& user_function )
 {
+  unsigned first_instruction_address = emitter.next_instruction_address();
+  DebugBlockGuard debug_block_guard( emitter, user_function.debug_variables );
+
+  emit.debug_statementbegin();
+  update_debug_location( user_function );
   if ( user_function.exported )
   {
     // emit the exported entry stub
@@ -568,13 +650,20 @@ void InstructionGenerator::visit_user_function( UserFunction& user_function )
 
   if ( !dynamic_cast<ReturnStatement*>( user_function.body().last_statement() ) )
   {
+    emit.debug_statementbegin();
+    update_debug_location( user_function.endfunction_location );
     emit.value( 0 );
     emit.return_from_user_function();
   }
+  unsigned last_instruction_address = emitter.next_instruction_address() - 1;
+  emitter.debug_user_function( user_function.name, first_instruction_address,
+                               last_instruction_address );
 }
 
 void InstructionGenerator::visit_value_consumer( ValueConsumer& node )
 {
+  emitter.debug_statementbegin();
+  update_debug_location( node );
   visit_children( node );
 
   emit.consume();
@@ -582,6 +671,8 @@ void InstructionGenerator::visit_value_consumer( ValueConsumer& node )
 
 void InstructionGenerator::visit_var_statement( VarStatement& node )
 {
+  emit.debug_statementbegin();
+  update_debug_location( node );
   if ( !node.variable )
     node.internal_error( "variable is not defined" );
   emit.declare_variable( *node.variable );
@@ -600,6 +691,8 @@ void InstructionGenerator::visit_var_statement( VarStatement& node )
 
 void InstructionGenerator::visit_while_loop( WhileLoop& loop )
 {
+  emit.debug_statementbegin();
+  update_debug_location( loop );
   emit.label( *loop.continue_label );
   generate( loop.predicate() );
   emit.jmp_if_false( *loop.break_label );

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -19,7 +19,7 @@ public:
                         std::map<std::string, FlowControlLabel>& user_function_labels,
                         bool in_function);
 
-  void generate( Node& node );
+  void generate( Node& );
 
   void update_debug_location( const Node& );
   void update_debug_location( const SourceLocation& );
@@ -34,7 +34,7 @@ public:
   void visit_branch_selector( BranchSelector& ) override;
   void visit_debug_statement_marker( DebugStatementMarker& ) override;
   void visit_dictionary_initializer( DictionaryInitializer& ) override;
-  void visit_dictionary_entry( DictionaryEntry& entry ) override;
+  void visit_dictionary_entry( DictionaryEntry& ) override;
   void visit_do_while_loop( DoWhileLoop& ) override;
   void visit_element_access( ElementAccess& ) override;
   void visit_element_assignment( ElementAssignment& ) override;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -33,8 +33,8 @@ public:
   void visit_block( Block& ) override;
   void visit_branch_selector( BranchSelector& ) override;
   void visit_debug_statement_marker( DebugStatementMarker& ) override;
-  void visit_dictionary_initializer( DictionaryInitializer& ) override;
   void visit_dictionary_entry( DictionaryEntry& ) override;
+  void visit_dictionary_initializer( DictionaryInitializer& ) override;
   void visit_do_while_loop( DoWhileLoop& ) override;
   void visit_element_access( ElementAccess& ) override;
   void visit_element_assignment( ElementAssignment& ) override;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -10,15 +10,19 @@ namespace Pol::Bscript::Compiler
 {
 class FlowControlLabel;
 class InstructionEmitter;
+class SourceLocation;
 
 class InstructionGenerator : public NodeVisitor
 {
 public:
-  explicit InstructionGenerator( InstructionEmitter&,
-                                 std::map<std::string, FlowControlLabel>& user_function_labels,
-                                 bool in_function );
+  InstructionGenerator( InstructionEmitter&,
+                        std::map<std::string, FlowControlLabel>& user_function_labels,
+                        bool in_function);
 
-  void generate( Node& );
+  void generate( Node& node );
+
+  void update_debug_location( const Node& );
+  void update_debug_location( const SourceLocation& );
 
   void visit_array_initializer( ArrayInitializer& ) override;
   void visit_assign_variable_consume( AssignVariableConsume& ) override;
@@ -28,8 +32,9 @@ public:
   void visit_binary_operator( BinaryOperator& ) override;
   void visit_block( Block& ) override;
   void visit_branch_selector( BranchSelector& ) override;
-  void visit_dictionary_entry( DictionaryEntry& ) override;
+  void visit_debug_statement_marker( DebugStatementMarker& ) override;
   void visit_dictionary_initializer( DictionaryInitializer& ) override;
+  void visit_dictionary_entry( DictionaryEntry& entry ) override;
   void visit_do_while_loop( DoWhileLoop& ) override;
   void visit_element_access( ElementAccess& ) override;
   void visit_element_assignment( ElementAssignment& ) override;

--- a/pol-core/bscript/compiler/format/DebugStoreSerializer.cpp
+++ b/pol-core/bscript/compiler/format/DebugStoreSerializer.cpp
@@ -1,0 +1,128 @@
+#include "DebugStoreSerializer.h"
+
+#include <fstream>
+
+#include "compiler/representation/CompiledScript.h"
+#include "compiler/representation/DebugBlock.h"
+#include "filefmt.h"
+
+namespace Pol::Bscript::Compiler
+{
+DebugStoreSerializer::DebugStoreSerializer( CompiledScript& compiled_script )
+  : compiled_script( compiled_script ), debug_store( compiled_script.debug )
+{
+}
+
+void DebugStoreSerializer::write( std::ofstream& ofs, std::ofstream* text_ofs )
+{
+  // just a version number
+  uint32_t version = 3;
+  ofs.write( reinterpret_cast<char*>( &version ), sizeof version );
+
+  uint32_t count;
+
+  count = static_cast<unsigned int>( debug_store.filenames.size() );
+  ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+  unsigned filenum = 0;
+  for ( auto& filename : debug_store.filenames )
+  {
+    if ( text_ofs )
+      *text_ofs << "File " << filenum++ << ": " << filename << std::endl;
+    count = static_cast<unsigned int>( filename.size() + 1 );
+    ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+    ofs.write( filename.c_str(), count );
+  }
+  count = static_cast<unsigned int>( compiled_script.global_variable_names.size() );
+  ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+  unsigned globalnum = 0;
+  for ( auto& global_name : compiled_script.global_variable_names )
+  {
+    if ( text_ofs )
+      *text_ofs << "Global " << globalnum++ << ": " << global_name << std::endl;
+    count = static_cast<unsigned int>( global_name.size() + 1 );
+    ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+    ofs.write( global_name.c_str(), count );
+  }
+  count = debug_store.instructions.size();
+  ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+  unsigned instruction_index = 0;
+  for ( auto& instruction_info : debug_store.instructions )
+  {
+    if ( text_ofs )
+      *text_ofs << "Ins " << instruction_index++ << ": File " << instruction_info.file_index
+                << ", Line " << instruction_info.line_number << ", Block "
+                << instruction_info.block_index << " "
+                << ( instruction_info.statement_begin ? "StatementBegin" : "" ) << std::endl;
+
+    BSCRIPT_DBG_INSTRUCTION ins{};
+    ins.filenum = instruction_info.file_index;
+    ins.linenum = instruction_info.line_number;
+    ins.blocknum = instruction_info.block_index;
+    ins.statementbegin = instruction_info.statement_begin ? 1 : 0;
+    ins.rfu1 = 0;
+    ins.rfu2 = 0;
+    ofs.write( reinterpret_cast<char*>( &ins ), sizeof ins );
+  }
+
+  count = debug_store.blocks.size();
+  ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+  unsigned blocknum = 0;
+  for ( auto& block : debug_store.blocks )
+  {
+    if ( text_ofs )
+    {
+      *text_ofs << "Block " << blocknum++ << ":" << std::endl;
+      *text_ofs << "  Parent block: " << block.parent_block_index << std::endl;
+    }
+
+    uint32_t tmp;
+    tmp = block.parent_block_index;
+    ofs.write( reinterpret_cast<char*>( &tmp ), sizeof tmp );
+    tmp = block.base_index;
+    ofs.write( reinterpret_cast<char*>( &tmp ), sizeof tmp );
+
+    count = static_cast<uint32_t>( block.local_variable_names.size() );
+    ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+
+    unsigned int varfirst = block.base_index;
+    auto varlast =
+        static_cast<unsigned int>( varfirst + block.local_variable_names.size() - 1 );
+    if ( varlast >= varfirst )
+    {
+      if ( text_ofs )
+        *text_ofs << "  Local variables " << varfirst << "-" << varlast << ": " << std::endl;
+      unsigned j = 0;
+      for ( auto& varname : block.local_variable_names )
+      {
+        if ( text_ofs )
+          *text_ofs << "      " << varfirst + j++ << ": " << varname << std::endl;
+
+        count = static_cast<unsigned int>( varname.size() + 1 );
+        ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+        ofs.write( varname.c_str(), count );
+      }
+    }
+  }
+  count = static_cast<unsigned int>( debug_store.user_functions.size() );
+  ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+  unsigned funcnum = 0;
+  for ( auto& user_function : debug_store.user_functions )
+  {
+    if ( text_ofs )
+    {
+      *text_ofs << "Function " << funcnum++ << ": " << user_function.name << std::endl;
+      *text_ofs << "  FirstPC=" << user_function.first_instruction
+                << ", lastPC=" << user_function.last_instruction << std::endl;
+    }
+    count = static_cast<unsigned int>( user_function.name.size() + 1 );
+    ofs.write( reinterpret_cast<char*>( &count ), sizeof count );
+    ofs.write( user_function.name.c_str(), count );
+    uint32_t tmp;
+    tmp = user_function.first_instruction;
+    ofs.write( reinterpret_cast<char*>( &tmp ), sizeof tmp );
+    tmp = user_function.last_instruction;
+    ofs.write( reinterpret_cast<char*>( &tmp ), sizeof tmp );
+  }
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/format/DebugStoreSerializer.h
+++ b/pol-core/bscript/compiler/format/DebugStoreSerializer.h
@@ -1,0 +1,26 @@
+#ifndef POLSERVER_DEBUGSTORESERIALIZER_H
+#define POLSERVER_DEBUGSTORESERIALIZER_H
+
+#include <iosfwd>
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class CompiledScript;
+class DebugStore;
+
+class DebugStoreSerializer
+{
+public:
+  explicit DebugStoreSerializer( CompiledScript& );
+
+  void write( std::ofstream& ofs, std::ofstream* text_ofs );
+
+private:
+  const CompiledScript& compiled_script;
+  const DebugStore& debug_store;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DEBUGSTORESERIALIZER_H

--- a/pol-core/bscript/compiler/format/ListingWriter.cpp
+++ b/pol-core/bscript/compiler/format/ListingWriter.cpp
@@ -14,7 +14,8 @@ ListingWriter::ListingWriter( CompiledScript& compiled_script ) : compiled_scrip
 
 void ListingWriter::write( std::ofstream& ofs )
 {
-  StoredTokenDecoder decoder( compiled_script.module_descriptors, compiled_script.data, nullptr );
+  StoredTokenDecoder decoder( compiled_script.module_descriptors, compiled_script.data,
+                              &compiled_script.debug );
   int i = 0;
   for ( auto& tkn : compiled_script.code )
   {

--- a/pol-core/bscript/compiler/format/ListingWriter.cpp
+++ b/pol-core/bscript/compiler/format/ListingWriter.cpp
@@ -14,7 +14,7 @@ ListingWriter::ListingWriter( CompiledScript& compiled_script ) : compiled_scrip
 
 void ListingWriter::write( std::ofstream& ofs )
 {
-  StoredTokenDecoder decoder( compiled_script.module_descriptors, compiled_script.data );
+  StoredTokenDecoder decoder( compiled_script.module_descriptors, compiled_script.data, nullptr );
   int i = 0;
   for ( auto& tkn : compiled_script.code )
   {

--- a/pol-core/bscript/compiler/format/StoredTokenDecoder.h
+++ b/pol-core/bscript/compiler/format/StoredTokenDecoder.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "clib/formatfwd.h"
+#include "token.h" // for DebugToken
 
 namespace Pol::Bscript
 {
@@ -13,12 +14,14 @@ class StoredToken;
 
 namespace Pol::Bscript::Compiler
 {
+class DebugStore;
 class ModuleDescriptor;
 
 class StoredTokenDecoder
 {
 public:
-  StoredTokenDecoder( const std::vector<ModuleDescriptor>&, const std::vector<std::byte>& data );
+  StoredTokenDecoder( const std::vector<ModuleDescriptor>&, const std::vector<std::byte>& data,
+                      const DebugStore* );
 
   void decode_to( const StoredToken&, fmt::Writer& );
 
@@ -27,10 +30,12 @@ private:
   int integer_at( unsigned offset ) const;
   [[nodiscard]] uint16_t uint16_t_at( unsigned offset ) const;
   std::string string_at( unsigned offset ) const;
+  const Pol::Bscript::DebugToken& debug_token_at( unsigned offset ) const;
   void decode_casejmp_table( fmt::Writer&, unsigned offset ) const;
 
   const std::vector<ModuleDescriptor>& module_descriptors;
   const std::vector<std::byte>& data;
+  const DebugStore* debug_store;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/CompiledScript.cpp
+++ b/pol-core/bscript/compiler/representation/CompiledScript.cpp
@@ -12,6 +12,7 @@ namespace Pol::Bscript::Compiler
 {
 CompiledScript::CompiledScript( CodeSection code,
                                 DataSection data,
+                                DebugStore debug,
                                 ExportedFunctions exported_functions,
                                 std::vector<std::string> global_variable_names,
                                 ModuleDescriptors module_descriptors,
@@ -19,6 +20,7 @@ CompiledScript::CompiledScript( CodeSection code,
                                 SourceFileIdentifiers source_file_identifiers)
   : code( std::move( code ) ),
     data( std::move( data ) ),
+    debug( std::move( debug ) ),
     exported_functions( std::move( exported_functions ) ),
     global_variable_names( std::move( global_variable_names ) ),
     module_descriptors( std::move( module_descriptors ) ),

--- a/pol-core/bscript/compiler/representation/CompiledScript.h
+++ b/pol-core/bscript/compiler/representation/CompiledScript.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "DebugStore.h"
+#include "compiler/representation/DebugStore.h"
 
 namespace Pol::Bscript
 {

--- a/pol-core/bscript/compiler/representation/CompiledScript.h
+++ b/pol-core/bscript/compiler/representation/CompiledScript.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "DebugStore.h"
+
 namespace Pol::Bscript
 {
 class StoredToken;
@@ -33,6 +35,7 @@ public:
 
   CompiledScript( CodeSection code_section,
                   DataSection data_section,
+                  DebugStore debug,
                   ExportedFunctions exported_functions,
                   std::vector<std::string> global_variable_names,
                   ModuleDescriptors modules,
@@ -44,6 +47,7 @@ public:
 
   const CodeSection code;
   const DataSection data;
+  const DebugStore debug;
   const ExportedFunctions exported_functions;
   const std::vector<std::string> global_variable_names;
   const ModuleDescriptors module_descriptors;

--- a/pol-core/bscript/compiler/representation/DebugBlock.cpp
+++ b/pol-core/bscript/compiler/representation/DebugBlock.cpp
@@ -1,0 +1,25 @@
+#include "DebugBlock.h"
+
+namespace Pol::Bscript::Compiler
+{
+/*
+ * A DebugBlock names the local variables in a block.
+ *
+ * Suppose local_variables_base_index is 4 and local_variables == { "x, y, z" }
+ * local #0: look up using parent_block_index
+ * local #1: "
+ * local #2: "
+ * local #3: "
+ * local #4: local named x
+ * local #5: local named y
+ * local #6: local named z
+ */
+DebugBlock::DebugBlock( unsigned parent_block_index, unsigned base_index,
+                        std::vector<std::string> local_variable_names )
+  : parent_block_index( parent_block_index ),
+    base_index( base_index ),
+    local_variable_names( std::move( local_variable_names ) )
+{
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/DebugBlock.h
+++ b/pol-core/bscript/compiler/representation/DebugBlock.h
@@ -1,0 +1,25 @@
+#ifndef POLSERVER_DEBUGBLOCK_H
+#define POLSERVER_DEBUGBLOCK_H
+
+#include <string>
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class DebugBlock
+{
+public:
+  DebugBlock( unsigned parent_block_index, unsigned base_index,
+              std::vector<std::string> local_variables );
+
+  const unsigned parent_block_index;
+
+  // this->local_variables[n] is overall local[n+base_index]
+  const unsigned base_index;
+
+  const std::vector<std::string> local_variable_names;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DEBUGBLOCK_H

--- a/pol-core/bscript/compiler/representation/DebugBlock.h
+++ b/pol-core/bscript/compiler/representation/DebugBlock.h
@@ -14,7 +14,7 @@ public:
 
   const unsigned parent_block_index;
 
-  // this->local_variables[n] is overall local[n+base_index]
+  // this->local_variable_names[n] is overall local[n+base_index]
   const unsigned base_index;
 
   const std::vector<std::string> local_variable_names;

--- a/pol-core/bscript/compiler/representation/DebugStore.cpp
+++ b/pol-core/bscript/compiler/representation/DebugStore.cpp
@@ -1,0 +1,39 @@
+#include "DebugStore.h"
+
+#include "DebugBlock.h"
+
+namespace Pol::Bscript::Compiler
+{
+DebugStore::DebugStore( std::vector<std::string> filenames ) : filenames( std::move( filenames ) )
+{
+  std::vector<std::string> empty;
+  blocks.emplace_back( 0, 0, empty );
+}
+
+DebugStore::DebugStore( DebugStore&& ) noexcept = default;
+DebugStore::~DebugStore() = default;
+
+unsigned DebugStore::add_block( unsigned parent_block_id,
+                                std::vector<std::string> local_variable_names )
+{
+  unsigned base_index = 0;
+  if ( parent_block_id )
+  {
+    auto& parent_block = blocks.at( parent_block_id );
+    base_index = parent_block.base_index + parent_block.local_variable_names.size();
+  }
+  blocks.emplace_back( parent_block_id, base_index, std::move( local_variable_names ) );
+  return blocks.size() - 1;
+}
+
+void DebugStore::add_instruction( const DebugStore::InstructionInfo& info )
+{
+  instructions.push_back( info );
+}
+
+void DebugStore::add_user_function( UserFunctionInfo uf )
+{
+  user_functions.push_back( std::move( uf ) );
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/DebugStore.cpp
+++ b/pol-core/bscript/compiler/representation/DebugStore.cpp
@@ -1,6 +1,8 @@
 #include "DebugStore.h"
 
-#include "DebugBlock.h"
+#include "compiler/model/LocalVariableScopeInfo.h"
+#include "compiler/model/Variable.h"
+#include "compiler/representation/DebugBlock.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -14,14 +16,16 @@ DebugStore::DebugStore( DebugStore&& ) noexcept = default;
 DebugStore::~DebugStore() = default;
 
 unsigned DebugStore::add_block( unsigned parent_block_id,
-                                std::vector<std::string> local_variable_names )
+                                const LocalVariableScopeInfo& local_variable_scope_info )
 {
-  unsigned base_index = 0;
-  if ( parent_block_id )
+  unsigned base_index = local_variable_scope_info.base_index;
+  std::vector<std::string> local_variable_names;
+  local_variable_names.reserve( local_variable_scope_info.variables.size() );
+  for ( auto& var : local_variable_scope_info.variables )
   {
-    auto& parent_block = blocks.at( parent_block_id );
-    base_index = parent_block.base_index + parent_block.local_variable_names.size();
+    local_variable_names.push_back( var->name );
   }
+
   blocks.emplace_back( parent_block_id, base_index, std::move( local_variable_names ) );
   return blocks.size() - 1;
 }

--- a/pol-core/bscript/compiler/representation/DebugStore.cpp
+++ b/pol-core/bscript/compiler/representation/DebugStore.cpp
@@ -15,7 +15,7 @@ DebugStore::DebugStore( std::vector<std::string> filenames ) : filenames( std::m
 DebugStore::DebugStore( DebugStore&& ) noexcept = default;
 DebugStore::~DebugStore() = default;
 
-unsigned DebugStore::add_block( unsigned parent_block_id,
+unsigned DebugStore::add_block( unsigned parent_block_index,
                                 const LocalVariableScopeInfo& local_variable_scope_info )
 {
   unsigned base_index = local_variable_scope_info.base_index;
@@ -26,7 +26,7 @@ unsigned DebugStore::add_block( unsigned parent_block_id,
     local_variable_names.push_back( var->name );
   }
 
-  blocks.emplace_back( parent_block_id, base_index, std::move( local_variable_names ) );
+  blocks.emplace_back( parent_block_index, base_index, std::move( local_variable_names ) );
   return blocks.size() - 1;
 }
 

--- a/pol-core/bscript/compiler/representation/DebugStore.h
+++ b/pol-core/bscript/compiler/representation/DebugStore.h
@@ -1,0 +1,48 @@
+#ifndef POLSERVER_DEBUGSTORE_H
+#define POLSERVER_DEBUGSTORE_H
+
+#include <string>
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class DebugBlock;
+
+class DebugStore
+{
+public:
+  explicit DebugStore( std::vector<std::string> filenames );
+  DebugStore( DebugStore&& ) noexcept;
+  ~DebugStore();
+
+  unsigned add_block( unsigned parent_block_index, std::vector<std::string> local_variable_names );
+
+  struct InstructionInfo {
+    unsigned file_index;
+    unsigned line_number;
+    unsigned block_index;
+    bool statement_begin;
+  };
+
+  void add_instruction( const InstructionInfo& );
+
+  struct UserFunctionInfo
+  {
+    std::string name;
+    unsigned first_instruction;
+    unsigned last_instruction;
+  };
+
+  void add_user_function( UserFunctionInfo );
+
+private:
+  friend class DebugStoreSerializer;
+  std::vector<DebugBlock> blocks;
+  std::vector<std::string> filenames;
+  std::vector<InstructionInfo> instructions;
+  std::vector<UserFunctionInfo> user_functions;
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_DEBUGSTORE_H

--- a/pol-core/bscript/compiler/representation/DebugStore.h
+++ b/pol-core/bscript/compiler/representation/DebugStore.h
@@ -7,6 +7,7 @@
 namespace Pol::Bscript::Compiler
 {
 class DebugBlock;
+class LocalVariableScopeInfo;
 
 class DebugStore
 {
@@ -15,7 +16,7 @@ public:
   DebugStore( DebugStore&& ) noexcept;
   ~DebugStore();
 
-  unsigned add_block( unsigned parent_block_index, std::vector<std::string> local_variable_names );
+  unsigned add_block( unsigned parent_block_index, const LocalVariableScopeInfo& );
 
   struct InstructionInfo {
     unsigned file_index;

--- a/pol-core/bscript/eprog.h
+++ b/pol-core/bscript/eprog.h
@@ -56,6 +56,12 @@ struct EPDbgBlock
   unsigned parentblockidx;
   unsigned parentvariables;
   std::vector<std::string> localvarnames;
+
+  bool operator==( const EPDbgBlock& other ) const
+  {
+    return parentblockidx == other.parentblockidx && parentvariables == other.parentvariables &&
+           localvarnames == other.localvarnames;
+  }
 };
 
 struct EPExportedFunction
@@ -63,6 +69,11 @@ struct EPExportedFunction
   std::string name;
   unsigned nargs;
   unsigned PC;
+
+  bool operator==( const EPExportedFunction& other ) const
+  {
+    return name == other.name && nargs == other.nargs && PC == other.PC;
+  }
 };
 
 struct EPDbgFunction
@@ -70,6 +81,11 @@ struct EPDbgFunction
   std::string name;
   unsigned firstPC;
   unsigned lastPC;
+
+  bool operator==( const EPDbgFunction& other ) const
+  {
+    return name == other.name && firstPC == other.firstPC && lastPC == other.lastPC;
+  }
 };
 
 struct BSCRIPT_SECTION_HDR;

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -175,10 +175,6 @@ std::vector<unsigned char> binary_contents( const std::string& pathname )
   return buffer;
 }
 
-std::string filename_with_option(const std::string& filename) {
-  return filename;
-}
-
 std::vector<std::string> instruction_filenames( const std::vector<unsigned>& ins_filenums, const std::vector<std::string>& filenames)
 {
   std::vector<std::string> result;
@@ -226,17 +222,17 @@ bool compare_compiler_output( const std::string& path )
 
   // this is why -T and -G conflict: using the same filenames for every script
 
-  std::string og_ecl = filename_with_option( "og-compiler.ecl");
-  std::string og_lst = filename_with_option( "og-compiler.lst");
+  std::string og_ecl( "og-compiler.ecl" );
+  std::string og_lst( "og-compiler.lst" );
 //  std::string og_disassembly = filename_with_option("og-compiler.ecl.txt");
-  std::string og_dbg = filename_with_option("og-compiler.dbg");
-  std::string og_dbg_txt = filename_with_option("og-compiler.dbg.txt");
+  std::string og_dbg( "og-compiler.dbg" );
+  std::string og_dbg_txt( "og-compiler.dbg.txt" );
 
-  std::string new_ecl = filename_with_option( "new-compiler.ecl" );
-  std::string new_lst = filename_with_option( "new-compiler.lst" );
+  std::string new_ecl( "new-compiler.ecl" );
+  std::string new_lst( "new-compiler.lst" );
 //  std::string new_disassembly = filename_with_option("new-compiler.ecl.txt");
-  std::string new_dbg = filename_with_option("new-compiler.dbg");
-  std::string new_dbg_txt = filename_with_option("new-compiler.dbg.txt");
+  std::string new_dbg( "new-compiler.dbg" );
+  std::string new_dbg_txt( "new-compiler.dbg.txt" );
 
   og_compiler.write_ecl( og_ecl );
   new_compiler.write_ecl( new_ecl );

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -135,8 +135,6 @@ struct Comparison
   std::atomic<long> NonMatchingResult {};
   std::atomic<long> MatchingOutput {};
   std::atomic<long> NonMatchingOutput {};
-  std::atomic<long> MatchingDebugOutput {};
-  std::atomic<long> NonMatchingDebugOutput {};
 } comparison;
 
 Compiler::SourceFileCache em_parse_tree_cache( summary.profile );
@@ -230,21 +228,21 @@ bool compare_compiler_output( const std::string& path )
 
   std::string og_ecl = filename_with_option( "og-compiler.ecl");
   std::string og_lst = filename_with_option( "og-compiler.lst");
-  std::string og_disassembly = filename_with_option("og-compiler.ecl.txt");
+//  std::string og_disassembly = filename_with_option("og-compiler.ecl.txt");
   std::string og_dbg = filename_with_option("og-compiler.dbg");
   std::string og_dbg_txt = filename_with_option("og-compiler.dbg.txt");
 
   std::string new_ecl = filename_with_option( "new-compiler.ecl" );
   std::string new_lst = filename_with_option( "new-compiler.lst" );
-  std::string new_disassembly = filename_with_option("new-compiler.ecl.txt");
+//  std::string new_disassembly = filename_with_option("new-compiler.ecl.txt");
   std::string new_dbg = filename_with_option("new-compiler.dbg");
   std::string new_dbg_txt = filename_with_option("new-compiler.dbg.txt");
 
   og_compiler.write_ecl( og_ecl );
   new_compiler.write_ecl( new_ecl );
 
-  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( og_ecl, og_disassembly );
-  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( new_ecl, new_disassembly );
+//  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( og_ecl, og_disassembly );
+//  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( new_ecl, new_disassembly );
 
   og_compiler.write_listing( og_lst );
   {
@@ -309,26 +307,16 @@ bool compare_compiler_output( const std::string& path )
 
     INFO_PRINT << "Not expected to match exactly:\n";
     INFO_PRINT << "  Debug Info matches:\n";
-    INFO_PRINT << "              all: " << dbg_matches << " (not expected to match)\n";
+    INFO_PRINT << "              all: " << dbg_matches << "\n";
     INFO_PRINT << "    ins filenames: " << ins_filenames_match << "\n";
-    INFO_PRINT << "        filenames: " << filenames_match << " (not expected to match)\n";
-    INFO_PRINT << "     file numbers: " << filenum_match << " (not expected to match)\n";
-    INFO_PRINT << "       ins_blocks: " << ins_blocks_match << " (not expected to match)\n";
+    INFO_PRINT << "        filenames: " << filenames_match << "\n";
+    INFO_PRINT << "     file numbers: " << filenum_match << "\n";
+    INFO_PRINT << "       ins_blocks: " << ins_blocks_match << "\n";
     INFO_PRINT << "           blocks: " << blocks_match << "\n";
     INFO_PRINT << "        functions: " << functions_match << "\n";
     INFO_PRINT << "  Debug Info (text) matches: " << dbg_txt_matches << "\n";
-    INFO_PRINT << "    - " << og_dbg_txt << " (not expected to match)\n";
-    INFO_PRINT << "    - " << new_dbg_txt << " (not expected to match)\n";
-    // ins_blocks_match: OG compiler lists the wrong block for loops
-    // filenum_match: OG compiler numbers files in order of use by an instruction
-    // filenames_match: OG compiler numbers files in order of use by an instruction
-    bool enough_dbg_matches = ins_filenames_match && blocks_match;
-    if ( enough_dbg_matches )
-      ++comparison.MatchingDebugOutput;
-    else
-      ++comparison.NonMatchingDebugOutput;
-    if ( !enough_dbg_matches )
-      throw std::runtime_error( "Debug info mismatch" );
+    INFO_PRINT << "    - " << og_dbg_txt << "\n";
+    INFO_PRINT << "    - " << new_dbg_txt << "\n";
   }
 
   return true;
@@ -1074,8 +1062,6 @@ bool run( int argc, char** argv, int* res )
     tmp << "  Result mismatches: " << comparison.NonMatchingResult << "\n";
     tmp << "     Output matches: " << comparison.MatchingOutput << "\n";
     tmp << "  Output mismatches: " << comparison.NonMatchingOutput << "\n";
-    tmp << "      Debug matches: " << comparison.MatchingDebugOutput << "\n";
-    tmp << "   Debug mismatches: " << comparison.NonMatchingDebugOutput << "\n";
     INFO_PRINT << tmp.str();
   }
 

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -224,23 +224,14 @@ bool compare_compiler_output( const std::string& path )
 
   std::string og_ecl( "og-compiler.ecl" );
   std::string og_lst( "og-compiler.lst" );
-//  std::string og_disassembly = filename_with_option("og-compiler.ecl.txt");
-  std::string og_dbg( "og-compiler.dbg" );
-  std::string og_dbg_txt( "og-compiler.dbg.txt" );
 
   std::string new_ecl( "new-compiler.ecl" );
   std::string new_lst( "new-compiler.lst" );
-//  std::string new_disassembly = filename_with_option("new-compiler.ecl.txt");
-  std::string new_dbg( "new-compiler.dbg" );
-  std::string new_dbg_txt( "new-compiler.dbg.txt" );
 
   og_compiler.write_ecl( og_ecl );
-  new_compiler.write_ecl( new_ecl );
-
-//  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( og_ecl, og_disassembly );
-//  Pol::Bscript::Compiler::SideBySideListingWriter().disassemble_file( new_ecl, new_disassembly );
-
   og_compiler.write_listing( og_lst );
+
+  new_compiler.write_ecl( new_ecl );
   {
     ref_ptr<EScriptProgram> program( new EScriptProgram );
     program->read( new_ecl.c_str() );
@@ -282,6 +273,12 @@ bool compare_compiler_output( const std::string& path )
 
   if ( compilercfg.GenerateDebugInfo )
   {
+    std::string og_dbg( "og-compiler.dbg" );
+    std::string og_dbg_txt( "og-compiler.dbg.txt" );
+
+    std::string new_dbg( "new-compiler.dbg" );
+    std::string new_dbg_txt( "new-compiler.dbg.txt" );
+
     og_compiler.write_dbg( og_dbg, compilercfg.GenerateDebugTextInfo );
     new_compiler.write_dbg( new_dbg, compilercfg.GenerateDebugTextInfo );
 


### PR DESCRIPTION
Write `.dbg` and `.dbg.txt` files if so configured, as well as `CTRL_STATEMENTBEGIN` if `-i` is passed to `ecompile`.

The information is close to what the OG compiler generates, but not exactly the same, in part because the debug info that the OG compiler writes isn't always correct.  For example, for a `foreach` loop with an inner `var`, the `ins_stepforeach` instruction will have a block number that has gone out of scope.

For this reason, there is no parity checking enforced against what the OG compiler generates.

Also: Changed OG compiler debug info for `foreach` iterator to match actual variable name.
    
Adds:
- [ast/DebugStatementMarker](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/ast/DebugStatementMarker.h): for "intrusive debug" (ecompile -i) instructions
- [codegen/DebugBlockGuard](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/codegen/DebugBlockGuard.h): pushes and pops debug block #
- [format/DebugStoreSerializer](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/format/DebugStoreSerializer.cpp): writes .dbg and .dbg.txt files
- [representation/DebugBlock](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/representation/DebugBlock.h): holds parent block # and local variable names for each block
- [representation/DebugStore](https://github.com/polserver/polserver/blob/ecompile-antlr/pol-core/bscript/compiler/representation/DebugStore.h): holds all debug information

