### PR TITLE
Use new compiler (optionally) for "compile includes" mode

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -238,6 +238,7 @@ set (bscript_sources    # sorted !
   compiler/model/FunctionLink.cpp
   compiler/model/FunctionLink.h
   compiler/model/LocalVariableScopeInfo.h
+  compiler/model/UserFunctionInclusion.h
   compiler/model/Variable.cpp
   compiler/model/Variable.h
   compiler/model/VariableScope.h

--- a/pol-core/bscript/compiler.cpp
+++ b/pol-core/bscript/compiler.cpp
@@ -4393,6 +4393,11 @@ void Compiler::write_included_filenames( const std::string& pathname )
   writeIncludedFilenames( pathname.c_str() );
 }
 
+void Compiler::set_include_compile_mode()
+{
+  setIncludeCompileMode();
+}
+
 Pol::Bscript::Compiler::LegacyFunctionOrder Compiler::get_legacy_function_order() const
 {
   std::vector<std::string> modulefunc_emit_order;

--- a/pol-core/bscript/compiler.h
+++ b/pol-core/bscript/compiler.h
@@ -285,6 +285,8 @@ public:
   void write_listing( const std::string& pathname ) override;
   void write_dbg( const std::string& pathname, bool include_debug_text ) override;
   void write_included_filenames( const std::string& pathname ) override;
+  void set_include_compile_mode() override;
+
 
   Pol::Bscript::Compiler::LegacyFunctionOrder get_legacy_function_order() const;
 

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -73,6 +73,11 @@ void Compiler::write_included_filenames( const std::string& /*pathname*/ )
 {
 }
 
+void Compiler::set_include_compile_mode()
+{
+  user_function_inclusion = UserFunctionInclusion::All;
+}
+
 bool Compiler::compile_file( const std::string& filename,
                              const LegacyFunctionOrder* legacy_function_order )
 {
@@ -131,7 +136,8 @@ std::unique_ptr<CompilerWorkspace> Compiler::build_workspace(
 {
   Pol::Tools::HighPerfTimer timer;
   CompilerWorkspaceBuilder workspace_builder( em_cache, inc_cache, profile, report );
-  auto workspace = workspace_builder.build( pathname, legacy_function_order );
+  auto workspace =
+      workspace_builder.build( pathname, legacy_function_order, user_function_inclusion );
   profile.build_workspace_micros += timer.ellapsed().count();
   return workspace;
 }
@@ -147,7 +153,7 @@ void Compiler::optimize( CompilerWorkspace& workspace, Report& report )
 {
   Pol::Tools::HighPerfTimer timer;
   Optimizer optimizer( workspace.constants, report );
-  optimizer.optimize( workspace );
+  optimizer.optimize( workspace, user_function_inclusion );
   profile.optimize_micros += timer.ellapsed().count();
 }
 

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "bscript/compiler/model/UserFunctionInclusion.h"
+
 namespace Pol::Bscript::Compiler
 {
 class CompiledScript;
@@ -27,6 +29,7 @@ public:
   void write_listing( const std::string& pathname ) override;
   void write_dbg( const std::string& pathname, bool include_debug_text ) override;
   void write_included_filenames( const std::string& pathname ) override;
+  void set_include_compile_mode() override;
 
   bool compile_file( const std::string& filename, const LegacyFunctionOrder* );
   void compile_file_steps( const std::string& pathname, const LegacyFunctionOrder*, Report& );
@@ -48,6 +51,7 @@ private:
   SourceFileCache& inc_cache;
   Profile& profile;
   std::unique_ptr<CompiledScript> output;
+  UserFunctionInclusion user_function_inclusion = UserFunctionInclusion::ReferencedOnly;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -28,7 +28,8 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileCache& em_cache,
 }
 
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
-    const std::string& pathname, const LegacyFunctionOrder* legacy_function_order )
+    const std::string& pathname, const LegacyFunctionOrder* legacy_function_order,
+    UserFunctionInclusion user_function_inclusion )
 {
   auto compiler_workspace = std::make_unique<CompilerWorkspace>( report );
   BuilderWorkspace workspace( *compiler_workspace, em_cache, inc_cache, profile, report );
@@ -51,7 +52,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
     return {};
   }
 
-  SourceFileProcessor src_processor( *ident, workspace, true );
+  SourceFileProcessor src_processor( *ident, workspace, true, user_function_inclusion );
 
   workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
   workspace.source_files[sf->pathname] = sf;

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "compiler/model/UserFunctionInclusion.h"
+
 namespace Pol::Bscript::Compiler
 {
 class BuilderWorkspace;
@@ -23,7 +25,8 @@ public:
 
   std::unique_ptr<CompilerWorkspace> build(
       const std::string& pathname,
-      const LegacyFunctionOrder* legacy_function_order );
+      const LegacyFunctionOrder* legacy_function_order,
+      UserFunctionInclusion );
 
 private:
   std::vector<const ModuleFunctionDeclaration*> get_module_functions_in_order(

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -23,6 +23,12 @@ const Function* FunctionResolver::find( const std::string& scoped_name )
     return nullptr;
 }
 
+void FunctionResolver::force_reference( const std::string& function_name,
+                                        const SourceLocation& loc )
+{
+  register_function_link( function_name, std::make_shared<FunctionLink>( loc ) );
+}
+
 void FunctionResolver::register_available_user_function(
     const SourceLocation& source_location,
     EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx )

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -27,6 +27,8 @@ public:
 
   const Function* find( const std::string& scoped_name );
 
+  void force_reference( const std::string& name, const SourceLocation& );
+
   void register_available_user_function(
       const SourceLocation&, EscriptGrammar::EscriptParser::FunctionDeclarationContext* );
   void register_function_link( const std::string& name,

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "compiler/astbuilder/ProgramBuilder.h"
+#include "compiler/model/UserFunctionInclusion.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -17,7 +18,8 @@ class SourceFile;
 class SourceFileProcessor : public EscriptGrammar::EscriptParserBaseVisitor
 {
 public:
-  SourceFileProcessor( const SourceFileIdentifier&, BuilderWorkspace&, bool is_src );
+  SourceFileProcessor( const SourceFileIdentifier&, BuilderWorkspace&, bool is_src,
+                       UserFunctionInclusion );
 
 public:
   void use_module( const std::string& name, SourceLocation& including_location,
@@ -55,6 +57,7 @@ protected:
 
 private:
   const bool is_src;
+  const UserFunctionInclusion user_function_inclusion;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/UserFunctionInclusion.h
+++ b/pol-core/bscript/compiler/model/UserFunctionInclusion.h
@@ -1,0 +1,14 @@
+#ifndef POLSERVER_USERFUNCTIONINCLUSION_H
+#define POLSERVER_USERFUNCTIONINCLUSION_H
+
+namespace Pol::Bscript::Compiler
+{
+enum class UserFunctionInclusion
+{
+  ReferencedOnly,
+  All
+};
+
+}  // namespace Pol::Bscript::Compiler
+
+#endif  // POLSERVER_USERFUNCTIONINCLUSION_H

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -33,9 +33,19 @@ Optimizer::Optimizer( Constants& constants, Report& report )
 {
 }
 
-void Optimizer::optimize( CompilerWorkspace& workspace )
+void Optimizer::optimize( CompilerWorkspace& workspace,
+                          UserFunctionInclusion user_function_inclusion )
 {
   workspace.accept( *this );
+
+  std::vector<UserFunction*> all_user_functions;
+  if ( user_function_inclusion == UserFunctionInclusion::All )
+  {
+    for ( auto& user_function : workspace.user_functions )
+    {
+      all_user_functions.push_back( user_function.get() );
+    }
+  }
 
   std::vector<UserFunction*> exported_functions;
   for ( auto& user_function : workspace.user_functions )
@@ -54,8 +64,17 @@ void Optimizer::optimize( CompilerWorkspace& workspace )
   {
     gatherer.reference( uf );
   }
+  if ( user_function_inclusion == UserFunctionInclusion::All )
+  {
+    for ( auto& uf : all_user_functions )
+    {
+      gatherer.reference( uf );
+    }
+  }
+
   workspace.referenced_module_function_declarations =
       gatherer.take_referenced_module_function_declarations();
+
   workspace.user_functions = gatherer.take_referenced_user_functions();
 }
 

--- a/pol-core/bscript/compiler/optimizer/Optimizer.h
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.h
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "compiler/model/UserFunctionInclusion.h"
+
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
@@ -16,7 +18,7 @@ class Optimizer : public NodeVisitor
 public:
   Optimizer( Constants&, Report& );
 
-  void optimize( CompilerWorkspace& );
+  void optimize( CompilerWorkspace&, UserFunctionInclusion );
   void visit_children( Node& ) override;
 
   void visit_binary_operator( BinaryOperator& ) override;

--- a/pol-core/bscript/facility/Compiler.h
+++ b/pol-core/bscript/facility/Compiler.h
@@ -18,6 +18,7 @@ public:
   virtual void write_listing( const std::string& pathname ) = 0;
   virtual void write_dbg( const std::string& pathname, bool include_debug_text ) = 0;
   virtual void write_included_filenames( const std::string& pathname ) = 0;
+  virtual void set_include_compile_mode() = 0;
 };
 
 }  // namespace Facility


### PR DESCRIPTION
Use the new compiler with the `-i` option (compile includes: compile all functions whether or not referenced) if `-g` is also specified.