### PR TITLE
New compiler: warn on double assignment to the same variable

### DIFF
--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include "clib/logfacility.h"
 #include "clib/strutil.h"
 #include "compiler/Report.h"
 #include "compiler/analyzer/Constants.h"
@@ -9,7 +10,9 @@
 #include "compiler/analyzer/FlowControlScope.h"
 #include "compiler/analyzer/LocalVariableScopes.h"
 #include "compiler/ast/Argument.h"
+#include "compiler/ast/AssignVariableConsume.h"
 #include "compiler/ast/BasicForLoop.h"
+#include "compiler/ast/BinaryOperator.h"
 #include "compiler/ast/Block.h"
 #include "compiler/ast/CaseDispatchDefaultSelector.h"
 #include "compiler/ast/CaseDispatchGroup.h"
@@ -72,6 +75,8 @@ void SemanticAnalyzer::register_const_declarations( CompilerWorkspace& workspace
 
 void SemanticAnalyzer::analyze()
 {
+  INFO_PRINT << workspace.top_level_statements->to_string_tree() << "\n";
+
   workspace.top_level_statements->accept( *this );
   if ( auto& program = workspace.program )
   {
@@ -84,6 +89,28 @@ void SemanticAnalyzer::analyze()
   }
 
   workspace.global_variable_names = globals.get_names();
+}
+
+void SemanticAnalyzer::visit_assign_variable_consume( AssignVariableConsume& node )
+{
+  visit_children( node );
+
+  if ( auto bop = dynamic_cast<BinaryOperator*>( &node.rhs() ) )
+  {
+    if ( bop->token_id == TOK_ASSIGN )
+    {
+      if ( auto second_ident = dynamic_cast<Identifier*>( &bop->lhs() ) )
+      {
+        if ( node.identifier().variable == second_ident->variable )
+        {
+          // we have something like
+          //      a := a := expr;
+          report.warning( node, "Double-assignment to the same variable '",
+                          node.identifier().name, "'." );
+        }
+      }
+    }
+  }
 }
 
 void SemanticAnalyzer::visit_basic_for_loop( BasicForLoop& node )

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -103,7 +103,7 @@ void SemanticAnalyzer::visit_assign_variable_consume( AssignVariableConsume& nod
           // we have something like
           //      a := a := expr;
           report.warning( node, "Double-assignment to the same variable '",
-                          node.identifier().name, "'." );
+                          node.identifier().name, "'.\n" );
         }
       }
     }

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -2,7 +2,6 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
-#include "clib/logfacility.h"
 #include "clib/strutil.h"
 #include "compiler/Report.h"
 #include "compiler/analyzer/Constants.h"
@@ -75,8 +74,6 @@ void SemanticAnalyzer::register_const_declarations( CompilerWorkspace& workspace
 
 void SemanticAnalyzer::analyze()
 {
-  INFO_PRINT << workspace.top_level_statements->to_string_tree() << "\n";
-
   workspace.top_level_statements->accept( *this );
   if ( auto& program = workspace.program )
   {

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -28,6 +28,7 @@ public:
   static void register_const_declarations( CompilerWorkspace&, Report& );
   void analyze();
 
+  void visit_assign_variable_consume( AssignVariableConsume& ) override;
   void visit_basic_for_loop( BasicForLoop& ) override;
   void visit_block( Block& ) override;
   void visit_case_statement( CaseStatement& ) override;


### PR DESCRIPTION
Warn on assignment statements like this, for which the OG compiler and the new compiler generate different code:

```
    x := x := expr;
```

This fixes https://github.com/polserver/polserver/issues/311

The OG compiler doesn't optimize the leftmost assignment to an 'assign-variable-consume',
so a listfile for the above looks like this:
```
  0: decl global #0
  1: #
  2: global #0
  3: global #0
  4: :=
  5: "hi"
  6: := #
  7: progend
```

The new compiler optimizes like this:
```
  0: decl global #0
  1: #
  2: global #0
  3: "hi"
  4: :=
  5: global0 :=
  6: progend
```

For reference, this is what a single assignment looks like:
```
  0: declare global #0
  1: # (consume)
  2: "hi" (string) len=2 offset=0x1
  3: global #0 :=
  4: progend
```