### PR TITLE
Remove Client::transmit 'needslock' parameter default.

### DIFF
--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -153,7 +153,7 @@ public:
   void unregister();  // removes updater for vitals and takes client away from clientlist
   void closeConnection();
   void transmit( const void* data, int len,
-                 bool needslock = false );  // for entire message or header only
+                 bool needslock );  // for entire message or header only
 
   void recv_remaining( int total_expected );
   void recv_remaining_nocrypt( int total_expected );

--- a/pol-core/pol/network/packethelper.h
+++ b/pol-core/pol/network/packethelper.h
@@ -38,9 +38,6 @@ public:
   ~PacketOut();
   void Release();
   void Send( Client* client, int len = -1 ) const;
-  // be really really careful with this function
-  // needs PolLock
-  void SendDirect( Client* client, int len = -1 ) const;
   T* operator->(void)const;
   T* Get();
 };
@@ -73,16 +70,6 @@ void PacketOut<T>::Send( Client* client, int len ) const
   if ( len == -1 )
     len = pkt->offset;
   Core::networkManager.clientTransmit->AddToQueue( client, &pkt->buffer, len );
-}
-
-template <class T>
-void PacketOut<T>::SendDirect( Client* client, int len ) const
-{
-  if ( pkt == 0 )
-    return;
-  if ( len == -1 )
-    len = pkt->offset;
-  client->transmit( &pkt->buffer, len );
 }
 
 template <class T>


### PR DESCRIPTION
Nothing actually passed it by default, because PacketOut::SendDirect is never called.

Also removed PacketOut::SendDirect.

I will remove the parameter entirely in a follow-up PR.  I am splitting them up in order to make it obvious that these changes will not affect behavior.