### PR TITLE
Removed Client::transmit 'needslock' parameter.  

### DIFF
--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -152,8 +152,7 @@ public:
 
   void unregister();  // removes updater for vitals and takes client away from clientlist
   void closeConnection();
-  void transmit( const void* data, int len,
-                 bool needslock );  // for entire message or header only
+  void transmit( const void* data, int len ); // always obtains PolLock when calling a SendFunction
 
   void recv_remaining( int total_expected );
   void recv_remaining_nocrypt( int total_expected );

--- a/pol-core/pol/network/clientio.cpp
+++ b/pol-core/pol/network/clientio.cpp
@@ -186,7 +186,7 @@ void Client::transmit_encrypted( const void* data, int len )
   THREAD_CHECKPOINT( active_client, 116 );
 }
 
-void Client::transmit( const void* data, int len, bool needslock )
+void Client::transmit( const void* data, int len )
 {
   ref_ptr<Core::BPacket> p;
   bool handled = false;
@@ -202,17 +202,9 @@ void Client::transmit( const void* data, int len, bool needslock )
     handled = GetAndCheckPacketHooked( this, data, phd );
     if ( handled )
     {
-      if ( needslock )
-      {
-        Core::PolLock lock;
-        std::lock_guard<std::mutex> guard( _SocketMutex );
-        CallOutgoingPacketExportedFunction( this, data, len, p, phd, handled );
-      }
-      else
-      {
-        std::lock_guard<std::mutex> guard( _SocketMutex );
-        CallOutgoingPacketExportedFunction( this, data, len, p, phd, handled );
-      }
+      Core::PolLock lock;
+      std::lock_guard<std::mutex> guard( _SocketMutex );
+      CallOutgoingPacketExportedFunction( this, data, len, p, phd, handled );
     }
   }
 

--- a/pol-core/pol/network/clienttransmit.cpp
+++ b/pol-core/pol/network/clienttransmit.cpp
@@ -72,7 +72,7 @@ void ClientTransmitThread()
           data->client->forceDisconnect();
         }
         else if ( data->client->isReallyConnected() )
-          data->client->transmit( static_cast<void*>( &data->data[0] ), data->len, true );
+          data->client->transmit( static_cast<void*>( &data->data[0] ), data->len );
       }
     }
     catch ( ClientTransmitQueue::Canceled& )


### PR DESCRIPTION
The parameter value passed was always `true`.