### PR TITLE
Add an error message about known reserved words

### DIFF
--- a/testsuite/escript/errors/errors004-reserved-word-as-argument-name.err2
+++ b/testsuite/escript/errors/errors004-reserved-word-as-argument-name.err2
@@ -1,1 +1,1 @@
-errors004-reserved-word-as-argument-name.src:3:13: error: extraneous input 'downto' expecting {'unused', ')', IDENTIFIER}
+errors004-reserved-word-as-argument-name.src:3:13: error: Did not expect reserved word 'downto' in this context.

--- a/testsuite/escript/errors/errors010-reserved-word-syntax-error.err1
+++ b/testsuite/escript/errors/errors010-reserved-word-syntax-error.err1
@@ -1,0 +1,1 @@
+Non-identifier declared as a variable: 'is'

--- a/testsuite/escript/errors/errors010-reserved-word-syntax-error.err2
+++ b/testsuite/escript/errors/errors010-reserved-word-syntax-error.err2
@@ -1,0 +1,1 @@
+errors010-reserved-word-syntax-error.src:1:5: error: Did not expect reserved word 'is' in this context.

--- a/testsuite/escript/errors/errors010-reserved-word-syntax-error.src
+++ b/testsuite/escript/errors/errors010-reserved-word-syntax-error.src
@@ -1,0 +1,2 @@
+var is := 1;
+print("the value is " + is);


### PR DESCRIPTION
There are a number of reserved words that might not be obvious that they are reserved.

When one is detected in a syntax error, add an error message about it.