### PR TITLE
Extract methods from threadedclient_io_finalize into client

### DIFF
--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -72,7 +72,7 @@ std::mutex ThreadedClient::_SocketMutex;
 
 ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, const Client& myClient )
     : myClient( myClient ),
-      thread_pid( static_cast<size_t>(-1) ),
+      thread_pid( static_cast<size_t>( -1 ) ),
       csocket( INVALID_SOCKET ),
       preDisconnect( false ),
       disconnect( false ),
@@ -82,7 +82,7 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, const Client& myC
       last_packet_at( 0 ),
       recv_state( RECV_STATE_CRYPTSEED_WAIT ),
       bufcheck1_AA( 0xAA ),
-      buffer(), // zero-initializes the buffer
+      buffer(),  // zero-initializes the buffer
       bufcheck2_55( 0x55 ),
       bytes_received( 0 ),
       message_length( 0 ),
@@ -518,8 +518,7 @@ void ThreadedClient::xmit( const void* data, unsigned short datalen )
     if ( datalen )  // anything left? if so, queue for later.
     {
       THREAD_CHECKPOINT( active_client, 211 );
-      POLLOG_ERROR.Format( "Client#{}: Switching to queued data mode (2)\n" )
-          << myClient.instance_;
+      POLLOG_ERROR.Format( "Client#{}: Switching to queued data mode (2)\n" ) << myClient.instance_;
       THREAD_CHECKPOINT( active_client, 212 );
       queue_data( cdata + nsent, datalen );
       THREAD_CHECKPOINT( active_client, 213 );

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -236,6 +236,10 @@ public:
 
   void transmit( const void* data, int len );  // always obtains PolLock when calling a SendFunction
 
+  int on_close();     // Called after the connection is closed (returns how long until on_logoff)
+  int test_logoff();  // Calls logofftest.ecl to determine how many seconds for the logoff timer
+  void on_logoff();   // Called when chr can finally logoff
+
   void setversion( const std::string& ver ) { version_ = ver; }
   const std::string& getversion() const { return version_; }
   VersionDetailStruct getversiondetail() const { return versiondetail_; }

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -46,9 +46,7 @@
 #pragma warning( disable : 4127 )  // conditional expression is constant, because of FD_SET
 #endif
 
-namespace Pol
-{
-namespace Core
+namespace Pol::Core
 {
 // This function below is defined (for now) in pol.cpp. That's ugly.
 void call_chr_scripts( Mobile::Character* chr, const std::string& root_script_ecl,
@@ -683,12 +681,12 @@ void handle_humongous_packet( Network::Client* client, unsigned int reported_siz
   tmp.Format( "Humongous packet (length {})", reported_size );
   report_weird_packet( client, tmp.str() );
 }
-}  // namespace Core
+}  // namespace Pol::Core
 
-namespace Network
+namespace Pol::Network
 {
-// on_close determines how long to wait until on_logoff is called. An alternative would be to call test_logoff
-// directly in the threadedclient_io_finalize.
+// on_close determines how long to wait until on_logoff is called. An alternative would be to call
+// test_logoff directly in the threadedclient_io_finalize.
 int Client::on_close()
 {
   unregister();
@@ -742,6 +740,4 @@ void Client::on_logoff()
   }
 }
 
-}  // namespace Network
-
-}  // namespace Pol
+}  // namespace Pol::Network


### PR DESCRIPTION
New methods are:
 - on_close, called when the connection is over. Returns the wait time for logoff.
 - test_logoff, called by on_close to determine how long chr must wait before logoff
 - on_logoff, called when the logoff timer expires

Note that I removed a `PolLock` which was previously used by the logoff timer. The timer itself was extracted as `threadedclient_sleep_until`. It seemed unnecessary to use `PolLock` because `polclock()` is protected by a SpinLock.