### PR TITLE
Sanity check for an unlikely issue

### DIFF
--- a/pol-core/pol/network/packethooks.cpp
+++ b/pol-core/pol/network/packethooks.cpp
@@ -208,6 +208,11 @@ void CallOutgoingPacketExportedFunction( Client* client, const void*& data, int&
       data = static_cast<void*>( &outpacket->buffer[0] );
       // pass the new size back to client::transmit
       inlength = cfBEu16( *sizeptr );
+      
+      // This shouldn't trigger unless something is wrong with BPacket.
+      passert_r( inlength <= outpacket->buffer.size(),
+                 "Specified packet length is greater than packet buffer!" );
+
       handled = false;
     }
     else


### PR DESCRIPTION
Coverity detected a possible tainted value for the length of a packet coming back from a packethook. The value should be maintained by BPacket but I don't think it hurts to add an extra check here. 

Alternatively, one could use BPacket's buffer.size() directly.