### PR TITLE
Move more specialized expression types from optimizer to AST builder

### DIFF
--- a/pol-core/bscript/compiler/ast/ValueConsumer.cpp
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.cpp
@@ -7,8 +7,8 @@
 namespace Pol::Bscript::Compiler
 {
 ValueConsumer::ValueConsumer( const SourceLocation& source_location,
-                              std::unique_ptr<Statement> child )
-    : Statement( source_location, std::move( child ) )
+                              std::unique_ptr<Expression> child )
+    : Expression( source_location, std::move( child ) )
 {
 }
 

--- a/pol-core/bscript/compiler/ast/ValueConsumer.h
+++ b/pol-core/bscript/compiler/ast/ValueConsumer.h
@@ -1,18 +1,18 @@
 #ifndef POLSERVER_VALUECONSUMER_H
 #define POLSERVER_VALUECONSUMER_H
 
-#include "compiler/ast/Statement.h"
+#include "compiler/ast/Expression.h"
 
 namespace Pol::Bscript::Compiler
 {
 class NodeVisitor;
 
-class ValueConsumer : public Statement
+class ValueConsumer : public Expression
 {
 public:
-  ValueConsumer( const SourceLocation&, std::unique_ptr<Statement> child );
+  ValueConsumer( const SourceLocation&, std::unique_ptr<Expression> child );
 
-  void accept( NodeVisitor& visitor ) override;
+  void accept( NodeVisitor& ) override;
   void describe_to( fmt::Writer& ) const override;
 };
 

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -55,7 +55,7 @@ void CompoundStatementBuilder::add_statements( EscriptParser::StatementContext* 
 
   if ( auto expr_ctx = ctx->expression() )
   {
-    statements.push_back( consume_statement_result( expression( expr_ctx ) ) );
+    statements.push_back( expression( expr_ctx, true ) );
   }
   else if ( auto if_st = ctx->ifStatement() )
   {

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -71,18 +71,9 @@ std::unique_ptr<Expression> ExpressionBuilder::binary_operator(
   {
     if ( auto element_access = dynamic_cast<ElementAccess*>( lhs.get() ) )
     {
-      if ( element_access->indexes().children.size() > 1 && consume )
-      {
-        return consume_expression_result( std::make_unique<ElementAssignment>(
-            location_for( *ctx ), false, element_access->take_entity(),
-            element_access->take_indexes(), std::move( rhs ) ) );
-      }
-      else
-      {
-        return std::make_unique<ElementAssignment>(
-            location_for( *ctx ), consume, element_access->take_entity(),
-            element_access->take_indexes(), std::move( rhs ) );
-      }
+      return std::make_unique<ElementAssignment>(
+          location_for( *ctx ), consume, element_access->take_entity(),
+          element_access->take_indexes(), std::move( rhs ) );
     }
     else if ( auto get_member = dynamic_cast<MemberAccess*>( lhs.get() ) )
     {

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.h
@@ -35,7 +35,7 @@ public:
       EscriptGrammar::EscriptParser::ExplicitArrayInitializerContext* );
 
   std::unique_ptr<Expression> binary_operator(
-      EscriptGrammar::EscriptParser::ExpressionContext* );
+      EscriptGrammar::EscriptParser::ExpressionContext*, bool consume );
 
   BTokenId binary_operator_token( EscriptGrammar::EscriptParser::ExpressionContext* );
 
@@ -51,7 +51,8 @@ public:
   std::unique_ptr<ErrorInitializer> error(
       EscriptGrammar::EscriptParser::ExplicitErrorInitializerContext* );
 
-  std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext* );
+  std::unique_ptr<Expression> expression( EscriptGrammar::EscriptParser::ExpressionContext*,
+                                          bool consume = false );
 
   std::vector<std::unique_ptr<Expression>> expressions(
       EscriptGrammar::EscriptParser::ArrayInitializerContext* );

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.cpp
@@ -11,10 +11,7 @@ namespace Pol::Bscript::Compiler
 {
 ModuleProcessor::ModuleProcessor( const SourceFileIdentifier& source_file_identifier,
                                   BuilderWorkspace& workspace, std::string modulename )
-  : profile( workspace.profile ),
-    report( workspace.report ),
-    source_file_identifier( source_file_identifier ),
-    workspace( workspace ),
+  : workspace( workspace ),
     tree_builder( source_file_identifier, workspace ),
     modulename( std::move( modulename ) )
 {

--- a/pol-core/bscript/compiler/astbuilder/ModuleProcessor.h
+++ b/pol-core/bscript/compiler/astbuilder/ModuleProcessor.h
@@ -25,9 +25,6 @@ public:
       EscriptGrammar::EscriptParser::ModuleDeclarationStatementContext* ) override;
 
 private:
-  Profile& profile;
-  Report& report;
-  const SourceFileIdentifier& source_file_identifier;
   BuilderWorkspace& workspace;
 
   ModuleDeclarationBuilder tree_builder;

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -11,7 +11,6 @@
 #include "compiler/ast/JumpStatement.h"
 #include "compiler/ast/ReturnStatement.h"
 #include "compiler/ast/StringValue.h"
-#include "compiler/ast/ValueConsumer.h"
 #include "compiler/ast/VarStatement.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/model/CompilerWorkspace.h"
@@ -61,8 +60,7 @@ void SimpleStatementBuilder::add_var_statements(
       {
         var_ast = std::make_unique<VarStatement>( loc, std::move( name ) );
       }
-      auto consumed = consume_statement_result( std::move( var_ast ) );
-      statements.push_back( std::move( consumed ) );
+      statements.push_back( std::move( var_ast ) );
     }
   }
 }
@@ -87,12 +85,6 @@ std::unique_ptr<ConstDeclaration> SimpleStatementBuilder::const_declaration(
 
   return std::make_unique<ConstDeclaration>( location_for( *ctx ), std::move( identifier ),
                                                std::move( value ) );
-}
-
-std::unique_ptr<Statement> SimpleStatementBuilder::consume_statement_result(
-    std::unique_ptr<Statement> statement )
-{
-  return std::make_unique<ValueConsumer>( statement->source_location, std::move( statement ) );
 }
 
 std::unique_ptr<JumpStatement> SimpleStatementBuilder::continue_statement(

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.h
@@ -8,8 +8,8 @@ namespace Pol::Bscript::Compiler
 class ConstDeclaration;
 class EnumDeclaration;
 class JumpStatement;
-class Statement;
 class ReturnStatement;
+class Statement;
 
 class SimpleStatementBuilder : public ExpressionBuilder
 {
@@ -27,9 +27,6 @@ public:
 
   std::unique_ptr<ConstDeclaration> const_declaration(
       EscriptGrammar::EscriptParser::ConstStatementContext* );
-
-  static std::unique_ptr<Statement> consume_statement_result(
-      std::unique_ptr<Statement> statement );
 
   std::unique_ptr<JumpStatement> continue_statement(
       EscriptGrammar::EscriptParser::ContinueStatementContext* ctx );

--- a/pol-core/bscript/compiler/astbuilder/TreeBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/TreeBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include <antlr4-runtime.h>
 
+#include "compiler/ast/ValueConsumer.h"
 #include "compiler/astbuilder/BuilderWorkspace.h"
 #include "compiler/file/SourceLocation.h"
 
@@ -13,6 +14,12 @@ TreeBuilder::TreeBuilder( const SourceFileIdentifier& source_file_identifier,
     source_file_identifier( source_file_identifier ),
     workspace( workspace )
 {
+}
+
+std::unique_ptr<Expression> TreeBuilder::consume_expression_result(
+    std::unique_ptr<Expression> expression )
+{
+  return std::make_unique<ValueConsumer>( expression->source_location, std::move( expression ) );
 }
 
 SourceLocation TreeBuilder::location_for( antlr4::ParserRuleContext& ctx ) const

--- a/pol-core/bscript/compiler/astbuilder/TreeBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/TreeBuilder.h
@@ -15,15 +15,18 @@ namespace antlr4
 }
 namespace Pol::Bscript::Compiler
 {
+class BuilderWorkspace;
+class Expression;
 class Report;
 class SourceLocation;
 class SourceFileIdentifier;
-class BuilderWorkspace;
 
 class TreeBuilder
 {
 public:
   TreeBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
+
+  static std::unique_ptr<Expression> consume_expression_result( std::unique_ptr<Expression> );
 
   SourceLocation location_for( antlr4::ParserRuleContext& ) const;
   SourceLocation location_for( antlr4::tree::TerminalNode& ) const;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -284,13 +284,22 @@ void InstructionGenerator::visit_element_assignment( ElementAssignment& node )
 {
   visit_children( node );
   update_debug_location( node );
+  auto num_indexes = node.indexes().children.size();
   if ( node.consume )
   {
-    emit.assign_subscript_consume();
+    if ( num_indexes == 1 )
+    {
+      emit.assign_subscript_consume();
+    }
+    else
+    {
+      // there is no assign-multisubscript-consume instruction
+      emit.assign_multisubscript( num_indexes );
+      emit.consume();
+    }
   }
   else
   {
-    auto num_indexes = node.indexes().children.size();
     if ( num_indexes == 1 )
       emit.assign_subscript();
     else

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -683,6 +683,8 @@ void InstructionGenerator::visit_var_statement( VarStatement& node )
 
     emit.assign();
   }
+
+  emit.consume();
 }
 
 void InstructionGenerator::visit_variable_assignment_statement( VariableAssignmentStatement& node )

--- a/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.cpp
@@ -77,30 +77,6 @@ void ValueConsumerOptimizer::visit_binary_operator( BinaryOperator& binary_opera
   }
 }
 
-void ValueConsumerOptimizer::visit_element_assignment( ElementAssignment& node )
-{
-  if ( node.indexes().children.size() == 1 )
-  {
-    auto indexes = node.take_indexes();
-    auto entity = node.take_entity();
-    auto rhs = node.take_rhs();
-    optimized_result = std::make_unique<ElementAssignment>(
-        node.source_location, true, std::move( entity ), std::move( indexes ), std::move( rhs ) );
-  }
-}
-
-void ValueConsumerOptimizer::visit_member_assignment( MemberAssignment& node )
-{
-  if ( node.consume )
-    node.internal_error(
-        "ValueConsumerOptimizer did not expect an already-consumed SetMember node" );
-  auto entity = node.take_entity();
-  auto rhs = node.take_rhs();
-  optimized_result =
-      std::make_unique<MemberAssignment>( node.source_location, true, std::move( entity ),
-                                          node.name, std::move( rhs ), node.known_member );
-}
-
 std::unique_ptr<Statement> ValueConsumerOptimizer::optimize( ValueConsumer& consume_value )
 {
   consume_value.children.at( 0 )->accept( *this );

--- a/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/ValueConsumerOptimizer.h
@@ -17,8 +17,6 @@ public:
   void visit_children( Node& ) override;
 
   void visit_binary_operator( BinaryOperator& ) override;
-  void visit_element_assignment( ElementAssignment& ) override;
-  void visit_member_assignment( MemberAssignment& ) override;
 
   std::unique_ptr<Statement> optimize( ValueConsumer& );
 };


### PR DESCRIPTION
Also:
- `VarStatement` now handles its own value consumption (no wrapping `ValueConsumer`)
- removed three unused fields from ModuleProcessor