### PR TITLE
Refactor clientio process data

### DIFF
--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -75,7 +75,7 @@ namespace Core
 {
 using namespace Network;
 
-void handle_unknown_packet( Client* client );
+void handle_unknown_packet( Network::ThreadedClient* session );
 
 void party_cmd_handler( Client* client, PKTBI_BF* msg );
 

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -89,6 +89,8 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient 
       last_msgtype( 255 ),
       msgtype_filter( Core::networkManager.login_filter.get() ),
       checkpoint( -1 ),  // CNXBUG
+      _fpLog_lock(),
+      fpLog( "" ),
       first_xmit_buffer( nullptr ),
       last_xmit_buffer( nullptr ),
       n_queued( 0 ),
@@ -106,8 +108,6 @@ Client::Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption )
       ready( false ),
       listen_port( 0 ),
       aosresist( false ),
-      _fpLog_lock(),
-      fpLog( "" ),
       pause_count( 0 ),
       gd( new ClientGameData ),
       instance_( ++instance_counter_ ),

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -194,6 +194,9 @@ public:
   const Core::MessageTypeFilter* msgtype_filter;
 
   int checkpoint;  // CNXBUG
+  
+  mutable Clib::SpinLock _fpLog_lock;
+  std::string fpLog;
 
   sockaddr ipaddr;
 
@@ -277,10 +280,7 @@ public:
   //
   unsigned short listen_port;
   bool aosresist;  // UOClient.Cfg Entry
-
-  mutable Clib::SpinLock _fpLog_lock;
-  std::string fpLog;
-
+  
   std::string status() const;
 
   void send_pause();

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -251,6 +251,8 @@ public:
 
   void handle_msg( unsigned char* pktbuffer, int pktlen );
 
+  void send_KR_encryption_response();
+
   void setversion( const std::string& ver ) { version_ = ver; }
   const std::string& getversion() const { return version_; }
   VersionDetailStruct getversiondetail() const { return versiondetail_; }

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -720,6 +720,76 @@ void Client::handle_msg( unsigned char* pktbuffer, int pktlen )
   }
 }
 
+void Client::send_KR_encryption_response()
+{
+  Network::PktHelper::PacketOut<Network::PktOut_E3> msg;
+  msg->WriteFlipped<u16>( 77u );
+  msg->WriteFlipped<u32>( 0x03u );
+  msg->Write<u8>( 0x02u );
+  msg->Write<u8>( 0x01u );
+  msg->Write<u8>( 0x03u );
+  msg->WriteFlipped<u32>( 0x13u );
+  msg->Write<u8>( 0x02u );
+  msg->Write<u8>( 0x11u );
+  msg->Write<u8>( 0x00u );
+  msg->Write<u8>( 0xfcu );
+  msg->Write<u8>( 0x2fu );
+  msg->Write<u8>( 0xe3u );
+  msg->Write<u8>( 0x81u );
+  msg->Write<u8>( 0x93u );
+  msg->Write<u8>( 0xcbu );
+  msg->Write<u8>( 0xafu );
+  msg->Write<u8>( 0x98u );
+  msg->Write<u8>( 0xddu );
+  msg->Write<u8>( 0x83u );
+  msg->Write<u8>( 0x13u );
+  msg->Write<u8>( 0xd2u );
+  msg->Write<u8>( 0x9eu );
+  msg->Write<u8>( 0xeau );
+  msg->Write<u8>( 0xe4u );
+  msg->Write<u8>( 0x13u );
+  msg->WriteFlipped<u32>( 0x10u );
+  msg->Write<u8>( 0x78u );
+  msg->Write<u8>( 0x13u );
+  msg->Write<u8>( 0xb7u );
+  msg->Write<u8>( 0x7bu );
+  msg->Write<u8>( 0xceu );
+  msg->Write<u8>( 0xa8u );
+  msg->Write<u8>( 0xd7u );
+  msg->Write<u8>( 0xbcu );
+  msg->Write<u8>( 0x52u );
+  msg->Write<u8>( 0xdeu );
+  msg->Write<u8>( 0x38u );
+  msg->Write<u8>( 0x30u );
+  msg->Write<u8>( 0xeau );
+  msg->Write<u8>( 0xe9u );
+  msg->Write<u8>( 0x1eu );
+  msg->Write<u8>( 0xa3u );
+  msg->WriteFlipped<u32>( 0x20u );
+  msg->WriteFlipped<u32>( 0x10u );
+  msg->Write<u8>( 0x5au );
+  msg->Write<u8>( 0xceu );
+  msg->Write<u8>( 0x3eu );
+  msg->Write<u8>( 0xe3u );
+  msg->Write<u8>( 0x97u );
+  msg->Write<u8>( 0x92u );
+  msg->Write<u8>( 0xe4u );
+  msg->Write<u8>( 0x8au );
+  msg->Write<u8>( 0xf1u );
+  msg->Write<u8>( 0x9au );
+  msg->Write<u8>( 0xd3u );
+  msg->Write<u8>( 0x04u );
+  msg->Write<u8>( 0x41u );
+  msg->Write<u8>( 0x03u );
+  msg->Write<u8>( 0xcbu );
+  msg->Write<u8>( 0x53u );
+  msg.Send( this );
+}
+
+
+//
+
+
 // ThreadedClient stuff
 void ThreadedClient::process_delayed_packets()
 {

--- a/pol-core/pol/network/clientthread.h
+++ b/pol-core/pol/network/clientthread.h
@@ -10,7 +10,7 @@ class ThreadedClient;
 namespace Pol::Core
 {
 bool client_io_thread( Network::Client* client, bool login );
-bool process_data( Network::Client* client );
+bool process_data( Network::ThreadedClient* client );
 bool check_inactivity( Network::Client* client );
 
 void handle_unknown_packet( Network::ThreadedClient* session );

--- a/pol-core/pol/network/clientthread.h
+++ b/pol-core/pol/network/clientthread.h
@@ -13,9 +13,9 @@ bool client_io_thread( Network::Client* client, bool login );
 bool process_data( Network::Client* client );
 bool check_inactivity( Network::Client* client );
 
-void handle_unknown_packet( Network::Client* client );
-void handle_undefined_packet( Network::Client* client );
-void handle_humongous_packet( Network::Client* client, unsigned int reported_size );
+void handle_unknown_packet( Network::ThreadedClient* session );
+void handle_undefined_packet( Network::ThreadedClient* session );
+void handle_humongous_packet( Network::ThreadedClient* session, unsigned int reported_size );
 }  // namespace Pol::Core
 
 #endif  // CLIENTTHREAD_H

--- a/pol-core/pol/party.cpp
+++ b/pol-core/pol/party.cpp
@@ -60,7 +60,7 @@ namespace Pol
 {
 namespace Core
 {
-void handle_unknown_packet( Network::Client* client );
+void handle_unknown_packet( Network::ThreadedClient* session );
 
 Party::Party( u32 serial )
     : _member_serials(),


### PR DESCRIPTION
The goal here is to change the signature of process_data() to take a ThreadedClient*. For this, the signature of small helper functions had to be changed first. The packet logging mechanism (fpLog) was moved up to ThreadedClient. 

Also, the KR encryption response packet was extracted as a Client method to clean up process_data().