### PR TITLE
Refactor of Client to use private inheritance from ThreadedClient

### DIFF
--- a/pol-core/pol/login.cpp
+++ b/pol-core/pol/login.cpp
@@ -387,7 +387,7 @@ void send_start( Network::Client* client )
 
 void login2( Network::Client* client, PKTIN_91* msg )  // Gameserver login and character listing
 {
-  client->encrypt_server_stream = true;
+  client->start_encrypted_server_stream();
 
   if ( Network::is_banned_ip( client ) )
   {

--- a/pol-core/pol/login.cpp
+++ b/pol-core/pol/login.cpp
@@ -291,7 +291,7 @@ void select_server( Network::Client* client, PKTIN_A0* msg )  // Relay player to
 
   rsp.Send( client );
 
-  client->cryptengine->Init( &nseed, Crypt::CCryptBase::typeGame );
+  client->init_crypto( &nseed, Crypt::CCryptBase::typeGame );
 }
 
 void send_start( Network::Client* client )

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -76,6 +76,9 @@ namespace Core
 using namespace Network;
 
 void handle_unknown_packet( Network::ThreadedClient* session );
+void handle_unknown_packet(Network::Client* client) {
+  handle_unknown_packet( client->session() );
+}
 
 void party_cmd_handler( Client* client, PKTBI_BF* msg );
 

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -143,6 +143,10 @@ void Client::Delete( Client* client )
 
 Client::~Client() {}
 
+void Client::init_crypto(void* nseed, int type) {
+    session()->cryptengine->Init( nseed, type );
+}
+
 void Client::unregister()
 {
   auto findClient =

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -188,17 +188,8 @@ void Client::PreDelete()
     chr = nullptr;
   }
 
-  {
-    Clib::SpinLockGuard guard( _fpLog_lock );
-    if ( !fpLog.empty() )
-    {
-      time_t now = time( nullptr );
-      auto time = Clib::localtime( now );
-      FLEXLOG( fpLog ) << "Log closed at " << asctime( &time ) << "\n";
-      CLOSE_FLEXLOG( fpLog );
-      fpLog.clear();
-    }
-  }
+  // stop packet-logging
+  stop_log();
 
   delete gd;
   gd = nullptr;

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -686,6 +686,7 @@ weak_ptr<Client> Client::getWeakPtr() const
   return weakptr;
 }
 
+// TODO: Add estimatedSize() to ThreadedClient and move the corresponding members
 size_t Client::estimatedSize() const
 {
   Clib::SpinLockGuard guard( _fpLog_lock );

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -231,7 +231,7 @@ private:
 };
 
 
-class Client : public ThreadedClient
+class Client : private ThreadedClient
 {
 public:
   Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption );
@@ -243,6 +243,11 @@ public:
   // later these will return a member "session" instead of casting
   ThreadedClient* session() { return static_cast<ThreadedClient*>( this ); }
   const ThreadedClient* session() const { return static_cast<const ThreadedClient*>( this ); }
+
+  // these remaining three members are ok to be public for now and will be wrapped later
+  using ThreadedClient::csocket;
+  using ThreadedClient::ipaddr;
+  using ThreadedClient::msgtype_filter;
 
   // wrappers for ThreadedClient members
   PacketLog start_log();

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -131,6 +131,13 @@ typedef struct
 
 class Client;
 
+enum class PacketLog
+{
+  Error,
+  Success,
+  Unchanged
+};
+
 class ThreadedClient
 {
 public:
@@ -151,6 +158,9 @@ public:
 
   bool has_delayed_packets() const;
   void process_delayed_packets();
+
+  PacketLog start_log( std::string filename );
+  PacketLog stop_log();
 
 protected:
   ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient );
@@ -233,6 +243,10 @@ public:
   // later these will return a member "session" instead of casting
   ThreadedClient* session() { return static_cast<ThreadedClient*>( this ); }
   const ThreadedClient* session() const { return static_cast<const ThreadedClient*>( this ); }
+
+  // wrappers for ThreadedClient members
+  PacketLog start_log();
+  PacketLog stop_log();
 
   void start_encrypted_server_stream() { session()->encrypt_server_stream = true; }
 

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -194,7 +194,7 @@ public:
   const Core::MessageTypeFilter* msgtype_filter;
 
   int checkpoint;  // CNXBUG
-  
+
   mutable Clib::SpinLock _fpLog_lock;
   std::string fpLog;
 
@@ -229,6 +229,10 @@ public:
   Client& operator=( const Client& ) = delete;
   static void Delete( Client* client );
   size_t estimatedSize() const;
+
+  // later these will return a member "session" instead of casting
+  ThreadedClient* session() { return static_cast<ThreadedClient*>( this ); }
+  const ThreadedClient* session() const { return static_cast<const ThreadedClient*>( this ); }
 
 protected:
   void PreDelete();
@@ -282,7 +286,7 @@ public:
   //
   unsigned short listen_port;
   bool aosresist;  // UOClient.Cfg Entry
-  
+
   std::string status() const;
 
   void send_pause();
@@ -343,7 +347,7 @@ inline bool ThreadedClient::isConnected() const
 }
 inline bool ThreadedClient::has_delayed_packets() const
 {
-    return !myClient.movementqueue.empty();
+  return !myClient.movementqueue.empty();
 }
 
 inline bool Client::isActive() const

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -249,6 +249,7 @@ public:
   PacketLog stop_log();
 
   void start_encrypted_server_stream() { session()->encrypt_server_stream = true; }
+  void init_crypto( void* nseed, int type );
 
   std::string ipaddrAsString() const { return session()->ipaddrAsString(); }
 

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -234,6 +234,17 @@ public:
   ThreadedClient* session() { return static_cast<ThreadedClient*>( this ); }
   const ThreadedClient* session() const { return static_cast<const ThreadedClient*>( this ); }
 
+  void start_encrypted_server_stream() { session()->encrypt_server_stream = true; }
+
+  std::string ipaddrAsString() const { return session()->ipaddrAsString(); }
+
+  bool isConnected() const { return session()->isConnected(); }
+  bool isReallyConnected() const { return session()->isReallyConnected(); }
+  void forceDisconnect() { session()->forceDisconnect(); }
+
+  Core::polclock_t last_activity_at() { return session()->last_activity_at; }
+  Core::polclock_t last_packet_at() { return session()->last_packet_at; }
+
 protected:
   void PreDelete();
   ~Client();

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -39,7 +39,7 @@
 #include "pktinid.h"
 #include <format/format.h>
 
-#define CLIENT_CHECKPOINT( x ) client->checkpoint = x
+#define CLIENT_CHECKPOINT( x ) client->session()->checkpoint = x
 #define SESSION_CHECKPOINT( x ) session->checkpoint = x
 
 namespace Pol::Core
@@ -239,17 +239,17 @@ bool client_io_thread( Network::Client* client, bool login )
   catch ( std::string& str )
   {
     POLLOG_ERROR.Format( "Client#{}: Exception in i/o thread: {}! (checkpoint={})\n" )
-        << client->instance_ << str << client->checkpoint;
+        << client->instance_ << str << client->session()->checkpoint;
   }
   catch ( const char* msg )
   {
     POLLOG_ERROR.Format( "Client#{}: Exception in i/o thread: {}! (checkpoint={})\n" )
-        << client->instance_ << msg << client->checkpoint;
+        << client->instance_ << msg << client->session()->checkpoint;
   }
   catch ( std::exception& ex )
   {
     POLLOG_ERROR.Format( "Client#{}: Exception in i/o thread: {}! (checkpoint={})\n" )
-        << client->instance_ << ex.what() << client->checkpoint;
+        << client->instance_ << ex.what() << client->session()->checkpoint;
   }
   CLIENT_CHECKPOINT( 20 );
 
@@ -267,7 +267,7 @@ bool client_io_thread( Network::Client* client, bool login )
   catch ( std::exception& ex )
   {
     POLLOG.Format( "Client#{}: Exception in i/o thread: {}! (checkpoint={}, what={})\n" )
-        << client->instance_ << client->checkpoint << ex.what();
+        << client->instance_ << client->session()->checkpoint << ex.what();
   }
 
   // queue delete of client ptr see method doc for reason

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -66,7 +66,7 @@ void set_polling_timeouts( Clib::SinglePoller& poller, bool single_threaded_logi
 
 // Taking a reference to SinglePoller is ugly here. But io_step, io_loop and clientpoller will
 // eventually move into the same class.
-bool threadedclient_io_step( Network::Client* session, Clib::SinglePoller& clientpoller,
+bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePoller& clientpoller,
                              int& nidle )
 {
   SESSION_CHECKPOINT( 1 );
@@ -173,7 +173,7 @@ bool threadedclient_io_step( Network::Client* session, Clib::SinglePoller& clien
   return true;
 }  // namespace Pol::Core
 
-void threadedclient_io_loop( Network::Client* session, bool login )
+void threadedclient_io_loop( Network::ThreadedClient* session, bool login )
 {
   int nidle = 0;
   session->last_packet_at = polclock();
@@ -200,27 +200,27 @@ void threadedclient_sleep_until( polclock_t when_logoff )
   }
 }
 
-void threadedclient_io_finalize( Network::Client* client )
+void threadedclient_io_finalize( Network::ThreadedClient* session )
 {
   int seconds_wait = 0;
   {
-    CLIENT_CHECKPOINT( 9 );
+    SESSION_CHECKPOINT( 9 );
     PolLock lck;
-    seconds_wait = client->on_close();
+    seconds_wait = session->myClient.on_close();
   }
 
-  CLIENT_CHECKPOINT( 10 );
+  SESSION_CHECKPOINT( 10 );
   if ( seconds_wait > 0 )
   {
-    polclock_t when_logoff = client->last_activity_at + seconds_wait * POLCLOCKS_PER_SEC;
+    polclock_t when_logoff = session->last_activity_at + seconds_wait * POLCLOCKS_PER_SEC;
     threadedclient_sleep_until( when_logoff );
   }
 
-  CLIENT_CHECKPOINT( 15 );
-  if ( client->chr )
+  SESSION_CHECKPOINT( 15 );
+  if ( session->myClient.chr )
   {
     PolLock lck;
-    client->on_logoff();
+    session->myClient.on_logoff();
   }
 }
 
@@ -234,7 +234,7 @@ bool client_io_thread( Network::Client* client, bool login )
   CLIENT_CHECKPOINT( 0 );
   try
   {
-    threadedclient_io_loop( client, login );
+    threadedclient_io_loop( client->session(), login );
   }
   catch ( std::string& str )
   {
@@ -262,7 +262,7 @@ bool client_io_thread( Network::Client* client, bool login )
 
   try
   {
-    threadedclient_io_finalize( client );
+    threadedclient_io_finalize( client->session() );
   }
   catch ( std::exception& ex )
   {
@@ -484,9 +484,10 @@ bool process_data( Network::ThreadedClient* session )
   return false;
 }
 
-bool check_inactivity( Network::Client* client )
+// TODO: We may want to take a buffer directly here instead of a ThreadedClient
+bool check_inactivity( Network::ThreadedClient* session )
 {
-  switch ( client->buffer[0] )
+  switch ( session->buffer[0] )
   {
   case PKTBI_73_ID:
   // Fallthrough
@@ -495,7 +496,7 @@ bool check_inactivity( Network::Client* client )
   case PKTBI_D6_IN_ID:
     return true;
   case PKTBI_BF_ID:
-    if ( ( client->buffer[3] == 0 ) && ( client->buffer[4] == PKTBI_BF::TYPE_SESPAM ) )
+    if ( ( session->buffer[3] == 0 ) && ( session->buffer[4] == PKTBI_BF::TYPE_SESPAM ) )
       return true;
     break;
   default:

--- a/pol-core/pol/network/clientthread.h
+++ b/pol-core/pol/network/clientthread.h
@@ -11,7 +11,7 @@ namespace Pol::Core
 {
 bool client_io_thread( Network::Client* client, bool login );
 bool process_data( Network::ThreadedClient* client );
-bool check_inactivity( Network::Client* client );
+bool check_inactivity( Network::ThreadedClient* session );
 
 void handle_unknown_packet( Network::ThreadedClient* session );
 void handle_undefined_packet( Network::ThreadedClient* session );

--- a/pol-core/pol/party.cpp
+++ b/pol-core/pol/party.cpp
@@ -981,7 +981,7 @@ void party_cmd_handler( Network::Client* client, PKTBI_BF* msg )
     handle_decline_invite( client, msg );
     break;
   default:
-    handle_unknown_packet( client );
+    handle_unknown_packet( client->session() );
   }
 }
 

--- a/pol-core/pol/pol.cpp
+++ b/pol-core/pol/pol.cpp
@@ -693,7 +693,7 @@ void threadstatus_thread( void )
       for ( const auto& client : Core::networkManager.clients )
         tmp << " " << client->ipaddrAsString() << " "
             << ( client->acct == nullptr ? "prelogin " : client->acct->name() ) << " "
-            << client->checkpoint << "\n";
+            << client->session()->checkpoint << "\n";
       if ( stateManager.polsig.check_attack_after_move_function_checkpoint )
         tmp << "check_attack_after_move() Checkpoint: "
             << stateManager.polsig.check_attack_after_move_function_checkpoint << "\n";

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -47,7 +47,7 @@ void UoClientThread::run()
     if ( !create() )
       return;
   }
-  client->thread_pid = threadhelp::thread_pid();
+  client->session()->thread_pid = threadhelp::thread_pid();
   client_io_thread( client );
 }
 

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -69,14 +69,17 @@ bool UoClientThread::create()
 
   PolLock lck;
   client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption );
+  
+  // TODO: move this into an initialization of ThreadedClient.
   client->csocket = _sck.release_handle();  // client cleans up its socket.
+  memcpy( &client->ipaddr, &client_addr, sizeof client->ipaddr );
+
   if ( _def->sticky )
     client->listen_port = _def->port;
   if ( _def->aosresist )
     client->aosresist = true;  // UOCLient.cfg Entry
   // Added null setting for pre-char selection checks using nullptr validation
   client->acct = nullptr;
-  memcpy( &client->ipaddr, &client_addr, sizeof client->ipaddr );
 
   networkManager.clients.push_back( client );
   CoreSetSysTrayToolTip( Clib::tostring( networkManager.clients.size() ) + " clients connected",

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -4664,10 +4664,10 @@ BObjectRef EClientRefObjImp::get_member_id( const int id )
     return BObjectRef( new BLong( obj_->UOExpansionFlagClient ) );
     break;
   case MBR_LAST_ACTIVITY_AT:
-    return BObjectRef( new BLong( obj_->last_activity_at ) );
+    return BObjectRef( new BLong( obj_->last_activity_at() ) );
     break;
   case MBR_LAST_PACKET_AT:
-    return BObjectRef( new BLong( obj_->last_packet_at ) );
+    return BObjectRef( new BLong( obj_->last_packet_at() ) );
     break;
   case MBR_PORT:
     return BObjectRef( new BLong( obj_->listen_port ) );


### PR DESCRIPTION
Please check the individual commits for details. Basically:
- Changed remaining clientthread functions to take a `ThreadedClient*` instead of a `Client*`
- Extracted `start_log`/`stop_log` as methods in ThreadedClient.
- Added a wrapper for `start_log`/`stop_log` to Client.
- Added simple wrappers of misc. members and methods of ThreadedClient as methods of Client

Remaining members from ThreadedClient that were made public in Client: `csocket`, `ipaddr`, `msgtype_filter`. Those are used all over the place and will be properly wrapped once ThreadedClient is a member of Client instead of a private base class.
