### PR TITLE
Fix boat packet overflow and add setting to control the refresh of decay timer for items on a boat's deck

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -347,6 +347,7 @@ Spell (int spellid)
 [HiddenTurnsCount               (0/1 {default 1})]
 [ItemColorMask                  (int mask {default 0xfff})]
 [DecayItems                     (0/1 {default 1})]
+[RefreshDecayAfterBoatMoves     (0/1 {default 1})]
 [UseTileFlagPrefix              (0/1 {default 1})]
 [UseWinLFH                      (0/1 {default 0})]
 [EventVisibilityCoreChecks      (0/1 {default 0})]
@@ -385,6 +386,7 @@ Spell (int spellid)
 [DefaultCharacterHeight         (1-32 {default 15})]
 [EnableWorldMapPackets          (0/1 (default 0))]
 </structure>
+  <explain><i>RefreshDecayAfterBoatMoves</i> if enabled item's decayat will be refreshed after each move or turn of a boat. Note that item decay on boats is not yet handled by the core.</explain>
   <explain><i>TotalStatsAtCreation:</i> takes a comma-delimited lists of values and/or ranges (default = '65,80'). Example: TotalStatsAtCreation=65,80,90-95,100-110</explain>
   <explain><i>MovementUsesStamina:</i> if enabled stamina costs are defined in movecost.cfg</explain>
   <explain><i>DefaultContainerMaxItems:</i> default is 125, DefaultContainerMaxWeight default is 250. itemdesc.cfg "MaxItems" and "MaxWeight" override these defaults.</explain>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,18 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>03-05-2021</datemodified>
+		<datemodified>03-07-2021</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>03-07-2021</date>
+			<author>Nando:</author>
+			<change type="Added">RefreshDecayAfterBoatMoves in servspecopt.cfg. Defaults to true to maintain the old behavior. If this setting is true,<br/>
+the items on deck will be refreshed after each movement or turn. You might want to disable this to implement item decay<br/>
+on boats. Note that POL doesn't yet handle item decay on boats.</change>
+			<change type="Fixed">HSA boat movement packets (0xF7 and 0xF6) will no longer overflow when too many items are on deck. Note that the packet<br/>
+will be truncated and might be misinterpreted by the client or leave ghost items behind.</change>
+		</entry>
 		<entry>
 			<date>03-05-2021</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,10 @@
 ﻿-- POL100.1.0 --
+03-07-2021 Nando:
+    Added: RefreshDecayAfterBoatMoves in servspecopt.cfg. Defaults to true to maintain the old behavior. If this setting is true,
+           the items on deck will be refreshed after each movement or turn. You might want to disable this to implement item decay 
+           on boats. Note that POL doesn't yet handle item decay on boats.
+    Fixed: HSA boat movement packets (0xF7 and 0xF6) will no longer overflow when too many items are on deck. Note that the packet
+           will be truncated and might be misinterpreted by the client or leave ghost items behind.
 03-05-2021 Kevin:
   Removed: The ability to generate the Escript wordlist via the -W argument to ecompile.exe has been removed. The Escript grammar can be
            described by the ANTLR .g4 files in the repository.

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -853,7 +853,8 @@ void UBoat::move_travellers( Plib::UFACING move_dir, const BoatContext& oldlocat
         item->x = newx + dx;
         item->y = newy + dy;
 
-        item->restart_decay_timer();
+        if ( Core::settingsManager.ssopt.refresh_decay_after_boat_moves )
+          item->restart_decay_timer();
         MoveItemWorldPosition( oldx, oldy, item, oldrealm );
       }
       else
@@ -866,7 +867,8 @@ void UBoat::move_travellers( Plib::UFACING move_dir, const BoatContext& oldlocat
         item->x += Core::move_delta[move_dir].xmove;
         item->y += Core::move_delta[move_dir].ymove;
 
-        item->restart_decay_timer();
+        if ( Core::settingsManager.ssopt.refresh_decay_after_boat_moves )
+          item->restart_decay_timer();
         MoveItemWorldPosition( oldx, oldy, item, nullptr );
       }
 
@@ -1018,8 +1020,8 @@ void UBoat::turn_travellers( RELATIVE_DIR dir, const BoatContext& oldlocation )
       item->x = newx;
       item->y = newy;
 
-      item->restart_decay_timer();
-
+      if ( Core::settingsManager.ssopt.refresh_decay_after_boat_moves )
+        item->restart_decay_timer();
       MoveItemWorldPosition( oldx, oldy, item, nullptr );
 
       Core::WorldIterator<Core::OnlinePlayerFilter>::InRange(

--- a/pol-core/pol/ssopt.cpp
+++ b/pol-core/pol/ssopt.cpp
@@ -62,6 +62,8 @@ void ServSpecOpt::read_servspecopt()
   settingsManager.ssopt.dblclick_wait = elem.remove_ulong( "DoubleClickWait", 0 );
   settingsManager.ssopt.decay_items = elem.remove_bool( "DecayItems", true );
   settingsManager.ssopt.default_decay_time = elem.remove_ulong( "DefaultDecayTime", 10 );
+  settingsManager.ssopt.refresh_decay_after_boat_moves =
+      elem.remove_bool( "RefreshDecayAfterBoatMoves", true );
   settingsManager.ssopt.default_doubleclick_range =
       elem.remove_ushort( "DefaultDoubleclickRange", 2 );
   settingsManager.ssopt.default_accessible_range =

--- a/pol-core/pol/ssopt.h
+++ b/pol-core/pol/ssopt.h
@@ -43,6 +43,7 @@ struct ServSpecOpt
   unsigned int dblclick_wait;
   bool decay_items;
   unsigned int default_decay_time;
+  bool refresh_decay_after_boat_moves;
   unsigned short default_doubleclick_range;
   int default_accessible_range;
   unsigned short default_light_level;


### PR DESCRIPTION
HSA movement packets (0xF7 and 0xF6) were overflowing for boats with too many items on deck. Added option to disable the refresh of item decay timer for items on deck after each movement. This setting will be useful to control item decay via script.