### PR TITLE
Fix crash in SendPacket(), packet.SendPacket() and DisconnectClient()...

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -6,7 +6,12 @@
 	</header>
 	<version name="POL100">
 		<entry>
-			<date>02-27-2020</date>
+			<date>02-27-2021</date>
+			<author>Nando:</author>
+			<change type="Fixed">Crash in SendPacket(), packet.SendPacket() and DisconnectClient() when the client was not yet logged in. Mostly affects packet hooks.</change>
+		</entry>
+		<entry>
+			<date>02-27-2021</date>
 			<author>Turley, Kevin:</author>
 			<change type="Added">os::GetEnvironmentVariable(name:=&quot;&quot;)<br/>
 Returns String value of given environment variable name. If name is empty, returns Dictionary of all allowed environment variables.<br/>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,7 +1,9 @@
 ﻿-- POL100 --
-02-27-2020 Turley, Kevin:
+02-27-2021 Nando:
+    Fixed: Crash in SendPacket(), packet.SendPacket() and DisconnectClient() when the client was not yet logged in. Mostly affects packet hooks.
+02-27-2021 Turley, Kevin:
     Added: os::GetEnvironmentVariable(name:="")
-           Returns String value of given environment variable name. If name is empty, returns Dictionary of all environment variables.
+           Returns String value of given environment variable name. If name is empty, returns Dictionary of all allowed environment variables.
            The pol.cfg setting AllowedEnvironmentVariablesAccess controls script access to this function. See documentation for more details.
 02-22-2021 Kevin:
     Fixed: Various compilation issues when using "\\" in scripts.

--- a/pol-core/pol/uoexec.cpp
+++ b/pol-core/pol/uoexec.cpp
@@ -213,6 +213,9 @@ using namespace Module;
 bool UOExecutor::getCharacterOrClientParam( unsigned param, Mobile::Character*& chrptr,
                                             Network::Client*& clientptr )
 {
+  chrptr = nullptr;
+  clientptr = nullptr;
+
   BObjectImp* imp = getParamImp( param );
   if ( imp == nullptr )
   {


### PR DESCRIPTION
… when the client was not yet logged in.

Those functions expected chrptr to be null when a character wasn't assigned to a client, but they instead got an uninitialized pointer. This caused a memory access error that crashed POL. Initializing those pointers to null fixes the issue.