### PR TITLE
Small changes to the internal webserver

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,6 +8,8 @@
 		<entry>
 			<date>02-27-2021</date>
 			<author>Nando:</author>
+			<change type="Added">Default mimetypes for .png, .js and .ico in the internal webserver</change>
+			<change type="Added">Allow URLs/filenames with a hyphen (-) in the internal webserver</change>
 			<change type="Fixed">Crash in SendPacket(), packet.SendPacket() and DisconnectClient() when the client was not yet logged in. Mostly affects packet hooks.</change>
 		</entry>
 		<entry>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,5 +1,7 @@
 ﻿-- POL100 --
 02-27-2021 Nando:
+    Added: Default mimetypes for .png, .js and .ico in the internal webserver
+    Added: Allow URLs/filenames with a hyphen (-) in the internal webserver
     Fixed: Crash in SendPacket(), packet.SendPacket() and DisconnectClient() when the client was not yet logged in. Mostly affects packet hooks.
 02-27-2021 Turley, Kevin:
     Added: os::GetEnvironmentVariable(name:="")

--- a/pol-core/pol/polwww.cpp
+++ b/pol-core/pol/polwww.cpp
@@ -80,6 +80,9 @@ void load_mime_config( void )
     gamestate.mime_types["jpg"] = "image/jpeg";
     gamestate.mime_types["jpeg"] = "image/jpeg";
     gamestate.mime_types["gif"] = "image/gif";
+    gamestate.mime_types["png"] = "image/png";
+    gamestate.mime_types["js"] = "text/javascript";
+    gamestate.mime_types["ico"] = "image/x-icon";
     return;
   }
 
@@ -312,7 +315,7 @@ bool legal_pagename( const std::string& page )
   for ( const char* t = page.c_str(); *t; ++t )
   {
     char ch = *t;
-    if ( isalnum( ch ) || ( ch == '/' ) || ( ch == '_' ) )
+    if ( isalnum( ch ) || ( ch == '/' ) || ( ch == '_' ) || (ch == '-') )
     {
       continue;
     }


### PR DESCRIPTION
Adds new default mimetypes for png, js and ico to the internal webserver.
Also allows file names with hyphen (-) on them.