### PR TITLE
Diagnostics: Improved highlighting from parse tree

### DIFF
--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -143,12 +143,16 @@ std::unique_ptr<CompilerWorkspace> Compiler::analyze( const std::string& pathnam
 {
   // Let's see how this explodes...
   std::unique_ptr<CompilerWorkspace> workspace = build_workspace( pathname, report, is_module );
-  register_constants( *workspace, report );
-  optimize( *workspace, report );
-  disambiguate( *workspace, report );
-  analyze( *workspace, report );
-  tokenize( *workspace );
-  return workspace;
+  if ( workspace )
+  {
+    register_constants( *workspace, report );
+    optimize( *workspace, report );
+    disambiguate( *workspace, report );
+    analyze( *workspace, report );
+    tokenize( *workspace );
+    return workspace;
+  }
+  return {};
 }
 
 std::unique_ptr<CompilerWorkspace> Compiler::build_workspace( const std::string& pathname,

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -280,7 +280,16 @@ void SemanticAnalyzer::visit_function_call( FunctionCall& fc )
   bool any_named = false;
 
   std::vector<std::unique_ptr<Argument>> arguments = fc.take_arguments();
-  auto parameters = fc.parameters();
+  auto params = fc.parameters();
+  if ( !params )
+  {
+    // The error is reported via FunctionResolver when called by
+    // CompierWorkspaceBuilder::build_referenced_user_functions. We just need to
+    // skip all of this.
+    return;
+  }
+
+  auto parameters = *params;
 
   for ( auto& arg_unique_ptr : arguments )
   {

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -14,7 +14,7 @@ void SemanticTokensBuilder::build()
 {
   if ( workspace.source )
   {
-    workspace.tokens = workspace.source->get_tokens( workspace.scope_tree );
+    workspace.tokens = workspace.source->get_tokens();
     workspace.source->accept( *this );
   }
 }

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -1,13 +1,8 @@
 #include "SemanticTokensBuilder.h"
-#include "bscript/compiler/ast/Identifier.h"
-#include "bscript/compiler/ast/NodeVisitor.h"
-#include "bscript/compiler/ast/StringValue.h"
-#include "bscript/compiler/ast/TopLevelStatements.h"
 #include "bscript/compiler/file/SourceFile.h"
 #include "bscript/compiler/model/CompilerWorkspace.h"
 
-#include <iostream>
-
+using namespace EscriptGrammar;
 namespace Pol::Bscript::Compiler
 {
 SemanticTokensBuilder::SemanticTokensBuilder( CompilerWorkspace& workspace )
@@ -20,7 +15,182 @@ void SemanticTokensBuilder::build()
   if ( workspace.source )
   {
     workspace.tokens = workspace.source->get_tokens( workspace.scope_tree );
+    workspace.source->accept( *this );
   }
+}
+
+void define( CompilerWorkspace& workspace, antlr4::Token* symbol, SemanticTokenType type )
+{
+  size_t line = symbol->getLine();
+  size_t character = symbol->getCharPositionInLine() + 1;
+  size_t token_length = symbol->getText().length();
+  workspace.tokens.push_back( SemanticToken{ line, character, token_length, type, {} } );
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionParameter(
+    EscriptParser::ModuleFunctionParameterContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
+    EscriptParser::StringIdentifierContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::NAMESPACE );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitForeachIterableExpression(
+    EscriptParser::ForeachIterableExpressionContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::NAMESPACE );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitForeachStatement(
+    EscriptParser::ForeachStatementContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitEnumStatement( EscriptParser::EnumStatementContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitEnumListEntry( EscriptParser::EnumListEntryContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitSwitchLabel( EscriptParser::SwitchLabelContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitBasicForStatement(
+    EscriptParser::BasicForStatementContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitVariableDeclaration(
+    EscriptParser::VariableDeclarationContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitProgramParameter(
+    EscriptParser::ProgramParameterContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitFunctionParameter(
+    EscriptParser::FunctionParameterContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitScopedFunctionCall(
+    EscriptParser::ScopedFunctionCallContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::NAMESPACE );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitFunctionReference(
+    EscriptParser::FunctionReferenceContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitPrimary( EscriptParser::PrimaryContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitNavigationSuffix(
+    EscriptParser::NavigationSuffixContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::PROPERTY );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitMethodCallSuffix(
+    EscriptParser::MethodCallSuffixContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitFunctionDeclaration(
+    EscriptParser::FunctionDeclarationContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+
+antlrcpp::Any SemanticTokensBuilder::visitFunctionCall( EscriptParser::FunctionCallContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
+antlrcpp::Any SemanticTokensBuilder::visitStructInitializerExpression(
+    EscriptParser::StructInitializerExpressionContext* ctx )
+{
+  if ( auto identifier = ctx->IDENTIFIER() )
+  {
+    define( workspace, identifier->getSymbol(), SemanticTokenType::PROPERTY );
+  }
+  visitChildren( ctx );
+  return antlrcpp::Any();
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -19,7 +19,7 @@ void SemanticTokensBuilder::build()
 {
   if ( workspace.source )
   {
-    workspace.tokens = workspace.source->get_tokens();
+    workspace.tokens = workspace.source->get_tokens( workspace.scope_tree );
   }
 }
 

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -19,18 +19,27 @@ void SemanticTokensBuilder::build()
   }
 }
 
-void define( CompilerWorkspace& workspace, antlr4::Token* symbol, SemanticTokenType type )
+void define( CompilerWorkspace& workspace, antlr4::tree::TerminalNode* node,
+             SemanticTokenType type )
 {
-  size_t line = symbol->getLine();
-  size_t character = symbol->getCharPositionInLine() + 1;
-  size_t token_length = symbol->getText().length();
-  workspace.tokens.push_back( SemanticToken{ line, character, token_length, type, {} } );
+  // Since we no longer fast-fail after parser errors, it is possible that nodes
+  // do not exist.
+  if ( node )
+  {
+    if ( auto symbol = node->getSymbol() )
+    {
+      size_t line = symbol->getLine();
+      size_t character = symbol->getCharPositionInLine() + 1;
+      size_t token_length = symbol->getText().length();
+      workspace.tokens.push_back( SemanticToken{ line, character, token_length, type, {} } );
+    }
+  }
 }
 
 antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionParameter(
     EscriptParser::ModuleFunctionParameterContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::PARAMETER );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -38,13 +47,10 @@ antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionParameter(
 antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
     EscriptParser::StringIdentifierContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    // stringIdentifier is currently produced in useDeclaration and
-    // includeDeclaration, so this will highlight both "use uo" and "include
-    // utils" as namespaces.
-    define( workspace, identifier->getSymbol(), SemanticTokenType::NAMESPACE );
-  }
+  // stringIdentifier is currently produced in useDeclaration and
+  // includeDeclaration, so this will highlight both "use uo" and "include
+  // utils" as namespaces.
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::NAMESPACE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -52,7 +58,7 @@ antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
 antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionDeclaration(
     EscriptParser::ModuleFunctionDeclarationContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -60,7 +66,7 @@ antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionDeclaration(
 antlrcpp::Any SemanticTokensBuilder::visitProgramDeclaration(
     EscriptParser::ProgramDeclarationContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -68,10 +74,7 @@ antlrcpp::Any SemanticTokensBuilder::visitProgramDeclaration(
 antlrcpp::Any SemanticTokensBuilder::visitForeachIterableExpression(
     EscriptParser::ForeachIterableExpressionContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
-  }
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -79,31 +82,28 @@ antlrcpp::Any SemanticTokensBuilder::visitForeachIterableExpression(
 antlrcpp::Any SemanticTokensBuilder::visitForeachStatement(
     EscriptParser::ForeachStatementContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
 
 antlrcpp::Any SemanticTokensBuilder::visitEnumStatement( EscriptParser::EnumStatementContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
 
 antlrcpp::Any SemanticTokensBuilder::visitEnumListEntry( EscriptParser::EnumListEntryContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
 
 antlrcpp::Any SemanticTokensBuilder::visitSwitchLabel( EscriptParser::SwitchLabelContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
-  }
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -111,7 +111,7 @@ antlrcpp::Any SemanticTokensBuilder::visitSwitchLabel( EscriptParser::SwitchLabe
 antlrcpp::Any SemanticTokensBuilder::visitBasicForStatement(
     EscriptParser::BasicForStatementContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -119,7 +119,7 @@ antlrcpp::Any SemanticTokensBuilder::visitBasicForStatement(
 antlrcpp::Any SemanticTokensBuilder::visitVariableDeclaration(
     EscriptParser::VariableDeclarationContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -127,7 +127,7 @@ antlrcpp::Any SemanticTokensBuilder::visitVariableDeclaration(
 antlrcpp::Any SemanticTokensBuilder::visitProgramParameter(
     EscriptParser::ProgramParameterContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::PARAMETER );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -135,7 +135,7 @@ antlrcpp::Any SemanticTokensBuilder::visitProgramParameter(
 antlrcpp::Any SemanticTokensBuilder::visitFunctionParameter(
     EscriptParser::FunctionParameterContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::PARAMETER );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -143,7 +143,7 @@ antlrcpp::Any SemanticTokensBuilder::visitFunctionParameter(
 antlrcpp::Any SemanticTokensBuilder::visitScopedFunctionCall(
     EscriptParser::ScopedFunctionCallContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::NAMESPACE );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::NAMESPACE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -151,17 +151,14 @@ antlrcpp::Any SemanticTokensBuilder::visitScopedFunctionCall(
 antlrcpp::Any SemanticTokensBuilder::visitFunctionReference(
     EscriptParser::FunctionReferenceContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
 
 antlrcpp::Any SemanticTokensBuilder::visitPrimary( EscriptParser::PrimaryContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
-  }
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::VARIABLE );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -169,10 +166,7 @@ antlrcpp::Any SemanticTokensBuilder::visitPrimary( EscriptParser::PrimaryContext
 antlrcpp::Any SemanticTokensBuilder::visitNavigationSuffix(
     EscriptParser::NavigationSuffixContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::PROPERTY );
-  }
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::PROPERTY );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -180,7 +174,7 @@ antlrcpp::Any SemanticTokensBuilder::visitNavigationSuffix(
 antlrcpp::Any SemanticTokensBuilder::visitMethodCallSuffix(
     EscriptParser::MethodCallSuffixContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -188,7 +182,7 @@ antlrcpp::Any SemanticTokensBuilder::visitMethodCallSuffix(
 antlrcpp::Any SemanticTokensBuilder::visitFunctionDeclaration(
     EscriptParser::FunctionDeclarationContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -196,7 +190,7 @@ antlrcpp::Any SemanticTokensBuilder::visitFunctionDeclaration(
 
 antlrcpp::Any SemanticTokensBuilder::visitFunctionCall( EscriptParser::FunctionCallContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::FUNCTION );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -204,10 +198,7 @@ antlrcpp::Any SemanticTokensBuilder::visitFunctionCall( EscriptParser::FunctionC
 antlrcpp::Any SemanticTokensBuilder::visitStructInitializerExpression(
     EscriptParser::StructInitializerExpressionContext* ctx )
 {
-  if ( auto identifier = ctx->IDENTIFIER() )
-  {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::PROPERTY );
-  }
+  define( workspace, ctx->IDENTIFIER(), SemanticTokenType::PROPERTY );
   visitChildren( ctx );
   return antlrcpp::Any();
 }

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -49,6 +49,14 @@ antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
   return antlrcpp::Any();
 }
 
+antlrcpp::Any SemanticTokensBuilder::visitProgramDeclaration(
+    EscriptParser::ProgramDeclarationContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
 antlrcpp::Any SemanticTokensBuilder::visitForeachIterableExpression(
     EscriptParser::ForeachIterableExpressionContext* ctx )
 {

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -49,6 +49,14 @@ antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
   return antlrcpp::Any();
 }
 
+antlrcpp::Any SemanticTokensBuilder::visitModuleFunctionDeclaration(
+    EscriptParser::ModuleFunctionDeclarationContext* ctx )
+{
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::FUNCTION );
+  visitChildren( ctx );
+  return antlrcpp::Any();
+}
+
 antlrcpp::Any SemanticTokensBuilder::visitProgramDeclaration(
     EscriptParser::ProgramDeclarationContext* ctx )
 {

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.cpp
@@ -40,6 +40,9 @@ antlrcpp::Any SemanticTokensBuilder::visitStringIdentifier(
 {
   if ( auto identifier = ctx->IDENTIFIER() )
   {
+    // stringIdentifier is currently produced in useDeclaration and
+    // includeDeclaration, so this will highlight both "use uo" and "include
+    // utils" as namespaces.
     define( workspace, identifier->getSymbol(), SemanticTokenType::NAMESPACE );
   }
   visitChildren( ctx );
@@ -51,7 +54,7 @@ antlrcpp::Any SemanticTokensBuilder::visitForeachIterableExpression(
 {
   if ( auto identifier = ctx->IDENTIFIER() )
   {
-    define( workspace, identifier->getSymbol(), SemanticTokenType::NAMESPACE );
+    define( workspace, identifier->getSymbol(), SemanticTokenType::VARIABLE );
   }
   visitChildren( ctx );
   return antlrcpp::Any();
@@ -108,7 +111,7 @@ antlrcpp::Any SemanticTokensBuilder::visitVariableDeclaration(
 antlrcpp::Any SemanticTokensBuilder::visitProgramParameter(
     EscriptParser::ProgramParameterContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
   visitChildren( ctx );
   return antlrcpp::Any();
 }
@@ -116,7 +119,7 @@ antlrcpp::Any SemanticTokensBuilder::visitProgramParameter(
 antlrcpp::Any SemanticTokensBuilder::visitFunctionParameter(
     EscriptParser::FunctionParameterContext* ctx )
 {
-  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::VARIABLE );
+  define( workspace, ctx->IDENTIFIER()->getSymbol(), SemanticTokenType::PARAMETER );
   visitChildren( ctx );
   return antlrcpp::Any();
 }

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
@@ -16,6 +16,8 @@ public:
 
   void build();
 
+  antlrcpp::Any visitModuleFunctionDeclaration(
+      EscriptGrammar::EscriptParser::ModuleFunctionDeclarationContext* ctx ) override;
   antlrcpp::Any visitModuleFunctionParameter(
       EscriptGrammar::EscriptParser::ModuleFunctionParameterContext* ctx ) override;
   antlrcpp::Any visitFunctionDeclaration(

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
@@ -22,6 +22,8 @@ public:
       EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx ) override;
   antlrcpp::Any visitStringIdentifier(
       EscriptGrammar::EscriptParser::StringIdentifierContext* ctx ) override;
+  antlrcpp::Any visitProgramDeclaration(
+      EscriptGrammar::EscriptParser::ProgramDeclarationContext* ctx ) override;
   antlrcpp::Any visitForeachIterableExpression(
       EscriptGrammar::EscriptParser::ForeachIterableExpressionContext* ctx ) override;
   antlrcpp::Any visitForeachStatement(

--- a/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticTokensBuilder.h
@@ -2,20 +2,56 @@
 #define POLSERVER_SEMANTICTOKENSBUILDER_H
 
 #include "bscript/compiler/model/SemanticTokens.h"
-#include <initializer_list>
-#include <vector>
+#include <EscriptGrammar/EscriptParserBaseVisitor.h>
 
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
 class Report;
 
-class SemanticTokensBuilder
+class SemanticTokensBuilder : public EscriptGrammar::EscriptParserBaseVisitor
 {
 public:
   SemanticTokensBuilder( CompilerWorkspace& workspace );
 
   void build();
+
+  antlrcpp::Any visitModuleFunctionParameter(
+      EscriptGrammar::EscriptParser::ModuleFunctionParameterContext* ctx ) override;
+  antlrcpp::Any visitFunctionDeclaration(
+      EscriptGrammar::EscriptParser::FunctionDeclarationContext* ctx ) override;
+  antlrcpp::Any visitStringIdentifier(
+      EscriptGrammar::EscriptParser::StringIdentifierContext* ctx ) override;
+  antlrcpp::Any visitForeachIterableExpression(
+      EscriptGrammar::EscriptParser::ForeachIterableExpressionContext* ctx ) override;
+  antlrcpp::Any visitForeachStatement(
+      EscriptGrammar::EscriptParser::ForeachStatementContext* ctx ) override;
+  antlrcpp::Any visitEnumStatement(
+      EscriptGrammar::EscriptParser::EnumStatementContext* ctx ) override;
+  antlrcpp::Any visitEnumListEntry(
+      EscriptGrammar::EscriptParser::EnumListEntryContext* ctx ) override;
+  antlrcpp::Any visitSwitchLabel( EscriptGrammar::EscriptParser::SwitchLabelContext* ctx ) override;
+  antlrcpp::Any visitBasicForStatement(
+      EscriptGrammar::EscriptParser::BasicForStatementContext* ctx ) override;
+  antlrcpp::Any visitVariableDeclaration(
+      EscriptGrammar::EscriptParser::VariableDeclarationContext* ctx ) override;
+  antlrcpp::Any visitProgramParameter(
+      EscriptGrammar::EscriptParser::ProgramParameterContext* ctx ) override;
+  antlrcpp::Any visitFunctionParameter(
+      EscriptGrammar::EscriptParser::FunctionParameterContext* ctx ) override;
+  antlrcpp::Any visitScopedFunctionCall(
+      EscriptGrammar::EscriptParser::ScopedFunctionCallContext* ctx ) override;
+  antlrcpp::Any visitFunctionReference(
+      EscriptGrammar::EscriptParser::FunctionReferenceContext* ctx ) override;
+  antlrcpp::Any visitPrimary( EscriptGrammar::EscriptParser::PrimaryContext* ctx ) override;
+  antlrcpp::Any visitNavigationSuffix(
+      EscriptGrammar::EscriptParser::NavigationSuffixContext* ctx ) override;
+  antlrcpp::Any visitMethodCallSuffix(
+      EscriptGrammar::EscriptParser::MethodCallSuffixContext* ctx ) override;
+  antlrcpp::Any visitFunctionCall(
+      EscriptGrammar::EscriptParser::FunctionCallContext* ctx ) override;
+  antlrcpp::Any visitStructInitializerExpression(
+      EscriptGrammar::EscriptParser::StructInitializerExpressionContext* ctx ) override;
 
 private:
   CompilerWorkspace& workspace;

--- a/pol-core/bscript/compiler/ast/FunctionCall.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionCall.cpp
@@ -43,12 +43,14 @@ std::vector<std::unique_ptr<Argument>> FunctionCall::take_arguments()
   return args;
 }
 
-std::vector<std::reference_wrapper<FunctionParameterDeclaration>> FunctionCall::parameters() const
+std::unique_ptr<std::vector<std::reference_wrapper<FunctionParameterDeclaration>>>
+FunctionCall::parameters() const
 {
   if ( auto fn = function_link->function() )
-    return fn->parameters();
+    return std::make_unique<std::vector<std::reference_wrapper<FunctionParameterDeclaration>>>(
+        fn->parameters() );
   else
-    internal_error( "function has not been resolved" );
+    return {};
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/FunctionCall.h
+++ b/pol-core/bscript/compiler/ast/FunctionCall.h
@@ -21,8 +21,8 @@ public:
   void describe_to( fmt::Writer& ) const override;
 
   std::vector<std::unique_ptr<Argument>> take_arguments();
-  [[nodiscard]] std::vector<std::reference_wrapper<FunctionParameterDeclaration>> parameters()
-      const;
+  [[nodiscard]] std::unique_ptr<std::vector<std::reference_wrapper<FunctionParameterDeclaration>>>
+  parameters() const;
 
   const std::shared_ptr<FunctionLink> function_link;
 

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -47,6 +47,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   if ( SourceFile::enforced_case_sensitivity_mismatch( source_location, pathname, report ) )
   {
     report.error( *ident, "Refusing to load '", pathname, "'." );
+    workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
     return {};
   }
 
@@ -55,6 +56,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   if ( !sf || report.error_count() )
   {
     report.error( *ident, "Unable to load '", pathname, "'." );
+    workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
     return {};
   }
 
@@ -90,6 +92,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build_module(
   if ( SourceFile::enforced_case_sensitivity_mismatch( source_location, pathname, report ) )
   {
     report.error( *ident, "Refusing to load '", pathname, "'." );
+    workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
     return {};
   }
 
@@ -97,6 +100,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build_module(
   if ( !sf || report.error_count() )
   {
     report.error( *ident, "Unable to load '", pathname, "'." );
+    workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
     return {};
   }
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -60,6 +60,9 @@ void SourceFileProcessor::use_module( const std::string& module_name,
     // that would just be noise, like missing module function declarations or constants.
     // But in diagnostics mode, we want to continue, so...
     report.error( including_location, "Unable to use module '", module_name, "'.\n" );
+    // Move the failed-to-load SourceFileIdentifier to the compiler to properly
+    // own diagnostic references.
+    workspace.compiler_workspace.referenced_source_file_identifiers.push_back( std::move( ident ) );
     return;
   }
   workspace.source_files[ pathname ] = sf;

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -159,6 +159,8 @@ void SourceFileProcessor::handle_include_declaration( EscriptParser::IncludeDecl
     {
       report.error( source_location, "Unable to include file '", canonical_include_pathname,
                     "': failed to load." );
+      workspace.compiler_workspace.referenced_source_file_identifiers.push_back(
+          std::move( ident ) );
       return;
     }
 

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -58,7 +58,9 @@ void SourceFileProcessor::use_module( const std::string& module_name,
   {
     // This is fatal because if we keep going, we'll likely report a bunch of errors
     // that would just be noise, like missing module function declarations or constants.
-    report.fatal( including_location, "Unable to use module '", module_name, "'.\n" );
+    // But in diagnostics mode, we want to continue, so...
+    report.error( including_location, "Unable to use module '", module_name, "'.\n" );
+    return;
   }
   workspace.source_files[ pathname ] = sf;
 

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -150,7 +150,7 @@ SemanticTokens SourceFile::get_tokens( ScopeTree& scope_tree )
   lexer.reset();
   for ( const auto& lexer_token : lexer.getAllTokens() )
   {
-    auto semantic_token = SemanticToken::from_lexer_token( scope_tree, *lexer_token );
+    auto semantic_token = SemanticToken::from_lexer_token( *lexer_token );
     if ( semantic_token )
     {
       auto& t = *semantic_token;

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -152,7 +152,9 @@ SemanticTokens SourceFile::get_tokens()
     auto semantic_token = SemanticToken::from_lexer_token( *lexer_token );
     if ( semantic_token )
     {
-      tokens.push_back( std::move( semantic_token ) );
+      auto& t = *semantic_token;
+      tokens.insert( tokens.end(), std::make_move_iterator( t.begin() ),
+                     std::make_move_iterator( t.end() ) );
     }
   }
   return tokens;

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -9,6 +9,7 @@
 #include "bscript/compiler/Report.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/file/SourceFileLoader.h"
+#include "bscript/compiler/model/ScopeTree.h"
 #include "bscript/compiler/model/SemanticTokens.h"
 #include "compilercfg.h"
 #include <EscriptGrammar/EscriptParserVisitor.h>
@@ -143,13 +144,13 @@ EscriptGrammar::EscriptParser::ModuleUnitContext* SourceFile::get_module_unit(
   return module_unit;
 }
 
-SemanticTokens SourceFile::get_tokens()
+SemanticTokens SourceFile::get_tokens( ScopeTree& scope_tree )
 {
   SemanticTokens tokens;
   lexer.reset();
   for ( const auto& lexer_token : lexer.getAllTokens() )
   {
-    auto semantic_token = SemanticToken::from_lexer_token( *lexer_token );
+    auto semantic_token = SemanticToken::from_lexer_token( scope_tree, *lexer_token );
     if ( semantic_token )
     {
       auto& t = *semantic_token;

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -144,7 +144,7 @@ EscriptGrammar::EscriptParser::ModuleUnitContext* SourceFile::get_module_unit(
   return module_unit;
 }
 
-SemanticTokens SourceFile::get_tokens( ScopeTree& scope_tree )
+SemanticTokens SourceFile::get_tokens()
 {
   SemanticTokens tokens;
   lexer.reset();

--- a/pol-core/bscript/compiler/file/SourceFile.h
+++ b/pol-core/bscript/compiler/file/SourceFile.h
@@ -47,7 +47,7 @@ public:
   EscriptGrammar::EscriptParser::ModuleUnitContext* get_module_unit(
       Report&, const SourceFileIdentifier& );
 
-  SemanticTokens get_tokens( ScopeTree& scope_tree );
+  SemanticTokens get_tokens();
 
   const std::string pathname;
 

--- a/pol-core/bscript/compiler/file/SourceFile.h
+++ b/pol-core/bscript/compiler/file/SourceFile.h
@@ -23,6 +23,7 @@ namespace Pol::Bscript::Compiler
 {
 class Profile;
 class Report;
+class ScopeTree;
 class SourceFileLoader;
 class SourceLocation;
 
@@ -46,7 +47,7 @@ public:
   EscriptGrammar::EscriptParser::ModuleUnitContext* get_module_unit(
       Report&, const SourceFileIdentifier& );
 
-  SemanticTokens get_tokens();
+  SemanticTokens get_tokens( ScopeTree& scope_tree );
 
   const std::string pathname;
 

--- a/pol-core/bscript/compiler/model/SemanticTokens.cpp
+++ b/pol-core/bscript/compiler/model/SemanticTokens.cpp
@@ -3,7 +3,8 @@
 
 namespace Pol::Bscript::Compiler
 {
-std::unique_ptr<SemanticToken> SemanticToken::from_lexer_token( const antlr4::Token& token )
+std::unique_ptr<std::list<SemanticToken>> SemanticToken::from_lexer_token(
+    const antlr4::Token& token )
 {
   switch ( token.getType() )
   {
@@ -58,11 +59,14 @@ std::unique_ptr<SemanticToken> SemanticToken::from_lexer_token( const antlr4::To
   case EscriptGrammar::EscriptLexer::DOUBLE:
   case EscriptGrammar::EscriptLexer::AS:
   case EscriptGrammar::EscriptLexer::IS:
-    return std::make_unique<SemanticToken>( SemanticToken{ token.getLine(),
-                                                           token.getCharPositionInLine() + 1,
-                                                           token.getText().length(),
-                                                           SemanticTokenType::KEYWORD,
-                                                           {} } );
+  {
+    std::list<SemanticToken> list{ SemanticToken{ token.getLine(),
+                                                  token.getCharPositionInLine() + 1,
+                                                  token.getText().length(),
+                                                  SemanticTokenType::KEYWORD,
+                                                  {} } };
+    return std::make_unique<std::list<SemanticToken>>( std::move( list ) );
+  }
   case EscriptGrammar::EscriptLexer::AND_A:
   case EscriptGrammar::EscriptLexer::AND_B:
   case EscriptGrammar::EscriptLexer::OR_A:
@@ -116,11 +120,14 @@ std::unique_ptr<SemanticToken> SemanticToken::from_lexer_token( const antlr4::To
   case EscriptGrammar::EscriptLexer::DEC:
   case EscriptGrammar::EscriptLexer::ELVIS:
   case EscriptGrammar::EscriptLexer::QUESTION:
-    return std::make_unique<SemanticToken>( SemanticToken{ token.getLine(),
-                                                           token.getCharPositionInLine() + 1,
-                                                           token.getText().length(),
-                                                           SemanticTokenType::OPERATOR,
-                                                           {} } );
+  {
+    std::list<SemanticToken> list{ SemanticToken{ token.getLine(),
+                                                  token.getCharPositionInLine() + 1,
+                                                  token.getText().length(),
+                                                  SemanticTokenType::OPERATOR,
+                                                  {} } };
+    return std::make_unique<std::list<SemanticToken>>( std::move( list ) );
+  }
 
 
   case EscriptGrammar::EscriptLexer::DECIMAL_LITERAL:
@@ -129,17 +136,61 @@ std::unique_ptr<SemanticToken> SemanticToken::from_lexer_token( const antlr4::To
   case EscriptGrammar::EscriptLexer::BINARY_LITERAL:
   case EscriptGrammar::EscriptLexer::FLOAT_LITERAL:
   case EscriptGrammar::EscriptLexer::HEX_FLOAT_LITERAL:
-    return std::make_unique<SemanticToken>( SemanticToken{ token.getLine(),
-                                                           token.getCharPositionInLine() + 1,
-                                                           token.getText().length(),
-                                                           SemanticTokenType::NUMBER,
-                                                           {} } );
+  {
+    std::list<SemanticToken> list{ SemanticToken{ token.getLine(),
+                                                  token.getCharPositionInLine() + 1,
+                                                  token.getText().length(),
+                                                  SemanticTokenType::NUMBER,
+                                                  {} } };
+    return std::make_unique<std::list<SemanticToken>>( std::move( list ) );
+  }
   case EscriptGrammar::EscriptLexer::STRING_LITERAL:
-    return std::make_unique<SemanticToken>( SemanticToken{ token.getLine(),
-                                                           token.getCharPositionInLine() + 1,
-                                                           token.getText().length(),
-                                                           SemanticTokenType::STRING,
-                                                           {} } );
+  case EscriptGrammar::EscriptLexer::INTERPOLATED_STRING_START:
+  case EscriptGrammar::EscriptLexer::STRING_LITERAL_INSIDE:
+  case EscriptGrammar::EscriptLexer::DOUBLE_QUOTE_INSIDE:
+  {
+    const auto& str = token.getText();
+    const auto size = str.size();
+
+    auto tokens = std::make_unique<std::list<SemanticToken>>();
+    size_t line = token.getLine();
+    size_t character = token.getCharPositionInLine() + 1;
+    size_t token_length = 0;
+    for ( size_t i = 0; i < size; i++ )
+    {
+      if ( str[i] == '\r' && i + 1 < size && str[i + 1] == '\n' )
+      {
+        tokens->push_back(
+            SemanticToken{ line, character, token_length, SemanticTokenType::STRING, {} } );
+        ++line;
+        character = 1;
+        token_length = 0;
+      }
+      else if ( str[i] == '\r' )
+      {
+        tokens->push_back(
+            SemanticToken{ line, character, token_length, SemanticTokenType::STRING, {} } );
+        ++line;
+        character = 1;
+        token_length = 0;
+      }
+      else if ( str[i] == '\n' )
+      {
+        tokens->push_back(
+            SemanticToken{ line, character, token_length, SemanticTokenType::STRING, {} } );
+        ++line;
+        character = 1;
+        token_length = 0;
+      }
+      else
+      {
+        ++token_length;
+      }
+    }
+    tokens->push_back(
+        SemanticToken{ line, character, token_length, SemanticTokenType::STRING, {} } );
+    return tokens;
+  }
   }
   return {};
 }

--- a/pol-core/bscript/compiler/model/SemanticTokens.cpp
+++ b/pol-core/bscript/compiler/model/SemanticTokens.cpp
@@ -7,7 +7,7 @@
 namespace Pol::Bscript::Compiler
 {
 std::unique_ptr<std::list<SemanticToken>> SemanticToken::from_lexer_token(
-    const ScopeTree& scope_tree, const antlr4::Token& token )
+    const antlr4::Token& token )
 {
   switch ( token.getType() )
   {
@@ -193,21 +193,6 @@ std::unique_ptr<std::list<SemanticToken>> SemanticToken::from_lexer_token(
     tokens->push_back(
         SemanticToken{ line, character, token_length, SemanticTokenType::STRING, {} } );
     return tokens;
-  }
-  case EscriptGrammar::EscriptLexer::IDENTIFIER:
-  {
-    const auto& str = token.getText();
-    auto line = static_cast<unsigned short>( token.getLine() );
-    auto character = static_cast<unsigned short>( token.getCharPositionInLine() + 1 );
-    // FIXME: this can be optimized to simultaneously walk the scope tree and
-    // the token list
-    auto variable = scope_tree.find_variable( str, Position{ line, character } );
-    if ( variable )
-    {
-      std::list<SemanticToken> list{ SemanticToken{
-          line, character, token.getText().length(), SemanticTokenType::VARIABLE, {} } };
-      return std::make_unique<std::list<SemanticToken>>( std::move( list ) );
-    }
   }
   }
 

--- a/pol-core/bscript/compiler/model/SemanticTokens.h
+++ b/pol-core/bscript/compiler/model/SemanticTokens.h
@@ -76,12 +76,12 @@ struct SemanticToken
   size_t character_column;
   size_t length;
   SemanticTokenType type;
-  std::vector<SemanticTokenModifier> modifiers;
+  std::list<SemanticTokenModifier> modifiers;
 
-  static std::unique_ptr<SemanticToken> from_lexer_token( const antlr4::Token& );
+  static std::unique_ptr<std::list<SemanticToken>> from_lexer_token( const antlr4::Token& );
 };
 
-using SemanticTokens = std::list<std::unique_ptr<SemanticToken>>;
+using SemanticTokens = std::list<SemanticToken>;
 }  // namespace Pol::Bscript::Compiler
 
 #endif

--- a/pol-core/bscript/compiler/model/SemanticTokens.h
+++ b/pol-core/bscript/compiler/model/SemanticTokens.h
@@ -79,8 +79,7 @@ struct SemanticToken
   SemanticTokenType type;
   std::list<SemanticTokenModifier> modifiers;
 
-  static std::unique_ptr<std::list<SemanticToken>> from_lexer_token( const ScopeTree&,
-                                                                     const antlr4::Token& );
+  static std::unique_ptr<std::list<SemanticToken>> from_lexer_token( const antlr4::Token& );
 };
 
 using SemanticTokens = std::list<SemanticToken>;

--- a/pol-core/bscript/compiler/model/SemanticTokens.h
+++ b/pol-core/bscript/compiler/model/SemanticTokens.h
@@ -12,6 +12,7 @@ class Token;
 namespace Pol::Bscript::Compiler
 {
 class CompilerWorkspace;
+class ScopeTree;
 
 // FIXME: truncate list after identifying proper usages
 enum class SemanticTokenType
@@ -78,7 +79,8 @@ struct SemanticToken
   SemanticTokenType type;
   std::list<SemanticTokenModifier> modifiers;
 
-  static std::unique_ptr<std::list<SemanticToken>> from_lexer_token( const antlr4::Token& );
+  static std::unique_ptr<std::list<SemanticToken>> from_lexer_token( const ScopeTree&,
+                                                                     const antlr4::Token& );
 };
 
 using SemanticTokens = std::list<SemanticToken>;


### PR DESCRIPTION
Use source parse tree for highlighting of identifiers instead of linear token list.