### PR TITLE
Boat pkt encoding len

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-21-2021</datemodified>
+		<datemodified>07-22-2021</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>07-22-2021</date>
+			<author>Turley:</author>
+			<change type="Fixed">Fixed crash when too many items exists an a boat.</change>
+		</entry>
 		<entry>
 			<date>07-21-2021</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100.1.0 --
+07-22-2021 Turley:
+    Fixed: Fixed crash when too many items exists an a boat.
 07-21-2021 Kevin:
     Fixed: Fixed bug where a target couldn't be cancelled in some clients.
 06-21-2021 Turley:

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -303,7 +303,7 @@ void UBoat::send_smooth_move( Network::Client* client, Plib::UFACING move_dir, u
   msg->WriteFlipped<u16>( newy );
   msg->WriteFlipped<u16>( ( z < 0 ) ? static_cast<u16>( 0x10000 + z ) : static_cast<u16>( z ) );
 
-  const u16 max_count = ( 0xffff - 18 ) / 10;
+  const u16 max_count = ( 0xf000 - 18 ) / 10; // encoding room?
   u16 object_count = 0;
   size_t len_offset = msg->offset;
   msg->offset += 2;  // Length
@@ -389,7 +389,7 @@ void UBoat::send_display_boat( Network::Client* client )
   msg->offset += 2;  // Length
 
   // Send_display_boat is only called for CLIENTTYPE_7090, so each 0xF3 is 26 bytes here
-  const u16 max_count = ( 0xffff - 5 ) / 26;
+  const u16 max_count = ( 0xf000 - 5 ) / 26; // encoding room?
   u16 object_count = 1;  // Add 1 for the boat aswell
   size_t len_offset = msg->offset;
   msg->offset += 2;  // Length

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -303,7 +303,8 @@ void UBoat::send_smooth_move( Network::Client* client, Plib::UFACING move_dir, u
   msg->WriteFlipped<u16>( newy );
   msg->WriteFlipped<u16>( ( z < 0 ) ? static_cast<u16>( 0x10000 + z ) : static_cast<u16>( z ) );
 
-  const u16 max_count = ( 0xf000 - 18 ) / 10; // encoding room?
+  // 0xf000 encoding room, huffman can take more space then the maximum of 0xffff
+  const u16 max_count = ( 0xf000 - 18 ) / 10;
   u16 object_count = 0;
   size_t len_offset = msg->offset;
   msg->offset += 2;  // Length
@@ -389,7 +390,8 @@ void UBoat::send_display_boat( Network::Client* client )
   msg->offset += 2;  // Length
 
   // Send_display_boat is only called for CLIENTTYPE_7090, so each 0xF3 is 26 bytes here
-  const u16 max_count = ( 0xf000 - 5 ) / 26; // encoding room?
+  // 0xf000 encoding room, huffman can take more space then the maximum of 0xffff
+  const u16 max_count = ( 0xf000 - 5 ) / 26;
   u16 object_count = 1;  // Add 1 for the boat aswell
   size_t len_offset = msg->offset;
   msg->offset += 2;  // Length

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -306,7 +306,7 @@ void UBoat::send_smooth_move( Network::Client* client, Plib::UFACING move_dir, u
   // 0xf000 encoding room, huffman can take more space then the maximum of 0xffff
   const u16 max_count = ( 0xf000 - 18 ) / 10;
   u16 object_count = 0;
-  size_t len_offset = msg->offset;
+  u16 len_offset = msg->offset;
   msg->offset += 2;  // Length
   for ( auto& component : Components )
   {
@@ -393,7 +393,7 @@ void UBoat::send_display_boat( Network::Client* client )
   // 0xf000 encoding room, huffman can take more space then the maximum of 0xffff
   const u16 max_count = ( 0xf000 - 5 ) / 26;
   u16 object_count = 1;  // Add 1 for the boat aswell
-  size_t len_offset = msg->offset;
+  u16 len_offset = msg->offset;
   msg->offset += 2;  // Length
 
   // Build boat part


### PR DESCRIPTION
Huffman encoding can need more space then the uncompressed pkt.
This leads to a crash in the newer boat pkts. 
The fix is simple: number of maximum items is now reduced so that the uncompressed pkt has a maximum size of 0xf000.