### PR TITLE
Throw compile error on function name conflict

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-03-2021</datemodified>
+		<datemodified>08-11-2021</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>08-11-2021</date>
+			<author>Kevin:</author>
+			<change type="Fixed">User Functions that conflict with the same name as Module Functions will now result in a compilation error.</change>
+		</entry>
 		<entry>
 			<date>08-03-2021</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100.1.0 --
+08-11-2021 Kevin:
+    Fixed: User Functions that conflict with the same name as Module Functions will now result in a compilation error.
 08-03-2021 Turley:
     Fixed: loading of npcdesc AttackCProp and ShieldCProp
     Fixed: loading of itemdesc NoDrop and NoDropException

--- a/testsuite/escript/func/func014-module-function-conflict.err
+++ b/testsuite/escript/func/func014-module-function-conflict.err
@@ -1,0 +1,1 @@
+func014-module-function-conflict.src:2:1: error: User Function 'Broadcast' conflicts with Module Function of the same name.

--- a/testsuite/escript/func/func014-module-function-conflict.src
+++ b/testsuite/escript/func/func014-module-function-conflict.src
@@ -1,0 +1,2 @@
+use uo;
+function Broadcast() endfunction

--- a/testsuite/escript/func/func015-module-function-conflict.err
+++ b/testsuite/escript/func/func015-module-function-conflict.err
@@ -1,0 +1,1 @@
+func015-module-function-conflict.src:1:1: error: User Function 'Broadcast' conflicts with Module Function of the same name.

--- a/testsuite/escript/func/func015-module-function-conflict.src
+++ b/testsuite/escript/func/func015-module-function-conflict.src
@@ -1,0 +1,2 @@
+function Broadcast() endfunction
+use uo;


### PR DESCRIPTION
User Functions that conflict with the same name as Module Functions will now result in a compilation error.

Fixes: #407