### PR TITLE
Fixes bug where attack hook was called recursively if a character was moved by the attack hook

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-13-2021</datemodified>
+		<datemodified>08-30-2021</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>08-30-2021</date>
+			<author>Nando:</author>
+			<change type="Fixed">Possible infinite recursion of the attack hook if a character was moved by the attack hook</change>
+		</entry>
 		<entry>
 			<date>08-14-2021</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+08-30-2021 Nando:
+    Fixed: Possible infinite recursion of the attack hook if a character was moved by the attack hook
 08-14-2021 Kevin:
     Fixed: The remaining drop errors (too far away; location blocked) can now be disabled via the ShowWarningItem option.
 08-11-2021 Kevin:

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -3451,6 +3451,9 @@ void Character::check_attack_after_move()
       FUNCTION_CHECKPOINT( check_attack_after_move, 4 );
       if ( Core::settingsManager.combat_config.send_swing_packet && client != nullptr )
         send_fight_occuring( client, opponent );
+
+      // we don't want attack() to recursively cause new attacks
+      mob_flags_.remove( MOB_FLAGS::READY_TO_SWING ); 
       attack( opponent );
       FUNCTION_CHECKPOINT( check_attack_after_move, 5 );
       reset_swing_timer();


### PR DESCRIPTION
When a character is ready to swing, it will attack after being moved. Moving the character from within the attack hook could thus cause an infinite recursion.