### PR TITLE
Add -Wnonportable-include-path for ANTLR warnings

### DIFF
--- a/pol-core/bscript/compiler/Antlr4Inc.h
+++ b/pol-core/bscript/compiler/Antlr4Inc.h
@@ -4,7 +4,9 @@
 #if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
+#ifdef __APPLE__
 #pragma GCC diagnostic ignored "-Wnonportable-include-path"
+#endif
 #endif
 
 #include <antlr4-runtime.h>

--- a/pol-core/bscript/compiler/Antlr4Inc.h
+++ b/pol-core/bscript/compiler/Antlr4Inc.h
@@ -4,6 +4,7 @@
 #if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
+#pragma GCC diagnostic ignored "-Wnonportable-include-path"
 #endif
 
 #include <antlr4-runtime.h>


### PR DESCRIPTION
Resolves Mac OS X build warnings like [this](https://github.com/polserver/polserver/runs/3514040612#step:10:273):

```
/Users/runner/work/polserver/polserver/lib/antlr/install/include/antlr4-runtime/<various>: warning: non-portable path to file '"token.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include "Token.h"
         ^~~~~~~~~
         "token.h"
2 warnings generated.
```