### PR TITLE
Uoconvert improvements

### DIFF
--- a/pol-core/plib/CMakeSources.cmake
+++ b/pol-core/plib/CMakeSources.cmake
@@ -21,6 +21,7 @@ set (plib_sources  # sorted !
   maptileserver.h
   mapwriter.cpp
   mapwriter.h
+  mul/tiledata.h
   pkg.cpp 
   pkg.h
   polfile.h

--- a/pol-core/plib/CMakeSources.cmake
+++ b/pol-core/plib/CMakeSources.cmake
@@ -21,6 +21,7 @@ set (plib_sources  # sorted !
   maptileserver.h
   mapwriter.cpp
   mapwriter.h
+  mul/map.h
   mul/tiledata.h
   pkg.cpp 
   pkg.h

--- a/pol-core/plib/mul/map.h
+++ b/pol-core/plib/mul/map.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace Pol::Plib::MUL
+{
+struct Map
+{
+  static constexpr size_t blockWidth = 8;
+  static constexpr size_t blockHeight = 8;
+  static constexpr size_t cellSize = 3;
+
+  // DWORD + 64 cells (3 bytes) per block
+  static constexpr size_t blockSize = 4 + cellSize * blockWidth * blockHeight;
+
+  static constexpr size_t expected_blocks( int width, int height )
+  {
+    return ( width / blockWidth ) * ( height / blockHeight );
+  }
+
+  static constexpr bool valid_size( size_t filesize, int width, int height )
+  {
+    if ( width % blockWidth != 0 )
+      return false;
+
+    if ( height % blockHeight != 0 )
+      return false;
+
+    size_t nblocks = filesize / Map::blockSize;
+    if ( expected_blocks( width, height ) != nblocks )
+      return false;
+
+    return true;
+  }
+};
+
+class MapInfo
+{
+  int _width = 0;
+  int _height = 0;
+
+  bool _guessed_correctly = false;
+
+  void set_default_size();
+  bool guess_size( size_t filesize );
+
+public:
+  int width() { return _width; }
+  int height() { return _height; }
+
+  bool guessed() { return _guessed_correctly; }
+  bool matches_filesize() { return Map::valid_size( filesize, _width, _height ); }
+  
+  const int mapid = -1;
+  const size_t filesize = 0;
+
+  MapInfo( int mapid ) : mapid( mapid )
+  {
+    set_default_size();
+  }
+
+  MapInfo( int mapid, size_t filesize ) : mapid( mapid ), filesize( filesize )
+  {
+    set_default_size();
+    if ( _height == 0 && _width == 0 )
+    {
+      _guessed_correctly = guess_size( filesize );
+    }
+  }
+};
+
+
+inline bool MapInfo::guess_size( size_t map_size )
+{
+  // Guessing is only implemented for britannia now
+  if ( mapid != 0 && mapid != 1 )
+    return false;
+
+  size_t mapblocks = map_size / Map::blockSize;
+  switch ( mapblocks )
+  {
+  case Map::expected_blocks( 6144, 4096 ):
+    _width = 6144;
+    _height = 4096;
+    break;
+
+  case Map::expected_blocks( 7168, 4096 ):
+    _width = 7168;
+    _height = 4096;
+    break;
+
+  // Last guess. Do we actually need the others?
+  default:
+    constexpr int common_height = 4096 / Map::blockHeight;
+
+    // Number of blocks has to be divisible by either dimension
+    if ( ( mapblocks % common_height ) != 0 )
+      return false;
+
+    _height = 4096;
+    _width = static_cast<int>( Map::blockWidth * ( mapblocks / common_height ) );
+    break;
+  }
+
+  return true;
+}
+
+
+inline void MapInfo::set_default_size()
+{
+  _width = 0;
+  _height = 0;
+
+  switch ( mapid )
+  {
+  case 0:  // britannia / britannia-alt
+  case 1:
+    // depends on the filesize
+    break;
+  case 2:  // ilshenar:
+    _width = 2304;
+    _height = 1600;
+    break;
+  case 3:  // malas
+    _width = 2560;
+    _height = 2048;
+    break;
+  case 4:  // tokuno
+    _width = 1448;
+    _height = 1448;
+    break;
+  case 5:  // termur
+    _width = 1280;
+    _height = 4096;
+    break;
+  }
+}
+
+};  // namespace Pol::Plib::MUL

--- a/pol-core/plib/mul/map.h
+++ b/pol-core/plib/mul/map.h
@@ -27,12 +27,14 @@ struct Map
       return false;
 
     size_t nblocks = filesize / Map::blockSize;
-    if ( expected_blocks( width, height ) != nblocks )
-      return false;
-
-    return true;
+    return expected_blocks( width, height ) == nblocks;
   }
 };
+static_assert( Map::blockSize == 196, "Size mismatch" );
+static_assert( Map::valid_size( 77070336, 6144, 4096 ) );                 // Legacy map
+static_assert( Map::valid_size( 89915392, 7168, 4096 ) );                 // New maps
+static_assert( Map::valid_size( 77070336 - 196, 6144, 4096 ) == false );  // Wrong map 1
+static_assert( Map::valid_size( 89915392 - 196, 7168, 4096 ) == false );  // Wrong map 2
 
 class MapInfo
 {
@@ -50,14 +52,11 @@ public:
 
   bool guessed() { return _guessed_correctly; }
   bool matches_filesize() { return Map::valid_size( filesize, _width, _height ); }
-  
+
   const int mapid = -1;
   const size_t filesize = 0;
 
-  MapInfo( int mapid ) : mapid( mapid )
-  {
-    set_default_size();
-  }
+  MapInfo( int mapid ) : mapid( mapid ) { set_default_size(); }
 
   MapInfo( int mapid, size_t filesize ) : mapid( mapid ), filesize( filesize )
   {

--- a/pol-core/plib/mul/tiledata.h
+++ b/pol-core/plib/mul/tiledata.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "plib/ustruct.h"
+
+namespace Pol::Plib::MUL
+{
+struct Tiledata_Legacy
+{
+  // Bytes to skip in tiledata.mul (0x68800) to access tile blocks
+  static constexpr size_t tilesStart = 0x68800;
+  static constexpr size_t tileSize = sizeof( USTRUCT_TILE );
+  static constexpr size_t blockSize = 4 + 32 * tileSize;  // DWORD + 32 tiles per block
+};
+static_assert( Tiledata_Legacy::blockSize == 1188, "Size mismatch" );
+
+struct Tiledata_HSA
+{
+  // Bytes to skip in tiledata.mul (0x78800) to access tile blocks in the new HSA format
+  static constexpr size_t tilesStart = 0x78800;
+  static constexpr size_t tileSize = sizeof( USTRUCT_TILE_HSA );
+  static constexpr size_t blockSize = 4 + 32 * tileSize;  // DWORD + 32 tiles per block
+};
+static_assert( Tiledata_HSA::blockSize == 1316, "Size mismatch" );
+
+
+class TiledataInfo
+{
+  bool _is_hsa = false;
+  size_t _max_tile_id = 0;
+
+  template <typename T>
+  static bool valid_size( size_t filesize )
+  {
+    if ( filesize <= T::tilesStart )
+      return false;
+
+    size_t remainder = ( filesize - T::tilesStart ) % T::blockSize;
+    if ( remainder == 0 )
+      return true;
+
+    // the last block might not have all 32 tiles, so we also check if an integer number of
+    // them fit here. (That shouldn't be the case for the original files, but we never know what
+    // people throw our way)
+    return ( remainder - 4 ) % T::tileSize == 0;
+  }
+
+  template <typename T>
+  static size_t get_max_tile_id( size_t filesize )
+  {
+    if ( filesize <= T::tilesStart )
+      return 0;
+
+    const size_t nblocks = ( filesize - T::tilesStart ) / T::blockSize;
+    const size_t remainder = ( filesize - T::tilesStart ) % T::blockSize;
+    const size_t leftovers = remainder / T::tileSize;
+
+    return ( 32 * nblocks + leftovers - 1 );
+  }
+
+  void detect( size_t filesize )
+  {
+    if ( valid_size<Tiledata_Legacy>( filesize ) )
+    {
+      _max_tile_id = get_max_tile_id<Tiledata_Legacy>( filesize );
+    }
+    else if ( valid_size<Tiledata_HSA>( filesize ) )
+    {
+      _is_hsa = true;
+      _max_tile_id = get_max_tile_id<Tiledata_HSA>( filesize );
+    }
+    else
+    {
+      // it's neither - don't try to read it
+      _max_tile_id = 0;
+    }
+  }
+
+public:
+  TiledataInfo( size_t filesize ) { detect( filesize ); }
+  bool is_hsa() { return _is_hsa; }
+  size_t max_tile_id() { return _max_tile_id; };
+};
+
+};  // namespace Pol::Plib::MUL

--- a/pol-core/plib/systemstate.cpp
+++ b/pol-core/plib/systemstate.cpp
@@ -3,6 +3,7 @@
 
 #include "../clib/stlutil.h"
 #include "pkg.h"
+#include "pol/objtype.h"
 #include "tiles.h"
 
 namespace Pol
@@ -18,8 +19,8 @@ SystemState::SystemState()
       accounts_txt_dirty( false ),
       accounts_txt_stat(),
       config(),
-      tile( nullptr ),
-      tiles_loaded( false )
+      tile( UOBJ_HSA_MAX + 1 ),
+      max_graphic( 0 )
 {
 }
 
@@ -27,8 +28,7 @@ void SystemState::deinitialize()
 {
   Clib::delete_all( packages );
   packages_byname.clear();
-  if ( tile != nullptr )
-    delete[] tile;
+  tile.clear();
 }
 
 size_t SystemState::estimatedSize() const

--- a/pol-core/plib/systemstate.h
+++ b/pol-core/plib/systemstate.h
@@ -40,8 +40,8 @@ public:
   struct stat accounts_txt_stat;
 
   Core::PolConfig config;
-  Tile* tile;
-  bool tiles_loaded;
+  std::vector<Tile> tile;
+  u16 max_graphic;
 
   size_t estimatedSize() const;
 

--- a/pol-core/plib/tiles.cpp
+++ b/pol-core/plib/tiles.cpp
@@ -11,10 +11,12 @@
 #include <stddef.h>
 
 #include "../clib/cfgelem.h"
+#include "../clib/cfgfile.h"
 #include "../clib/logfacility.h"
 #include "../clib/passert.h"
 #include "mapfunc.h"
 #include "pkg.h"
+#include "pol/objtype.h"
 #include "systemstate.h"
 
 namespace Pol
@@ -24,7 +26,7 @@ namespace Plib
 void load_tile_entry( const Package* /*pkg*/, Clib::ConfigElem& elem )
 {
   unsigned short graphic = static_cast<unsigned short>( strtoul( elem.rest(), nullptr, 0 ) );
-  passert_always( graphic < ( systemstate.config.max_tile_id + 1 ) );
+  passert_always( graphic < ( systemstate.tile.size() ) );
   Tile& entry = systemstate.tile[graphic];
   entry.desc = elem.remove_string( "Desc" );
   entry.uoflags = elem.remove_ulong( "UoFlags" );
@@ -33,17 +35,34 @@ void load_tile_entry( const Package* /*pkg*/, Clib::ConfigElem& elem )
   entry.weight = static_cast<u8>( elem.remove_ushort( "Weight" ) );
   entry.flags = readflags( elem );
 
-  systemstate.tiles_loaded = true;
+  if ( graphic > systemstate.max_graphic )
+    systemstate.max_graphic = graphic;
+}
+
+
+u16 get_max_tile()
+{
+  if ( systemstate.max_graphic > 0x7FFF )
+    return 0xFFFF;
+  else if ( systemstate.max_graphic > 0x3FFF )
+    return 0x7FFF;
+  else
+    return 0x3FFF;
 }
 
 void load_tiles_cfg()
 {
-  systemstate.tile = new Tile[static_cast<size_t>( systemstate.config.max_tile_id + 1 )];
-
   load_all_cfgs( "tiles.cfg", "TILE", load_tile_entry );
 
-  if ( !systemstate.tiles_loaded )
+  if ( systemstate.max_graphic == 0 )
     ERROR_PRINT << "Warning: No tiles loaded. Please check tiles.cfg\n";
+  else
+  {
+    systemstate.config.max_tile_id = get_max_tile();
+    systemstate.tile.resize( systemstate.config.max_tile_id + 1 );
+    INFO_PRINT << "Maximum defined graphic: " << Clib::hexint( systemstate.max_graphic ) << ", "
+               << "maximum tile id: " << Clib::hexint( systemstate.config.max_tile_id ) << "\n";
+  }
 }
 }  // namespace Plib
 }  // namespace Pol

--- a/pol-core/plib/tiles.cpp
+++ b/pol-core/plib/tiles.cpp
@@ -10,10 +10,12 @@
 
 #include <stddef.h>
 
-#include "../clib/cfgelem.h"
-#include "../clib/cfgfile.h"
-#include "../clib/logfacility.h"
-#include "../clib/passert.h"
+#include "clib/cfgelem.h"
+#include "clib/cfgfile.h"
+#include "clib/logfacility.h"
+#include "clib/passert.h"
+#include "clib/strutil.h"
+
 #include "mapfunc.h"
 #include "pkg.h"
 #include "pol/objtype.h"

--- a/pol-core/plib/uofile.h
+++ b/pol-core/plib/uofile.h
@@ -49,6 +49,7 @@ extern int uo_usedif;
 extern bool uo_readuop;
 extern unsigned short uo_map_width;
 extern unsigned short uo_map_height;
+extern size_t uo_map_size;
 
 extern int cfg_max_statics_per_block;
 extern int cfg_warning_statics_per_block;

--- a/pol-core/plib/uofile00.cpp
+++ b/pol-core/plib/uofile00.cpp
@@ -12,10 +12,12 @@
 #include "../clib/fileutil.h"
 #include "../clib/logfacility.h"
 #include "../clib/strutil.h"
+#include "plib/mul/map.h"
 #include "plib/mul/tiledata.h"
 #include "plib/uopreader/uop.h"
 #include "pol/objtype.h"
 #include "systemstate.h"
+
 
 namespace Pol
 {
@@ -145,11 +147,11 @@ bool uo_readuop = true;
 
 unsigned short uo_map_width = 0;
 unsigned short uo_map_height = 0;
+size_t uo_map_size = 0;
 
 void open_tiledata( void )
 {
   int tiledata_size;
-  size_t nblocks;
 
   tilefile = open_uo_file( "tiledata.mul", &tiledata_size );
 
@@ -183,22 +185,8 @@ void open_map( void )
   if ( !uo_readuop || !open_uopmap_file( uo_mapid, &map_size ) )
     mapfile = open_map_file( "map", uo_mapid, &map_size );
 
-  if ( ( uo_mapid == 0 || uo_mapid == 1 ) && ( uo_map_width == 0 || uo_map_height == 0 ) )
-  {
-    bool use_legacy_dimensions = ( map_size / 196 ) == 393216;
-    if ( use_legacy_dimensions )
-    {
-      uo_map_width = 6144;
-      uo_map_height = 4096;
-    }
-    else
-    {
-      uo_map_width = 7168;
-      uo_map_height = 4096;
-    }
-    INFO_PRINT << "Using calculated map dimensions: " << uo_map_width << "x" << uo_map_height
-               << "\n";
-  }
+  // Store the file size in a global variable (UGH!)
+  uo_map_size = map_size;
 }
 
 void open_uo_data_files( void )

--- a/pol-core/plib/uofile00.cpp
+++ b/pol-core/plib/uofile00.cpp
@@ -12,6 +12,7 @@
 #include "../clib/fileutil.h"
 #include "../clib/logfacility.h"
 #include "../clib/strutil.h"
+#include "pol/objtype.h"
 #include "systemstate.h"
 
 namespace Pol
@@ -31,7 +32,7 @@ FILE* mapdif_file = nullptr;
 
 std::ifstream uopmapfile;
 
-bool open_uopmap_file( const int mapid )
+bool open_uopmap_file( const int mapid, int* out_file_size = nullptr )
 {
   std::string filepart = "map" + std::to_string( mapid ) + "LegacyMUL.uop";
   std::string filename = systemstate.config.uo_datafile_root + filepart;
@@ -43,10 +44,20 @@ bool open_uopmap_file( const int mapid )
   }
 
   uopmapfile.open( filename, std::ios::binary );
-  return (bool)uopmapfile;
+
+  if ( (bool)uopmapfile )
+  {
+    if ( out_file_size != nullptr )
+    {
+      *out_file_size = Clib::filesize( filename.c_str() );
+    }
+    return true;
+  }
+
+  return false;
 }
 
-FILE* open_uo_file( const std::string& filename_part )
+FILE* open_uo_file( const std::string& filename_part, int* out_file_size = nullptr )
 {
   std::string filename = systemstate.config.uo_datafile_root + filename_part;
   FILE* fp = fopen( filename.c_str(), "rb" );
@@ -66,10 +77,14 @@ FILE* open_uo_file( const std::string& filename_part )
 
     throw std::runtime_error( "Error opening UO datafile." );
   }
+  if ( out_file_size != nullptr )
+  {
+    *out_file_size = Clib::filesize( filename.c_str() );
+  }
   return fp;
 }
 
-FILE* open_map_file( std::string name, int map_id )
+FILE* open_map_file( std::string name, int map_id, int* out_file_size = nullptr )
 {
   std::string filename;
 
@@ -81,25 +96,75 @@ FILE* open_map_file( std::string name, int map_id )
     filename = name + "0.mul";
   }
 
-  return open_uo_file( filename );
+  return open_uo_file( filename, out_file_size );
 }
 
 int uo_mapid = 0;
-int uo_usedif = 0;
+int uo_usedif = 1;
 bool uo_readuop = true;
 
-unsigned short uo_map_width = 6144;
-unsigned short uo_map_height = 4096;
-void open_uo_data_files( void )
-{
-  std::string filename;
+unsigned short uo_map_width = 0;
+unsigned short uo_map_height = 0;
 
+void open_tiledata( void )
+{
+  int tiledata_size;
+  size_t nblocks;
+
+  tilefile = open_uo_file( "tiledata.mul", &tiledata_size );
+
+  if ( ( tiledata_size - 428032 ) % 1188 != 0 && ( tiledata_size - 493568 ) % 1316 == 0 )
+  {
+    cfg_use_new_hsa_format = true;
+    nblocks = ( tiledata_size - 493568 ) / 1316;
+  }
+  else
+  {
+    cfg_use_new_hsa_format = false;
+    nblocks = ( tiledata_size - 428032 ) / 1188;
+  }
+
+  // Save the parameters into this ugly global state we have
+  Plib::systemstate.config.max_tile_id = 32 * nblocks - 1;
+
+  INFO_PRINT << "Converting with parameters: UseNewHSAFormat = "
+             << ( cfg_use_new_hsa_format ? "True" : "False" )
+             << ", MaxTileId = " << Clib::hexint( Plib::systemstate.config.max_tile_id ) << "\n";
+}
+
+void open_map( void )
+{
+  int map_size;
   // First tries to load the new UOP files. Otherwise fall back to map[N].mul files.
   // map1 uses map0 + 'dif' files, unless there is a map1.mul (newer clients)
   // same for staidx and statics
 
-  if ( !uo_readuop || !open_uopmap_file( uo_mapid ) )
-    mapfile = open_map_file( "map", uo_mapid );
+  if ( !uo_readuop || !open_uopmap_file( uo_mapid, &map_size ) )
+    mapfile = open_map_file( "map", uo_mapid, &map_size );
+
+  if ( ( uo_mapid == 0 || uo_mapid == 1 ) && ( uo_map_width == 0 || uo_map_height == 0 ) )
+  {
+    bool use_legacy_dimensions = ( map_size / 196 ) == 393216;
+    if ( use_legacy_dimensions )
+    {
+      uo_map_width = 6144;
+      uo_map_height = 4096;
+    }
+    else
+    {
+      uo_map_width = 7168;
+      uo_map_height = 4096;
+    }
+    INFO_PRINT << "Using calculated map dimensions: " << uo_map_width << "x" << uo_map_height
+               << "\n";
+  }
+}
+
+void open_uo_data_files( void )
+{
+  std::string filename;
+
+  open_map();
 
   sidxfile = open_map_file( "staidx", uo_mapid );
   statfile = open_map_file( "statics", uo_mapid );
@@ -112,7 +177,7 @@ void open_uo_data_files( void )
   {
     verfile = nullptr;
   }
-  tilefile = open_uo_file( "tiledata.mul" );
+  open_tiledata();
 
   if ( uo_usedif )
   {

--- a/pol-core/plib/uofile00.cpp
+++ b/pol-core/plib/uofile00.cpp
@@ -9,9 +9,10 @@
 #include <fstream>
 #include <string>
 
-#include "../clib/fileutil.h"
-#include "../clib/logfacility.h"
-#include "../clib/strutil.h"
+#include "clib/fileutil.h"
+#include "clib/logfacility.h"
+#include "clib/passert.h"
+#include "clib/strutil.h"
 #include "plib/mul/map.h"
 #include "plib/mul/tiledata.h"
 #include "plib/uopreader/uop.h"

--- a/pol-core/plib/uofilei.h
+++ b/pol-core/plib/uofilei.h
@@ -31,7 +31,7 @@ extern std::ifstream uopmapfile;
 
 struct USTRUCT_VERSION;
 
-FILE* open_uo_file( const std::string& filename_part );
+FILE* open_uo_file( const std::string& filename_part, int* out_file_size = nullptr );
 
 bool check_verdata( unsigned int file, unsigned int block, const USTRUCT_VERSION*& vrec );
 

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -78,12 +78,10 @@ void PolConfig::read_pol_config( bool initial_load )
     Plib::systemstate.config.web_server = elem.remove_bool( "WebServer", false );
     Plib::systemstate.config.web_server_port = elem.remove_ushort( "WebServerPort", 8080 );
 
-    unsigned short max_tile = elem.remove_ushort( "MaxTileID", UOBJ_DEFAULT_MAX );
-
-    if ( max_tile != UOBJ_DEFAULT_MAX && max_tile != UOBJ_SA_MAX && max_tile != UOBJ_HSA_MAX )
-      Plib::systemstate.config.max_tile_id = UOBJ_DEFAULT_MAX;
-    else
-      Plib::systemstate.config.max_tile_id = max_tile;
+    if ( elem.has_prop( "MaxTileID" ) )
+    {
+      INFO_PRINT << "Warning: MaxTileID has been removed from pol.cfg.\n";
+    }
 
     unsigned int max_obj = elem.remove_unsigned( "MaxObjtype", EXTOBJ_HIGHEST_DEFAULT );
     if ( max_obj < EXTOBJ_HIGHEST_DEFAULT || max_obj > 0xFFFFFFFF )

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -59,7 +59,7 @@ struct PolConfig
   unsigned short inactivity_warning_timeout;
   unsigned short inactivity_disconnect_timeout;
   unsigned short min_cmdlevel_to_login;
-  unsigned int max_tile_id;
+  size_t max_tile_id;
   unsigned int max_objtype;
 
   unsigned short max_clients;

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -4,34 +4,35 @@
 #include <string.h>
 #include <string>
 
-#include "../clib/Program/ProgramMain.h"
-#include "../clib/cfgelem.h"
-#include "../clib/cfgfile.h"
-#include "../clib/fileutil.h"
-#include "../clib/logfacility.h"
-#include "../clib/passert.h"
-#include "../clib/rawtypes.h"
-#include "../clib/stlutil.h"
-#include "../clib/timer.h"
-#include "../plib/clidata.h"
-#include "../plib/mapcell.h"
-#include "../plib/mapfunc.h"
-#include "../plib/mapshape.h"
-#include "../plib/mapsolid.h"
-#include "../plib/maptile.h"
-#include "../plib/mapwriter.h"
-#include "../plib/polfile.h"
-#include "../plib/realmdescriptor.h"
-#include "../plib/systemstate.h"
-#include "../plib/udatfile.h"
-#include "../plib/uofile.h"
-#include "../plib/uofilei.h"
-#include "../plib/uoinstallfinder.h"
-#include "../plib/uopreader/uop.h"
-#include "../plib/uopreader/uophash.h"
-#include "../plib/ustruct.h"
-#include "../pol/landtile.h"
-#include "../pol/objtype.h"
+#include "clib/Program/ProgramMain.h"
+#include "clib/cfgelem.h"
+#include "clib/cfgfile.h"
+#include "clib/fileutil.h"
+#include "clib/logfacility.h"
+#include "clib/passert.h"
+#include "clib/rawtypes.h"
+#include "clib/stlutil.h"
+#include "clib/timer.h"
+#include "plib/clidata.h"
+#include "plib/mapcell.h"
+#include "plib/mapfunc.h"
+#include "plib/mapshape.h"
+#include "plib/mapsolid.h"
+#include "plib/maptile.h"
+#include "plib/mapwriter.h"
+#include "plib/mul/map.h"
+#include "plib/polfile.h"
+#include "plib/realmdescriptor.h"
+#include "plib/systemstate.h"
+#include "plib/udatfile.h"
+#include "plib/uofile.h"
+#include "plib/uofilei.h"
+#include "plib/uoinstallfinder.h"
+#include "plib/uopreader/uop.h"
+#include "plib/uopreader/uophash.h"
+#include "plib/ustruct.h"
+#include "pol/landtile.h"
+#include "pol/objtype.h"
 
 
 namespace Pol
@@ -1054,39 +1055,24 @@ int UoConvertMain::main()
     UoConvert::uo_readuop = (bool)programArgsFindEquals( "readuop=", 1, false );
 
     std::string realm = programArgsFindEquals( "realm=", "britannia" );
-    int default_width = 0;
-    int default_height = 0;
-    switch ( UoConvert::uo_mapid )
-    {
-    case 0:
-    case 1:
-      // calculate this value later in open_map()
-      break;
-    case 2:  // ilshenar:
-      default_width = 2304;
-      default_height = 1600;
-      break;
-    case 3:  // malas
-      default_width = 2560;
-      default_height = 2048;
-      break;
-    case 4:  // tokuno
-      default_width = 1448;
-      default_height = 1448;
-      break;
-    case 5:  // termur
-      default_width = 1280;
-      default_height = 4096;
-      break;
-    }
 
     UoConvert::open_uo_data_files();
     UoConvert::read_uo_data();
 
+    // Auto-detects defaults for mapid=0 or 1 based on the map size. All other sizes are fixed based on the mapid.
+    Pol::Plib::MUL::MapInfo mapinfo( UoConvert::uo_mapid, UoConvert::uo_map_size );
+    int default_width = mapinfo.width();
+    int default_height = mapinfo.height();
+
+    if ( mapinfo.guessed() )
+      INFO_PRINT << "Auto-detected map dimensions: " << default_width << "x" << default_height << '\n';
+
     uo_map_width =
-        programArgsFindEquals( "width=", default_width == 0 ? uo_map_width : default_width, false );
-    uo_map_height = programArgsFindEquals(
-        "height=", default_height == 0 ? uo_map_height : default_height, false );
+        static_cast<unsigned short>( programArgsFindEquals( "width=", default_width, false ) );
+    uo_map_height =
+        static_cast<unsigned short>( programArgsFindEquals( "height=", default_height, false ) );
+
+    check_for_errors_in_map_parameters();
 
     int x = programArgsFindEquals( "x=", -1, false );
     int y = programArgsFindEquals( "y=", -1, false );
@@ -1166,6 +1152,30 @@ int UoConvertMain::main()
   }
   UoConvert::clear_tiledata();
   return 0;
+}
+void UoConvertMain::check_for_errors_in_map_parameters()
+{
+  if ( !Pol::Plib::MUL::Map::valid_size( UoConvert::uo_map_size, uo_map_width, uo_map_height ) )
+  {
+    using namespace Pol::Plib;
+
+    size_t expected_size =
+        MUL::Map::blockSize * MUL::Map::expected_blocks( uo_map_width, uo_map_height );
+
+    INFO_PRINT << "\nWarning: Width and height do not match the map size (" << UoConvert::uo_map_size
+               << " bytes, expected " << expected_size << ")\n\n";
+
+    if ( uo_map_width == 0 || uo_map_height == 0 )
+      throw std::runtime_error( "Width and height were not identified automatically. Please specify them manually." );
+
+
+    if ( ( uo_map_width % MUL::Map::blockWidth != 0 ) ||
+         ( uo_map_height % MUL::Map::blockHeight != 0 ) )
+      throw std::runtime_error( "Width and height must be divisible by 8" );
+
+    if ( uo_map_size < expected_size )
+      throw std::runtime_error( "Map size is smaller than the given width and height" );
+  }
 }
 bool UoConvertMain::convert_uop_to_mul()
 {

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -1059,13 +1059,15 @@ int UoConvertMain::main()
     UoConvert::open_uo_data_files();
     UoConvert::read_uo_data();
 
-    // Auto-detects defaults for mapid=0 or 1 based on the map size. All other sizes are fixed based on the mapid.
+    // Auto-detects defaults for mapid=0 or 1 based on the map size. All other sizes are fixed based
+    // on the mapid.
     Pol::Plib::MUL::MapInfo mapinfo( UoConvert::uo_mapid, UoConvert::uo_map_size );
     int default_width = mapinfo.width();
     int default_height = mapinfo.height();
 
     if ( mapinfo.guessed() )
-      INFO_PRINT << "Auto-detected map dimensions: " << default_width << "x" << default_height << '\n';
+      INFO_PRINT << "Auto-detected map dimensions: " << default_width << "x" << default_height
+                 << '\n';
 
     uo_map_width =
         static_cast<unsigned short>( programArgsFindEquals( "width=", default_width, false ) );
@@ -1162,11 +1164,12 @@ void UoConvertMain::check_for_errors_in_map_parameters()
     size_t expected_size =
         MUL::Map::blockSize * MUL::Map::expected_blocks( uo_map_width, uo_map_height );
 
-    INFO_PRINT << "\nWarning: Width and height do not match the map size (" << UoConvert::uo_map_size
-               << " bytes, expected " << expected_size << ")\n\n";
+    INFO_PRINT << "\nWarning: Width and height do not match the map size ("
+               << UoConvert::uo_map_size << " bytes, expected " << expected_size << ")\n\n";
 
     if ( uo_map_width == 0 || uo_map_height == 0 )
-      throw std::runtime_error( "Width and height were not identified automatically. Please specify them manually." );
+      throw std::runtime_error(
+          "Width and height were not identified automatically. Please specify them manually." );
 
 
     if ( ( uo_map_width % MUL::Map::blockWidth != 0 ) ||

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -1157,10 +1157,8 @@ int UoConvertMain::main()
 }
 void UoConvertMain::check_for_errors_in_map_parameters()
 {
-  if ( !Pol::Plib::MUL::Map::valid_size( UoConvert::uo_map_size, uo_map_width, uo_map_height ) )
+  if ( !MUL::Map::valid_size( UoConvert::uo_map_size, uo_map_width, uo_map_height ) )
   {
-    using namespace Pol::Plib;
-
     size_t expected_size =
         MUL::Map::blockSize * MUL::Map::expected_blocks( uo_map_width, uo_map_height );
 

--- a/pol-core/uoconvert/UoConvertMain.h
+++ b/pol-core/uoconvert/UoConvertMain.h
@@ -54,6 +54,8 @@ public:
 protected:
   virtual int main();
 
+  void check_for_errors_in_map_parameters();
+
   bool convert_uop_to_mul();
 
   void setup_uoconvert();


### PR DESCRIPTION
By @KevinEady. Makes uoconvert easier to use:

- `SystemState::tiles` changed from c-style `Tile*` to `std::vector<>`
- `MaxTileId` removed from pol.cfg, uoconvert command line
- Calculate `MaxTileId` from...
  - (pol) maximum defined graphic in tiles.cfg
  - (uoconvert) tiledata.mul byte size
- `UseNewHSAFormat` removed from uoconvert.cfg
- Calculated `UseNewHSAFormat` from...
  - (pol) not needed
  - (uoconvert) tiledata.mul byte size
- Auto-calculate dimenions for maps 0,1 if not provided from byte size