### PR TITLE
Change outgoing packet handlers to write CP-1252 when appropriate

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>11-02-2021</datemodified>
+		<datemodified>11-08-2021</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>11-08-2021</date>
+			<author>Brndd:</author>
+			<change type="Fixed">Outgoing packets with text field now correctly encode the text as CP-1252.</change>
+		</entry>
 		<entry>
 			<date>11-02-2021</date>
 			<author>Brndd:</author>

--- a/pol-core/clib/strutil.cpp
+++ b/pol-core/clib/strutil.cpp
@@ -154,24 +154,27 @@ bool isValidUnicode( const std::string& str )
   return utf8::find_invalid( str.begin(), str.end() ) == str.end();
 }
 
+// This is something of a misnomer because this actually converts CP-1252 to UTF-8,
+// not ISO-8859 to UTF-8.
 void sanitizeUnicodeWithIso( std::string* str )
 {
   if ( isValidUnicode( *str ) )
     return;
-  // assume iso8859
+  // assume cp-1252
   std::string utf8( "" );
   utf8.reserve( 2 * str->size() + 1 );
 
+  auto backinserter = std::back_inserter(utf8);
   for ( const auto& s : *str )
   {
     if ( !( s & 0x80 ) )
     {
-      utf8.push_back( s );
+      *(backinserter++) = s;
     }
     else
     {
-      utf8.push_back( 0xc2 | ( (unsigned char)( s ) >> 6 ) );
-      utf8.push_back( 0xbf & s );
+      uint32_t codepoint = cp1252ToUnicode(s);
+      utf8::unchecked::append(codepoint, backinserter);
     }
   }
   *str = utf8;

--- a/pol-core/clib/strutil.cpp
+++ b/pol-core/clib/strutil.cpp
@@ -154,27 +154,24 @@ bool isValidUnicode( const std::string& str )
   return utf8::find_invalid( str.begin(), str.end() ) == str.end();
 }
 
-// This is something of a misnomer because this actually converts CP-1252 to UTF-8,
-// not ISO-8859 to UTF-8.
 void sanitizeUnicodeWithIso( std::string* str )
 {
   if ( isValidUnicode( *str ) )
     return;
-  // assume cp-1252
+  // assume iso8859
   std::string utf8( "" );
   utf8.reserve( 2 * str->size() + 1 );
 
-  auto backinserter = std::back_inserter(utf8);
   for ( const auto& s : *str )
   {
     if ( !( s & 0x80 ) )
     {
-      *(backinserter++) = s;
+      utf8.push_back( s );
     }
     else
     {
-      uint32_t codepoint = cp1252ToUnicode(s);
-      utf8::unchecked::append(codepoint, backinserter);
+      utf8.push_back( 0xc2 | ( (unsigned char)( s ) >> 6 ) );
+      utf8.push_back( 0xbf & s );
     }
   }
   *str = utf8;

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+11-08-2021 Brndd:
+    Fixed: Outgoing packets with text field now correctly encode the text as CP-1252.
 11-02-2021 Brndd:
   Changed: SetString packet hook method will now write CP-1252 (extended ASCII) encoded text. This is what is used for the majority of packet fields that are not UTF-16.
     Added: Added a new SetUtf8String packet hook method which will write UTF-8 encoded text.

--- a/pol-core/pol/clfunc.cpp
+++ b/pol-core/pol/clfunc.cpp
@@ -63,7 +63,7 @@ void say_above_cl( UObject* obj, unsigned int cliloc_num, const std::string& arg
   msg->WriteFlipped<u16>( color );
   msg->WriteFlipped<u16>( font );
   msg->WriteFlipped<u32>( cliloc_num );
-  msg->Write( obj->description().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30, false );
   msg->Write( utf16text, true );  // ctLEu16
   u16 len = msg->offset;
   msg->offset = 1;
@@ -87,7 +87,7 @@ void private_say_above_cl( Mobile::Character* chr, const UObject* obj, unsigned 
   msg->WriteFlipped<u16>( color );
   msg->WriteFlipped<u16>( font );
   msg->WriteFlipped<u32>( cliloc_num );
-  msg->Write( obj->description().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30, false );
   msg->Write( utf16text, true );  // ctLEu16
   u16 len = msg->offset;
   msg->offset = 1;
@@ -105,7 +105,8 @@ void send_sysmessage_cl_affix( Client* client, unsigned int cliloc_num, const st
   std::vector<u16> utf16text = Bscript::String::toUTF16( arguments );
   if ( utf16text.size() > SPEECH_MAX_LEN )
     utf16text.resize( SPEECH_MAX_LEN );
-  unsigned affix_len = static_cast<unsigned>( affix.size() + 1 );
+  std::string convertedAffix = Clib::strUtf8ToCp1252(affix);
+  unsigned affix_len = static_cast<unsigned>( convertedAffix.size() + 1 );
   if ( affix_len > SPEECH_MAX_LEN + 1 )
     affix_len = SPEECH_MAX_LEN + 1;
 
@@ -117,7 +118,7 @@ void send_sysmessage_cl_affix( Client* client, unsigned int cliloc_num, const st
   msg->WriteFlipped<u32>( cliloc_num );
   msg->Write<u8>( ( prepend ) ? 1u : 0u );
   msg->Write( "System", 30, false );
-  msg->Write( affix.c_str(), static_cast<u16>( affix_len ) );
+  msg->Write( convertedAffix.c_str(), static_cast<u16>( affix_len ) );
   msg->WriteFlipped( utf16text, true );
   u16 len = msg->offset;
   msg->offset = 1;
@@ -134,7 +135,8 @@ void say_above_cl_affix( UObject* obj, unsigned int cliloc_num, const std::strin
   std::vector<u16> utf16text = Bscript::String::toUTF16( arguments );
   if ( utf16text.size() > SPEECH_MAX_LEN )
     utf16text.resize( SPEECH_MAX_LEN );
-  unsigned affix_len = static_cast<unsigned>( affix.size() + 1 );
+  std::string convertedAffix = Clib::strUtf8ToCp1252(affix);
+  unsigned affix_len = static_cast<unsigned>( convertedAffix.size() + 1 );
   if ( affix_len > SPEECH_MAX_LEN + 1 )
     affix_len = SPEECH_MAX_LEN + 1;
 
@@ -145,8 +147,8 @@ void say_above_cl_affix( UObject* obj, unsigned int cliloc_num, const std::strin
   msg->WriteFlipped<u16>( font );
   msg->WriteFlipped<u32>( cliloc_num );
   msg->Write<u8>( ( prepend ) ? 1u : 0u );
-  msg->Write( obj->description().c_str(), 30, false );
-  msg->Write( affix.c_str(), static_cast<u16>( affix_len ) );
+  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30, false );
+  msg->Write( convertedAffix.c_str(), static_cast<u16>( affix_len ) );
   msg->WriteFlipped( utf16text, true );
   u16 len = msg->offset;
   msg->offset = 1;
@@ -166,7 +168,8 @@ void private_say_above_cl_affix( Mobile::Character* chr, const UObject* obj,
   std::vector<u16> utf16text = Bscript::String::toUTF16( arguments );
   if ( utf16text.size() > SPEECH_MAX_LEN )
     utf16text.resize( SPEECH_MAX_LEN );
-  unsigned affix_len = static_cast<unsigned>( affix.size() + 1 );
+  std::string convertedAffix = Clib::strUtf8ToCp1252(affix);
+  unsigned affix_len = static_cast<unsigned>( convertedAffix.size() + 1 );
   if ( affix_len > SPEECH_MAX_LEN + 1 )
     affix_len = SPEECH_MAX_LEN + 1;
 
@@ -177,8 +180,8 @@ void private_say_above_cl_affix( Mobile::Character* chr, const UObject* obj,
   msg->WriteFlipped<u16>( font );
   msg->WriteFlipped<u32>( cliloc_num );
   msg->Write<u8>( ( prepend ) ? 1u : 0u );
-  msg->Write( obj->description().c_str(), 30, false );
-  msg->Write( affix.c_str(), static_cast<u16>( affix_len ) );
+  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30, false );
+  msg->Write( convertedAffix.c_str(), static_cast<u16>( affix_len ) );
   msg->WriteFlipped( utf16text, true );
   u16 len = msg->offset;
   msg->offset = 1;
@@ -217,7 +220,8 @@ void build_sysmessage_cl_affix( PktOut_CC* msg, unsigned int cliloc_num, const s
   std::vector<u16> utf16text = Bscript::String::toUTF16( arguments );
   if ( utf16text.size() > SPEECH_MAX_LEN )
     utf16text.resize( SPEECH_MAX_LEN );
-  unsigned affix_len = static_cast<unsigned>( affix.size() + 1 );
+  std::string convertedAffix = Clib::strUtf8ToCp1252(affix);
+  unsigned affix_len = static_cast<unsigned>( convertedAffix.size() + 1 );
   if ( affix_len > SPEECH_MAX_LEN + 1 )
     affix_len = SPEECH_MAX_LEN + 1;
 
@@ -229,7 +233,7 @@ void build_sysmessage_cl_affix( PktOut_CC* msg, unsigned int cliloc_num, const s
   msg->WriteFlipped<u32>( cliloc_num );
   msg->Write<u8>( ( prepend ) ? 1u : 0u );
   msg->Write( "System", 30, false );
-  msg->Write( affix.c_str(), static_cast<u16>( affix_len ) );
+  msg->Write( convertedAffix.c_str(), static_cast<u16>( affix_len ) );
   msg->WriteFlipped( utf16text, true );
   u16 len = msg->offset;
   msg->offset = 1;

--- a/pol-core/pol/dblclick.cpp
+++ b/pol-core/pol/dblclick.cpp
@@ -58,10 +58,10 @@ void send_paperdoll( Network::Client* client, Mobile::Character* chr )
                        ( !chr->has_title_suffix() ? "" : " " + chr->title_suffix() );
     if ( chr->has_title_race() )
       name += " (" + chr->title_race() + ")";
-    msg->Write( name.c_str(), 60 );
+    msg->Write( Clib::strUtf8ToCp1252(name).c_str(), 60 );
   }
   else
-    msg->Write( chr->name().c_str(), 60 );
+    msg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 60 );
 
 
   // MuadDib changed to reflect true status for 0x20 packet. 1/4/2007

--- a/pol-core/pol/dropitem.cpp
+++ b/pol-core/pol/dropitem.cpp
@@ -562,7 +562,7 @@ bool do_open_trade_window( Network::Client* client, Items::Item* item, Mobile::C
   msg->Write<u32>( client->chr->trade_container()->serial_ext );
   msg->Write<u32>( dropon->trade_container()->serial_ext );
   msg->Write<u8>( 1u );
-  msg->Write( dropon->name().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(dropon->name()).c_str(), 30, false );
 
   msg.Send( client );
 
@@ -571,7 +571,7 @@ bool do_open_trade_window( Network::Client* client, Items::Item* item, Mobile::C
   msg->Write<u32>( dropon->trade_container()->serial_ext );
   msg->Write<u32>( client->chr->trade_container()->serial_ext );
   msg->offset++;  // u8 havename same as above
-  msg->Write( client->chr->name().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(client->chr->name()).c_str(), 30, false );
   msg.Send( dropon->client );
 
   if ( item != nullptr )

--- a/pol-core/pol/login.cpp
+++ b/pol-core/pol/login.cpp
@@ -201,7 +201,7 @@ void loginserver_login( Network::Client* client, PKTIN_80* msg )
     {
       ++servcount;
       msgA8->WriteFlipped<u16>( idx + 1u );
-      msgA8->Write( server->name.c_str(), 30 );
+      msgA8->Write( Clib::strUtf8ToCp1252(server->name).c_str(), 30 );
       msgA8->WriteFlipped<u16>( idx + 1u );
       msgA8->offset += 2;  // u8 percentfull, s8 timezone
       msgA8->Write( server->ip, 4 );
@@ -329,7 +329,7 @@ void send_start( Network::Client* client )
       Mobile::Character* chr = client->acct->get_character( i );
       if ( chr )
       {
-        msg->Write( chr->name().c_str(), 30, false );
+        msg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 30, false );
         msg->offset += 30;  // password
       }
       else
@@ -346,8 +346,8 @@ void send_start( Network::Client* client )
     msg->Write<u8>( i );
     if ( client->ClientType & Network::CLIENTTYPE_70130 )
     {
-      msg->Write( gamestate.startlocations[i]->city.c_str(), 32, false );
-      msg->Write( gamestate.startlocations[i]->desc.c_str(), 32, false );
+      msg->Write( Clib::strUtf8ToCp1252(gamestate.startlocations[i]->city).c_str(), 32, false );
+      msg->Write( Clib::strUtf8ToCp1252(gamestate.startlocations[i]->desc).c_str(), 32, false );
 
       Pos3d coord = gamestate.startlocations[i]->coords[0];
 
@@ -360,8 +360,8 @@ void send_start( Network::Client* client )
     }
     else
     {
-      msg->Write( gamestate.startlocations[i]->city.c_str(), 31, false );
-      msg->Write( gamestate.startlocations[i]->desc.c_str(), 31, false );
+      msg->Write( Clib::strUtf8ToCp1252(gamestate.startlocations[i]->city).c_str(), 31, false );
+      msg->Write( Clib::strUtf8ToCp1252(gamestate.startlocations[i]->desc).c_str(), 31, false );
     }
   }
 

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -550,7 +550,7 @@ void handle_allnames( Client* client, PKTBI_98_IN* msg )
     PktHelper::PacketOut<PktOut_98> msgOut;
     msgOut->WriteFlipped<u16>( 37u );  // static length
     msgOut->Write<u32>( the_mob->serial_ext );
-    msgOut->Write( the_mob->name().c_str(), 30, false );
+    msgOut->Write( Clib::strUtf8ToCp1252(the_mob->name()).c_str(), 30, false );
     msgOut.Send( client );
   }
   else

--- a/pol-core/pol/module/npcmod.cpp
+++ b/pol-core/pol/module/npcmod.cpp
@@ -671,7 +671,7 @@ BObjectImp* NPCExecutorModule::mf_Say()
     msg->Write<u8>( texttype );
     msg->WriteFlipped<u16>( npc.speech_color() );
     msg->WriteFlipped<u16>( npc.speech_font() );
-    msg->Write( npc.name().c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252(npc.name()).c_str(), 30 );
     msg->Write( text, ( strlen( text ) > SPEECH_MAX_LEN + 1 )
                           ? SPEECH_MAX_LEN + 1
                           : static_cast<u16>( strlen( text ) + 1 ) );
@@ -691,7 +691,7 @@ BObjectImp* NPCExecutorModule::mf_Say()
     ucmsg->WriteFlipped<u16>( npc.speech_color() );
     ucmsg->WriteFlipped<u16>( npc.speech_font() );
     ucmsg->Write( "ENU", 4 );
-    ucmsg->Write( npc.description().c_str(), 30 );
+    ucmsg->Write( Clib::strUtf8ToCp1252(npc.description()).c_str(), 30 );
     ucmsg->WriteFlipped( utf16, true );
     uclen = ucmsg->offset;
     ucmsg->offset = 1;
@@ -777,7 +777,7 @@ BObjectImp* NPCExecutorModule::mf_SayUC()
     talkmsg->WriteFlipped<u16>( npc.speech_color() );
     talkmsg->WriteFlipped<u16>( npc.speech_font() );
     talkmsg->Write( languc.c_str(), 4 );
-    talkmsg->Write( npc.description().c_str(), 30 );
+    talkmsg->Write( Clib::strUtf8ToCp1252(npc.description()).c_str(), 30 );
     talkmsg->WriteFlipped( utf16, true );
     u16 len = talkmsg->offset;
     talkmsg->offset = 1;

--- a/pol-core/pol/speech.cpp
+++ b/pol-core/pol/speech.cpp
@@ -86,8 +86,8 @@ void handle_processed_speech( Network::Client* client, const std::string& text, 
   {
     INFO_PRINT << chr->name() << " speaking w/ color 0x" << fmt::hexu( cfBEu16( color ) ) << "\n";
   }
-
-  u16 textlen = static_cast<u16>( text.size() + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  u16 textlen = static_cast<u16>( convertedText.size() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -98,8 +98,8 @@ void handle_processed_speech( Network::Client* client, const std::string& text, 
   talkmsg->Write<u8>( type );  // FIXME authorize
   talkmsg->WriteFlipped<u16>( textcol );
   talkmsg->WriteFlipped<u16>( font );
-  talkmsg->Write( chr->name().c_str(), 30 );
-  talkmsg->Write( text.c_str(), textlen );
+  talkmsg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 30 );
+  talkmsg->Write( convertedText.c_str(), textlen );
   u16 len = talkmsg->offset;
   talkmsg->offset = 1;
   talkmsg->WriteFlipped<u16>( len );
@@ -260,7 +260,7 @@ void SendUnicodeSpeech( Network::Client* client, PKTIN_AD* msgin, const std::str
   talkmsg->WriteFlipped<u16>( textcol );
   talkmsg->WriteFlipped<u16>( msgin->font );
   talkmsg->Write( msgin->lang, 4 );
-  talkmsg->Write( chr->name().c_str(), 30 );
+  talkmsg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 30 );
 
   std::vector<u16> utf16 = Bscript::String::toUTF16( text );
   if ( utf16.size() > SPEECH_MAX_LEN )

--- a/pol-core/pol/statmsg.cpp
+++ b/pol-core/pol/statmsg.cpp
@@ -34,7 +34,7 @@ void send_full_statmsg( Network::Client* client, Mobile::Character* chr )
   PacketOut<Network::PktOut_11> msg;
   msg->offset += 2;  // msglen
   msg->Write<u32>( chr->serial_ext );
-  msg->Write( chr->name().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 30, false );
   bool ignore_caps = Core::settingsManager.ssopt.core_ignores_defence_caps;
   if ( networkManager.uoclient_general.hits.any )
   {
@@ -278,7 +278,7 @@ void send_short_statmsg( Network::Client* client, Mobile::Character* chr )
   PacketOut<Network::PktOut_11> msg;
   msg->offset += 2;  // msglen
   msg->Write<u32>( chr->serial_ext );
-  msg->Write( chr->name().c_str(), 30, false );
+  msg->Write( Clib::strUtf8ToCp1252(chr->name()).c_str(), 30, false );
 
   if ( networkManager.uoclient_general.hits.any )
   {

--- a/pol-core/pol/testing/poltest.cpp
+++ b/pol-core/pol/testing/poltest.cpp
@@ -31,6 +31,7 @@ bool run_pol_tests()
 #endif
   RUNTEST( test_splitnamevalue )
   RUNTEST( test_convertquotedstring )
+  RUNTEST( test_sanitizeUnicodeWithIso )
   RUNTEST( test_encodingconversions )
 
   //  skilladv_test();

--- a/pol-core/pol/testing/testenv.h
+++ b/pol-core/pol/testing/testenv.h
@@ -79,6 +79,7 @@ void create_test_environment();
 
 void test_splitnamevalue();
 void test_convertquotedstring();
+void test_sanitizeUnicodeWithIso();
 void test_encodingconversions();
 
 void map_test();

--- a/pol-core/pol/testing/testmisc.cpp
+++ b/pol-core/pol/testing/testmisc.cpp
@@ -225,6 +225,38 @@ void test_convertquotedstring()
   test_dqs( "\" \\\"hi\"", " \"hi" );
 }
 
+void test_sanitizeUnicodeWithIso()
+{
+  std::string input;
+  std::string output;
+  std::string expected;
+
+  input = "Some weird characters: \x87 \x95 \x80.";
+  output = std::string(input);
+  expected = "Some weird characters: ‡ • €.";
+  Clib::sanitizeUnicodeWithIso(&output);
+  if ( output != expected )
+  {
+    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput: " << input << "\n\toutput: " << output << "\n\texpected: " << expected << "\n";
+    UnitTest::inc_failures();
+  }
+  else
+    UnitTest::inc_successes();
+
+  input = "Maybe someone just wants to say \xC3\xA4 in CP-1252.";
+  output = std::string(input);
+  expected = "Maybe someone just wants to say Ã¤ in CP-1252.";
+  Clib::sanitizeUnicodeWithIso(&output);
+  if ( output != expected )
+  {
+    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput:    " << input << "\n\toutput:   " << output << "\n\texpected: " << expected << "\n";
+    UnitTest::inc_failures();
+  }
+  else
+    UnitTest::inc_successes();
+
+}
+
 void test_cp1252ToUtf8( const std::string& in, const std::string& expected )
 {
   std::string converted = Clib::strCp1252ToUtf8(in);

--- a/pol-core/pol/testing/testmisc.cpp
+++ b/pol-core/pol/testing/testmisc.cpp
@@ -237,7 +237,8 @@ void test_sanitizeUnicodeWithIso()
   Clib::sanitizeUnicodeWithIso(&output);
   if ( output != expected )
   {
-    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput: " << input << "\n\toutput: " << output << "\n\texpected: " << expected << "\n";
+    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput:    " << input << "\n\toutput:   " <<
+        output << "\n\texpected: " << expected << "\n";
     UnitTest::inc_failures();
   }
   else
@@ -249,7 +250,8 @@ void test_sanitizeUnicodeWithIso()
   Clib::sanitizeUnicodeWithIso(&output);
   if ( output != expected )
   {
-    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput:    " << input << "\n\toutput:   " << output << "\n\texpected: " << expected << "\n";
+    INFO_PRINT << "sanitizeUnicodeWithIso fails!\n\tinput:    " << input << "\n\toutput:   " <<
+        output << "\n\texpected: " << expected << "\n";
     UnitTest::inc_failures();
   }
   else

--- a/pol-core/pol/testing/testmisc.cpp
+++ b/pol-core/pol/testing/testmisc.cpp
@@ -231,9 +231,9 @@ void test_sanitizeUnicodeWithIso()
   std::string output;
   std::string expected;
 
-  input = "Some weird characters: \x87 \x95 \x80.";
+  input = "Some weird characters: \xC3 \xD0 \xA9.";
   output = std::string(input);
-  expected = "Some weird characters: ‡ • €.";
+  expected = "Some weird characters: Ã Ð ©.";
   Clib::sanitizeUnicodeWithIso(&output);
   if ( output != expected )
   {
@@ -244,9 +244,9 @@ void test_sanitizeUnicodeWithIso()
   else
     UnitTest::inc_successes();
 
-  input = "Maybe someone just wants to say \xC3\xA4 in CP-1252.";
+  input = "Maybe someone just wants to say \xC3\xA4. Well, that is probably an acceptable loss.";
   output = std::string(input);
-  expected = "Maybe someone just wants to say Ã¤ in CP-1252.";
+  expected = "Maybe someone just wants to say ä. Well, that is probably an acceptable loss.";
   Clib::sanitizeUnicodeWithIso(&output);
   if ( output != expected )
   {

--- a/pol-core/pol/tips.cpp
+++ b/pol-core/pol/tips.cpp
@@ -21,16 +21,17 @@ namespace Core
 {
 bool send_tip( Network::Client* client, const char* tipname, unsigned short tipnum )
 {
-  size_t textlen = strlen( tipname );
+  std::string convertedText = Clib::strUtf8ToCp1252( tipname );
+  size_t textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > 0 && unsigned( textlen ) <= 9999 )
   {
     Network::PktHelper::PacketOut<Network::PktOut_A6> msg;
-    msg->WriteFlipped<u16>( textlen + 11 );
+    msg->WriteFlipped<u16>( textlen + 10 );
     msg->Write<u8>( PKTOUT_A6_TYPE_TIP );
     msg->offset += 2;  // unk4,5
     msg->WriteFlipped<u16>( tipnum );
-    msg->WriteFlipped<u16>( textlen + 1 );
-    msg->Write( tipname, static_cast<u16>( textlen + 1 ) );
+    msg->WriteFlipped<u16>( textlen );
+    msg->Write( convertedText.c_str(), textlen );
     msg.Send( client );
     return true;
   }
@@ -42,17 +43,18 @@ bool send_tip( Network::Client* client, const char* tipname, unsigned short tipn
 
 void send_tip( Network::Client* client, const std::string& tiptext )
 {
-  size_t textlen = tiptext.size();
+  std::string convertedText = Clib::strUtf8ToCp1252(tiptext);
+  size_t textlen = static_cast<u16>( convertedText.size() + 1 );
   if ( textlen >= 10000 )
     textlen = 9999;
 
   Network::PktHelper::PacketOut<Network::PktOut_A6> msg;
-  msg->WriteFlipped<u16>( textlen + 11 );
+  msg->WriteFlipped<u16>( textlen + 10 );
   msg->Write<u8>( PKTOUT_A6_TYPE_TIP );
   msg->offset += 2;  // unk4,5
   msg->offset += 2;  // tipnum
-  msg->WriteFlipped<u16>( textlen + 1 );
-  msg->Write( tiptext.c_str(), static_cast<u16>( textlen + 1 ) );
+  msg->WriteFlipped<u16>( textlen );
+  msg->Write( convertedText.c_str(), textlen );
   msg.Send( client );
 }
 

--- a/pol-core/pol/tips.cpp
+++ b/pol-core/pol/tips.cpp
@@ -22,7 +22,7 @@ namespace Core
 bool send_tip( Network::Client* client, const char* tipname, unsigned short tipnum )
 {
   std::string convertedText = Clib::strUtf8ToCp1252( tipname );
-  size_t textlen = static_cast<u16>( convertedText.length() + 1 );
+  size_t textlen = convertedText.length() + 1;
   if ( textlen > 0 && unsigned( textlen ) <= 9999 )
   {
     Network::PktHelper::PacketOut<Network::PktOut_A6> msg;
@@ -31,7 +31,7 @@ bool send_tip( Network::Client* client, const char* tipname, unsigned short tipn
     msg->offset += 2;  // unk4,5
     msg->WriteFlipped<u16>( tipnum );
     msg->WriteFlipped<u16>( textlen );
-    msg->Write( convertedText.c_str(), textlen );
+    msg->Write( convertedText.c_str(), static_cast<u16>( textlen ) );
     msg.Send( client );
     return true;
   }
@@ -44,7 +44,7 @@ bool send_tip( Network::Client* client, const char* tipname, unsigned short tipn
 void send_tip( Network::Client* client, const std::string& tiptext )
 {
   std::string convertedText = Clib::strUtf8ToCp1252(tiptext);
-  size_t textlen = static_cast<u16>( convertedText.size() + 1 );
+  size_t textlen = convertedText.size() + 1;
   if ( textlen >= 10000 )
     textlen = 9999;
 
@@ -54,7 +54,7 @@ void send_tip( Network::Client* client, const std::string& tiptext )
   msg->offset += 2;  // unk4,5
   msg->offset += 2;  // tipnum
   msg->WriteFlipped<u16>( textlen );
-  msg->Write( convertedText.c_str(), textlen );
+  msg->Write( convertedText.c_str(), static_cast<u16>( textlen ) );
   msg.Send( client );
 }
 

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -1159,7 +1159,8 @@ void send_sysmessage( Network::Client* client, const char* text, unsigned short 
                       unsigned short color )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( strlen( text ) + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -1170,7 +1171,7 @@ void send_sysmessage( Network::Client* client, const char* text, unsigned short 
   msg->WriteFlipped<u16>( color );
   msg->WriteFlipped<u16>( font );
   msg->Write( "System", 30 );
-  msg->Write( text, textlen );
+  msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -1233,7 +1234,8 @@ void broadcast_unicode( const std::string& text, const std::string& lang, unsign
 void send_nametext( Client* client, const Character* chr, const std::string& str )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( str.length() + 1 );
+  std::string convertedString = Clib::strUtf8ToCp1252(str);
+  u16 textlen = static_cast<u16>( convertedString.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -1243,8 +1245,8 @@ void send_nametext( Client* client, const Character* chr, const std::string& str
   msg->Write<u8>( Plib::TEXTTYPE_YOU_SEE );
   msg->WriteFlipped<u16>( chr->name_color( client->chr ) );  // 0x03B2
   msg->WriteFlipped<u16>( 3u );
-  msg->Write( str.c_str(), 30 );
-  msg->Write( str.c_str(), textlen );
+  msg->Write( convertedString.c_str(), 30 );
+  msg->Write( convertedString.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -1255,7 +1257,8 @@ bool say_above( const UObject* obj, const char* text, unsigned short font, unsig
                 unsigned int journal_print )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( strlen( text ) + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -1272,10 +1275,10 @@ bool say_above( const UObject* obj, const char* text, unsigned short font, unsig
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( obj->description().c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
     break;
   }
-  msg->Write( text, textlen );
+  msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -1305,7 +1308,7 @@ bool say_above_unicode( const UObject* obj, const std::string& text, const std::
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( obj->description().c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
     break;
   }
   msg->WriteFlipped( utf16text );
@@ -1323,7 +1326,8 @@ bool private_say_above( Character* chr, const UObject* obj, const char* text, un
   if ( chr->client == nullptr )
     return false;
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( strlen( text ) + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -1340,10 +1344,10 @@ bool private_say_above( Character* chr, const UObject* obj, const char* text, un
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( obj->description().c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
     break;
   }
-  msg->Write( text, textlen );
+  msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -1376,7 +1380,7 @@ bool private_say_above_unicode( Character* chr, const UObject* obj, const std::s
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( obj->description().c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
     break;
   }
   msg->WriteFlipped( utf16text );
@@ -1393,7 +1397,8 @@ bool private_say_above_ex( Character* chr, const UObject* obj, const char* text,
   if ( chr->client == nullptr )
     return false;
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( strlen( text ) + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
 
@@ -1403,8 +1408,8 @@ bool private_say_above_ex( Character* chr, const UObject* obj, const char* text,
   msg->Write<u8>( Plib::TEXTTYPE_NORMAL );
   msg->WriteFlipped<u16>( color );
   msg->WriteFlipped<u16>( 3u );
-  msg->Write( obj->description().c_str(), 30 );
-  msg->Write( text, textlen );
+  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+  msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -1415,7 +1420,8 @@ bool private_say_above_ex( Character* chr, const UObject* obj, const char* text,
 void send_objdesc( Client* client, Item* item )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  u16 textlen = static_cast<u16>( item->description().length() + 1 );
+  std::string convertedText = Clib::strUtf8ToCp1252( item->description() );
+  u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
   msg->offset += 2;
@@ -1425,7 +1431,7 @@ void send_objdesc( Client* client, Item* item )
   msg->WriteFlipped<u16>( 0x03B2u );
   msg->WriteFlipped<u16>( 3u );
   msg->Write( "System", 30 );
-  msg->Write( item->description().c_str(), textlen );
+  msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
   msg->WriteFlipped<u16>( len );
@@ -2155,7 +2161,8 @@ void sendCharProfile( Character* chr, Character* of_who, const std::string& titl
   std::vector<u16> uwtext = Bscript::String::toUTF16( utext );
   std::vector<u16> ewtext = Bscript::String::toUTF16( etext );
 
-  size_t titlelen = title.size();
+  std::string convertedText = Clib::strUtf8ToCp1252(title);
+  size_t titlelen = convertedText.length() + 1;
   // Check Lengths
   if ( titlelen > SPEECH_MAX_LEN )
     titlelen = SPEECH_MAX_LEN;
@@ -2167,7 +2174,7 @@ void sendCharProfile( Character* chr, Character* of_who, const std::string& titl
   // Build Packet
   msg->offset += 2;
   msg->Write<u32>( of_who->serial_ext );
-  msg->Write( title.c_str(), static_cast<u16>( titlelen + 1 ) );
+  msg->Write( convertedText.c_str(), static_cast<u16>(titlelen) );
   msg->WriteFlipped( uwtext );
   msg->WriteFlipped( ewtext );
   u16 len = msg->offset;

--- a/pol-core/pol/ufunc2.cpp
+++ b/pol-core/pol/ufunc2.cpp
@@ -35,11 +35,12 @@ bool send_menu( Client* client, Menu* menu )
   msg->offset += 2;
   msg->offset += 4;  // used_item_serial
   msg->WriteFlipped<u16>( menu->menu_id );
-  size_t stringlen = strlen( menu->title );
+  std::string convertedText = Clib::strUtf8ToCp1252(menu->title);
+  size_t stringlen = convertedText.length();
   if ( stringlen > 80 )
     stringlen = 80;
   msg->Write<u8>( stringlen );  // NOTE null-term not included!
-  msg->Write( menu->title, static_cast<u16>( stringlen ), false );
+  msg->Write( convertedText.c_str(), static_cast<u16>( stringlen ), false );
   msg->Write<u8>( menu->menuitems_.size() );
 
   for ( unsigned idx = 0; idx < menu->menuitems_.size(); idx++ )
@@ -51,11 +52,12 @@ bool send_menu( Client* client, Menu* menu )
     MenuItem* mi = &menu->menuitems_[idx];
     msg->WriteFlipped<u16>( mi->graphic_ );
     msg->WriteFlipped<u16>( mi->color_ );
-    stringlen = strlen( mi->title );
+    std::string convertedText = Clib::strUtf8ToCp1252(mi->title);
+    stringlen = convertedText.length();
     if ( stringlen > 80 )
       stringlen = 80;
     msg->Write<u8>( stringlen );  // NOTE null-term not included!
-    msg->Write( mi->title, static_cast<u16>( stringlen ), false );
+    msg->Write( convertedText.c_str(), static_cast<u16>( stringlen ), false );
   }
   u16 len = msg->offset;
   msg->offset = 1;

--- a/pol-core/pol/ufunc2.cpp
+++ b/pol-core/pol/ufunc2.cpp
@@ -52,7 +52,7 @@ bool send_menu( Client* client, Menu* menu )
     MenuItem* mi = &menu->menuitems_[idx];
     msg->WriteFlipped<u16>( mi->graphic_ );
     msg->WriteFlipped<u16>( mi->color_ );
-    std::string convertedText = Clib::strUtf8ToCp1252(mi->title);
+    convertedText = Clib::strUtf8ToCp1252(mi->title);
     stringlen = convertedText.length();
     if ( stringlen > 80 )
       stringlen = 80;


### PR DESCRIPTION
I went through all uses of `PacketWriter::Write( const char* x, u16 len, bool nullterm = true )` and converted the written string to CP-1252 in the packets which should use it. This should fix most encoding errors like this:

![broken1](https://user-images.githubusercontent.com/5822375/140424283-db909501-b233-4dca-a857-a1872aec5929.png)

So that they appear correctly like this:
![broken2](https://user-images.githubusercontent.com/5822375/140424284-52f23784-03f1-4a51-b353-c202c0564e99.png)

Characters not in the CP-1252 code page will be replaced by question marks.

My methodology for the conversion was this:

- If the packet has a fixed-length string, simply convert by wrapping the string in the `strUtf8ToCp1252()` function in the `Write()` call. This is safe, because CP-1252 strings are always the same length or shorter than UTF-8 strings.
- If the packet has a null-terminated string, the conversion is done a little bit before the `Write()` call, depending a little on the exact implementation of the function, so that the function gets the converted string's (rather than the original UTF-8 string's) length for the various checks that are usually done.

-----

~~I also updated `Clib::sanitizeUnicodeWithIso()` so that it "sanitizes" with CP-1252 instead. This function seems quite poorly named; it is apparently mostly used in some BScript stuff and things like speech packet handlers to convert CP-1252 encoded text into UTF-8. It currently does not do that (correctly, at least), and I have written a test which demonstrates this problem.~~ This function seems to be intended to be used for text from script and config files. It's not actually used for anything too important on incoming packets, so it's not relevant.