### PR TITLE
Fixed move of mobiles/items between realms

### DIFF
--- a/cmake/core_tests.cmake
+++ b/cmake/core_tests.cmake
@@ -15,15 +15,28 @@ endif()
 set_tests_properties(cleantestdir PROPERTIES FIXTURES_SETUP client)
 
 # generate client files, minimal distro and needed core cfgs
+add_test(NAME testenv_map1
+  COMMAND poltool testfiles
+    outdir=coretest/client
+    width=1600
+    height=1600
+    mapid=1
+    hsa=0
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+set_tests_properties(testenv_map1 PROPERTIES DEPENDS cleantestdir)
+set_tests_properties(testenv_map1 PROPERTIES FIXTURES_SETUP client)
+
 add_test(NAME testenv
   COMMAND poltool testenv
     outdir=coretest
     width=192
     height=192
+    mapid=0
     hsa=0
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
-set_tests_properties(testenv PROPERTIES DEPENDS cleantestdir)
+set_tests_properties(testenv PROPERTIES DEPENDS testenv_map1)
 set_tests_properties(testenv PROPERTIES FIXTURES_SETUP client)
 
 add_test(NAME shard_cfgfiles
@@ -68,7 +81,7 @@ set_tests_properties(shard_testpkgs PROPERTIES FIXTURES_SETUP shard)
 # uoconvert part
 
 add_test(NAME uoconvert_map
-  COMMAND uoconvert map britannia 
+  COMMAND uoconvert map realm=britannia 
     width=192 height=192 
     uodata=client
     maxtileid=0x3fff
@@ -78,7 +91,7 @@ set_tests_properties( uoconvert_map PROPERTIES FIXTURES_REQUIRED client)
 set_tests_properties( uoconvert_map PROPERTIES FIXTURES_SETUP uoconvert)
 
 add_test(NAME uoconvert_statics
-  COMMAND uoconvert statics britannia 
+  COMMAND uoconvert statics realm=britannia 
     uodata=client
     maxtileid=0x3fff
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
@@ -88,7 +101,7 @@ set_tests_properties( uoconvert_statics PROPERTIES FIXTURES_REQUIRED client)
 set_tests_properties( uoconvert_statics PROPERTIES FIXTURES_SETUP uoconvert)
 
 add_test(NAME uoconvert_maptile
-  COMMAND uoconvert maptile britannia 
+  COMMAND uoconvert maptile realm=britannia 
     uodata=client
     maxtileid=0x3fff
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
@@ -96,6 +109,41 @@ add_test(NAME uoconvert_maptile
 set_tests_properties( uoconvert_maptile PROPERTIES FIXTURES_REQUIRED client)
 set_tests_properties( uoconvert_maptile PROPERTIES DEPENDS uoconvert_map)
 set_tests_properties( uoconvert_maptile PROPERTIES FIXTURES_SETUP uoconvert)
+
+add_test(NAME uoconvert_map2
+  COMMAND uoconvert map realm=britannia2
+    width=1600
+    height=1600
+    mapid=1
+    uodata=client
+    maxtileid=0x3fff
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
+)
+set_tests_properties( uoconvert_map2 PROPERTIES DEPENDS uoconvert_maptile)
+set_tests_properties( uoconvert_map2 PROPERTIES FIXTURES_REQUIRED client)
+set_tests_properties( uoconvert_map2 PROPERTIES FIXTURES_SETUP uoconvert)
+
+add_test(NAME uoconvert_statics2
+  COMMAND uoconvert statics realm=britannia2
+    uodata=client
+    mapid=1
+    maxtileid=0x3fff
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
+)
+set_tests_properties( uoconvert_statics2 PROPERTIES DEPENDS uoconvert_map2)
+set_tests_properties( uoconvert_statics2 PROPERTIES FIXTURES_REQUIRED client)
+set_tests_properties( uoconvert_statics2 PROPERTIES FIXTURES_SETUP uoconvert)
+
+add_test(NAME uoconvert_maptile2
+  COMMAND uoconvert maptile realm=britannia2
+    uodata=client
+    mapid=1
+    maxtileid=0x3fff
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
+)
+set_tests_properties( uoconvert_maptile2 PROPERTIES FIXTURES_REQUIRED client)
+set_tests_properties( uoconvert_maptile2 PROPERTIES DEPENDS uoconvert_map2)
+set_tests_properties( uoconvert_maptile2 PROPERTIES FIXTURES_SETUP uoconvert)
 
 add_test(NAME uoconvert_tiles
   COMMAND uoconvert tiles

--- a/pol-core/pol/core.h
+++ b/pol-core/pol/core.h
@@ -19,6 +19,8 @@
 
 #include <string>
 
+#include "base/position.h"
+
 namespace Pol
 {
 namespace Items
@@ -45,8 +47,7 @@ enum Priority
 };
 void CoreSetSysTrayToolTip( const std::string& text, Priority pri );
 
-bool move_character_to( Mobile::Character* chr, unsigned short x, unsigned short y, short z,
-                        int flags, Realms::Realm* oldrealm );
+bool move_character_to( Mobile::Character* chr, Pos4d newpos, int flags );
 
 const int MOVEITEM_IGNOREMOVABLE = 0x20000000L;
 const int MOVEITEM_FORCELOCATION = 0x40000000L;

--- a/pol-core/pol/door.cpp
+++ b/pol-core/pol/door.cpp
@@ -60,7 +60,7 @@ void UDoor::toggle()
     setposition( pos() + dd->mod );
   }
 
-  MoveItemWorldPosition( oldpos.x(), oldpos.y(), this, nullptr );
+  MoveItemWorldPosition( oldpos, this );
 
   send_item_to_inrange( this );
 }

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -3781,12 +3781,13 @@ bool Character::CustomHousingMove( unsigned char i_dir )
         const Multi::MultiDef& def = house->multidef();
         auto relpos = newpos - house->pos().xy();
         // minx and y are wall elements and z is 7
-        // mobile will look like flying when allowing the min coords 
+        // mobile will look like flying when allowing the min coords
         if ( def.within_multi( relpos ) && relpos.x() != def.minrxyz.x() &&
              relpos.y() != def.minrxyz.y() )
         {
+          Core::Pos4d oldpos = pos();
           setposition( newpos );
-          MoveCharacterWorldPosition( lastx, lasty, x(), y(), this, nullptr );
+          MoveCharacterWorldPosition( oldpos, this );
 
           position_changed();
           set_dirty();
@@ -3877,6 +3878,7 @@ bool Character::move( unsigned char i_dir )
     if ( !cached_settings.get( PRIV_FLAGS::FIRE_WHILE_MOVING ) && weapon->is_projectile() )
       reset_swing_timer();
 
+    Core::Pos4d oldpos = pos();
     setposition( new_pos );
 
     if ( on_mount() && !script_isa( Core::POLCLASS_NPC ) )
@@ -3910,7 +3912,7 @@ bool Character::move( unsigned char i_dir )
     }
 
     gradual_boost = current_boost;
-    MoveCharacterWorldPosition( lastx, lasty, x(), y(), this, nullptr );
+    MoveCharacterWorldPosition( oldpos, this );
 
     position_changed();
     if ( walkon_item != nullptr )

--- a/pol-core/pol/module/uomod.h
+++ b/pol-core/pol/module/uomod.h
@@ -340,16 +340,13 @@ protected:
   bool getStaticOrDynamicMenuParam( unsigned param, Core::Menu*& menu );
 
 protected:
-  Bscript::BObjectImp* internal_MoveItem( Items::Item* item, Core::xcoord x, Core::ycoord y,
-                                          Core::zcoord z, int flags, Realms::Realm* newrealm );
-  Bscript::BObjectImp* internal_MoveCharacter( Mobile::Character* chr, Core::xcoord x,
-                                               Core::ycoord y, Core::zcoord z, int flags,
-                                               Realms::Realm* newrealm );
-  Bscript::BObjectImp* internal_MoveBoat( Multi::UBoat* boat, Core::xcoord x, Core::ycoord y,
-                                          Core::zcoord z, int flags, Realms::Realm* newrealm );
-  Bscript::BObjectImp* internal_MoveContainer( Core::UContainer* container, Core::xcoord x,
-                                               Core::ycoord y, Core::zcoord z, int flags,
-                                               Realms::Realm* newrealm );
+  Bscript::BObjectImp* internal_MoveItem( Items::Item* item, Core::Pos4d newpos, int flags );
+  Bscript::BObjectImp* internal_MoveCharacter( Mobile::Character* chr, const Core::Pos4d& newpos,
+                                               int flags );
+  Bscript::BObjectImp* internal_MoveBoat( Multi::UBoat* boat, const Core::Pos4d& newpos,
+                                          int flags );
+  Bscript::BObjectImp* internal_MoveContainer( Core::UContainer* container,
+                                               const Core::Pos4d& newpos, int flags );
   static Core::Range3d internal_InBoxAreaChecks( const Core::Pos2d& p1, int z1,
                                                  const Core::Pos2d& p2, int z2,
                                                  Realms::Realm* realm );

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -178,7 +178,7 @@ bool send_vendorwindow_contents( Client* client, UContainer* for_sale, bool send
   {
     Item* item = ( *for_sale )[i];
     // const ItemDesc& id = find_itemdesc( item->objtype_ );
-    std::string desc = Clib::strUtf8ToCp1252(item->merchant_description());
+    std::string desc = Clib::strUtf8ToCp1252( item->merchant_description() );
     size_t addlen = 5 + desc.size();
     if ( msg->offset + addlen > sizeof msg->buffer )
     {
@@ -655,7 +655,7 @@ bool send_vendorsell( Client* client, NPC* merchant, UContainer* sellfrom, UCont
       unsigned int buyprice;
       if ( !item->getbuyprice( buyprice ) )
         continue;
-      std::string desc = Clib::strUtf8ToCp1252(item->merchant_description());
+      std::string desc = Clib::strUtf8ToCp1252( item->merchant_description() );
       if ( msg->offset + desc.size() + 14 > sizeof msg->buffer )
       {
         return false;
@@ -1575,7 +1575,7 @@ BObjectImp* UOExecutorModule::mf_SendTextEntryGump()
   msg->Write<u32>( chr->serial_ext );
   msg->offset += 2;  // u8 type,index
 
-  std::string convertedString = Clib::strUtf8ToCp1252(line1->value());
+  std::string convertedString = Clib::strUtf8ToCp1252( line1->value() );
   size_t numbytes = convertedString.length() + 1;
   if ( numbytes > 256 )
     numbytes = 256;
@@ -1585,7 +1585,7 @@ BObjectImp* UOExecutorModule::mf_SendTextEntryGump()
   msg->Write<u8>( static_cast<u8>( cancel ) );
   msg->Write<u8>( static_cast<u8>( style ) );
   msg->WriteFlipped<s32>( maximum );
-  convertedString = Clib::strUtf8ToCp1252(line2->value());
+  convertedString = Clib::strUtf8ToCp1252( line2->value() );
   numbytes = convertedString.length() + 1;
   if ( numbytes > 256 )
     numbytes = 256;
@@ -2289,7 +2289,7 @@ BObjectImp* UOExecutorModule::mf_SendOpenBook()
         const BObjectImp* line_imp = arr->imp_at( linenum );
         std::string linetext;
         if ( line_imp )
-          linetext = line_imp->getStringRep(); //This is UTF-8
+          linetext = line_imp->getStringRep();  // This is UTF-8
         if ( msg->offset + linetext.size() + 1 > sizeof msg->buffer )
         {
           return new BError( "Buffer overflow" );
@@ -2385,7 +2385,7 @@ void read_book_page_handler( Client* client, PKTBI_66* msg )
       BObjectImpRefVec params;
       params.push_back( ref_ptr<BObjectImp>( new BLong( linenum ) ) );
       BObject line_ob = book->call_custom_method( "getline", params );
-      linetext = line_ob->getStringRep(); //this is UTF-8
+      linetext = line_ob->getStringRep();  // this is UTF-8
 
       if ( msgOut->offset + linetext.size() + 1 > sizeof msgOut->buffer )
       {
@@ -2522,7 +2522,8 @@ BObjectImp* UOExecutorModule::mf_SendHousingTool()
     msg->Write<u8>( 0xFFu );         // fixme
     msg.Send( chr->client );
   }
-  move_character_to( chr, house->x(), house->y(), house->z() + 7, MOVEITEM_FORCELOCATION, nullptr );
+  Core::Pos4d newpos = house->pos() + Core::Vec3d( 0, 0, 7 );
+  move_character_to( chr, newpos, MOVEITEM_FORCELOCATION );
 
   house->WorkingDesign.AddComponents( house );
   house->CurrentDesign.AddComponents( house );
@@ -2544,7 +2545,7 @@ BObjectImp* UOExecutorModule::mf_SendHousingTool()
     if ( multichr != chr )
     {
       Core::Pos4d pos = house->pos() + Core::Vec2d( def.minrxyz.x(), def.maxrxyz.y() + 1 );
-      move_character_to( multichr, pos.x(), pos.y(), pos.z(), MOVEITEM_FORCELOCATION, nullptr );
+      move_character_to( multichr, pos, MOVEITEM_FORCELOCATION );
     }
     moblist.pop_back();
   }

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -700,9 +700,8 @@ void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pk
     msg.Send( chr->client );
   }
   const MultiDef& def = house->multidef();
-  Core::Pos3d newpos = house->pos3d() + Core::Vec2d( def.minrxyz.x(), def.maxrxyz.y() + 1 );
-  move_character_to( chr, newpos.x(), newpos.y(), newpos.z(), Core::MOVEITEM_FORCELOCATION,
-                     nullptr );
+  Core::Pos4d newpos = house->pos() + Core::Vec2d( def.minrxyz.x(), def.maxrxyz.y() + 1 );
+  move_character_to( chr, newpos, Core::MOVEITEM_FORCELOCATION );
   if ( chr->client )
   {
     chr->client->gd->custom_house_serial = 0;
@@ -905,9 +904,9 @@ void CustomHousesSelectFloor( Core::PKTBI_D7* msg )
 
   if ( chr )
   {
-    move_character_to( chr, chr->x(), chr->y(),
-                       house->z() + CustomHouseDesign::custom_house_z_xlate_table[floor],
-                       Core::MOVEITEM_FORCELOCATION, nullptr );
+    Core::Pos4d newpos = chr->pos();
+    newpos.z( house->z() + CustomHouseDesign::custom_house_z_xlate_table[floor] );
+    move_character_to( chr, newpos, Core::MOVEITEM_FORCELOCATION );
     if ( chr->client )
       CustomHousesSendFull( house, chr->client, HOUSE_DESIGN_WORKING );
   }

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -869,7 +869,7 @@ void move_to_ground( Items::Item* item )
 
 void move_to_ground( Mobile::Character* chr )
 {
-  move_character_to( chr, chr->x(), chr->y(), chr->z(), Core::MOVEITEM_FORCELOCATION, nullptr );
+  move_character_to( chr, chr->pos(), Core::MOVEITEM_FORCELOCATION );
 }
 
 // void send_remove_object_if_inrange( Client *client, const UObject *item );

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -1161,7 +1161,7 @@ void send_sysmessage( Network::Client* client, const char* text, unsigned short 
                       unsigned short color )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  std::string convertedText = Clib::strUtf8ToCp1252( text );
   u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
@@ -1236,7 +1236,7 @@ void broadcast_unicode( const std::string& text, const std::string& lang, unsign
 void send_nametext( Client* client, const Character* chr, const std::string& str )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  std::string convertedString = Clib::strUtf8ToCp1252(str);
+  std::string convertedString = Clib::strUtf8ToCp1252( str );
   u16 textlen = static_cast<u16>( convertedString.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )
     textlen = SPEECH_MAX_LEN + 1;
@@ -1259,7 +1259,7 @@ bool say_above( const UObject* obj, const char* text, unsigned short font, unsig
                 unsigned int journal_print )
 {
   PktHelper::PacketOut<PktOut_1C> msg;
-  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  std::string convertedText = Clib::strUtf8ToCp1252( text );
   u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
@@ -1277,7 +1277,7 @@ bool say_above( const UObject* obj, const char* text, unsigned short font, unsig
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252( obj->description() ).c_str(), 30 );
     break;
   }
   msg->Write( convertedText.c_str(), textlen );
@@ -1310,7 +1310,7 @@ bool say_above_unicode( const UObject* obj, const std::string& text, const std::
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252( obj->description() ).c_str(), 30 );
     break;
   }
   msg->WriteFlipped( utf16text );
@@ -1328,7 +1328,7 @@ bool private_say_above( Character* chr, const UObject* obj, const char* text, un
   if ( chr->client == nullptr )
     return false;
   PktHelper::PacketOut<PktOut_1C> msg;
-  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  std::string convertedText = Clib::strUtf8ToCp1252( text );
   u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
@@ -1346,7 +1346,7 @@ bool private_say_above( Character* chr, const UObject* obj, const char* text, un
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252( obj->description() ).c_str(), 30 );
     break;
   }
   msg->Write( convertedText.c_str(), textlen );
@@ -1382,7 +1382,7 @@ bool private_say_above_unicode( Character* chr, const UObject* obj, const std::s
     break;
   case JOURNAL_PRINT_NAME:
   default:
-    msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+    msg->Write( Clib::strUtf8ToCp1252( obj->description() ).c_str(), 30 );
     break;
   }
   msg->WriteFlipped( utf16text );
@@ -1399,7 +1399,7 @@ bool private_say_above_ex( Character* chr, const UObject* obj, const char* text,
   if ( chr->client == nullptr )
     return false;
   PktHelper::PacketOut<PktOut_1C> msg;
-  std::string convertedText = Clib::strUtf8ToCp1252(text);
+  std::string convertedText = Clib::strUtf8ToCp1252( text );
   u16 textlen = static_cast<u16>( convertedText.length() + 1 );
   if ( textlen > SPEECH_MAX_LEN + 1 )  // FIXME need to handle this better second msg?
     textlen = SPEECH_MAX_LEN + 1;
@@ -1410,7 +1410,7 @@ bool private_say_above_ex( Character* chr, const UObject* obj, const char* text,
   msg->Write<u8>( Plib::TEXTTYPE_NORMAL );
   msg->WriteFlipped<u16>( color );
   msg->WriteFlipped<u16>( 3u );
-  msg->Write( Clib::strUtf8ToCp1252(obj->description()).c_str(), 30 );
+  msg->Write( Clib::strUtf8ToCp1252( obj->description() ).c_str(), 30 );
   msg->Write( convertedText.c_str(), textlen );
   u16 len = msg->offset;
   msg->offset = 1;
@@ -1603,19 +1603,18 @@ void subtract_amount_from_item( Item* item, unsigned short amount )
 
 void move_item( Item* item, Core::UFACING facing )
 {
-  u16 oldx = item->x();
-  u16 oldy = item->y();
+  Pos4d oldpos = item->pos();
 
   item->setposition( item->pos().move( facing ) );
 
   item->restart_decay_timer();
-  MoveItemWorldPosition( oldx, oldy, item, nullptr );
+  MoveItemWorldPosition( oldpos, item );
 
   WorldIterator<OnlinePlayerFilter>::InVisualRange(
       item, [&]( Character* zonechr ) { send_item( zonechr->client, item ); } );
   Network::RemoveObjectPkt msgremove( item->serial_ext );
   WorldIterator<OnlinePlayerFilter>::InRange(
-      oldx, oldy, item->realm(), RANGE_VISUAL,
+      oldpos, RANGE_VISUAL,
       [&]( Character* zonechr )
       {
         if ( !inrange( zonechr, item ) )  // not in range.  If old loc was in range, send a delete.
@@ -1629,22 +1628,26 @@ void move_item( Item* item, Core::UFACING facing )
 // that needs to get it. There should be a better method for this. Such as, a function
 // to run all the checks after building the packet here, then send as it needs to.
 void move_item( Item* item, unsigned short newx, unsigned short newy, signed char newz,
-                Realms::Realm* oldrealm )
+                Realms::Realm* /*oldrealm*/ )
+{
+  // TODO POS remove me
+  move_item( item, Core::Pos4d( newx, newy, newz, item->realm() ) );
+}
+void move_item( Items::Item* item, const Core::Pos4d& newpos )
 {
   item->set_dirty();
 
-  u16 oldx = item->x();
-  u16 oldy = item->y();
-  item->setposition( Pos4d( newx, newy, newz, item->realm() ) );
+  Core::Pos4d oldpos = item->pos();
+  item->setposition( newpos );
 
   item->restart_decay_timer();
-  MoveItemWorldPosition( oldx, oldy, item, oldrealm );
+  MoveItemWorldPosition( oldpos, item );
 
   WorldIterator<OnlinePlayerFilter>::InVisualRange(
       item, [&]( Character* zonechr ) { send_item( zonechr->client, item ); } );
   Network::RemoveObjectPkt msgremove( item->serial_ext );
   WorldIterator<OnlinePlayerFilter>::InRange(
-      oldx, oldy, oldrealm, RANGE_VISUAL,
+      oldpos, RANGE_VISUAL,
       [&]( Character* zonechr )
       {
         if ( !inrange( zonechr, item ) )  // not in range.  If old loc was in range, send a delete.
@@ -2163,7 +2166,7 @@ void sendCharProfile( Character* chr, Character* of_who, const std::string& titl
   std::vector<u16> uwtext = Bscript::String::toUTF16( utext );
   std::vector<u16> ewtext = Bscript::String::toUTF16( etext );
 
-  std::string convertedText = Clib::strUtf8ToCp1252(title);
+  std::string convertedText = Clib::strUtf8ToCp1252( title );
   size_t titlelen = convertedText.length() + 1;
   // Check Lengths
   if ( titlelen > SPEECH_MAX_LEN )
@@ -2176,7 +2179,7 @@ void sendCharProfile( Character* chr, Character* of_who, const std::string& titl
   // Build Packet
   msg->offset += 2;
   msg->Write<u32>( of_who->serial_ext );
-  msg->Write( convertedText.c_str(), static_cast<u16>(titlelen) );
+  msg->Write( convertedText.c_str(), static_cast<u16>( titlelen ) );
   msg->WriteFlipped( uwtext );
   msg->WriteFlipped( ewtext );
   u16 len = msg->offset;

--- a/pol-core/pol/ufunc.h
+++ b/pol-core/pol/ufunc.h
@@ -221,6 +221,7 @@ void destroy_item( Items::Item* item );
 void move_item( Items::Item* item, Core::UFACING facing );
 void move_item( Items::Item* item, unsigned short newx, unsigned short newy, signed char newz,
                 Realms::Realm* oldrealm );
+void move_item( Items::Item* item, const Core::Pos4d& newpos );
 
 void send_char_if_newly_inrange( Mobile::Character* chr, Network::Client* client );
 void send_item_if_newly_inrange( Items::Item* item, Network::Client* client );

--- a/pol-core/pol/uworld.h
+++ b/pol-core/pol/uworld.h
@@ -50,14 +50,11 @@ void move_multi_in_world( unsigned short oldx, unsigned short oldy, unsigned sho
 
 void SetCharacterWorldPosition( Mobile::Character* chr, Realms::WorldChangeReason reason );
 void ClrCharacterWorldPosition( Mobile::Character* chr, Realms::WorldChangeReason reason );
-void MoveCharacterWorldPosition( unsigned short oldx, unsigned short oldy, unsigned short newx,
-                                 unsigned short newy, Mobile::Character* chr,
-                                 Realms::Realm* oldrealm );  // TODO Pos dont pass both new and old
+void MoveCharacterWorldPosition( const Core::Pos4d& oldpos, Mobile::Character* chr );
 
 void SetItemWorldPosition( Items::Item* item );
 void ClrItemWorldPosition( Items::Item* item );
-void MoveItemWorldPosition( unsigned short oldx, unsigned short oldy, Items::Item* item,
-                            Realms::Realm* oldrealm );  // TODO Pos
+void MoveItemWorldPosition( const Core::Pos4d& oldpos, Items::Item* item );
 
 int get_toplevel_item_count();
 int get_mobile_count();

--- a/pol-core/poltool/PolToolMain.cpp
+++ b/pol-core/poltool/PolToolMain.cpp
@@ -16,8 +16,8 @@
 #include "../plib/maptileserver.h"
 #include "../plib/realmdescriptor.h"
 #include "baredistro.h"
-#include "testfiles.h"
 #include "testenv.h"
+#include "testfiles.h"
 #include <format/format.h>
 
 #include <zlib.h>
@@ -285,7 +285,8 @@ int PolToolMain::main()
     int maxtiles = programArgsFindEquals( "maxtiles=", 0x3fff, true );
     int width = programArgsFindEquals( "width=", 6144, false );
     int height = programArgsFindEquals( "height=", 4096, false );
-    PolTool::FileGenerator g( outdir, hsa, maxtiles, width, height );
+    int mapid = programArgsFindEquals( "mapid=", 0, false );
+    PolTool::FileGenerator g( outdir, hsa, maxtiles, mapid, width, height );
     g.generateTiledata();
     g.generateMap();
     g.generateStatics();

--- a/pol-core/poltool/testenv.cpp
+++ b/pol-core/poltool/testenv.cpp
@@ -29,7 +29,7 @@ void TestEnv::generate()
     fs::create_directories( _basedir );
 
   fs::path clientdir = _basedir / "client";
-  FileGenerator g( clientdir, _hsa, _maxtiles, _width, _height );
+  FileGenerator g( clientdir, _hsa, _maxtiles, 0, _width, _height );
   g.generateTiledata();
   g.generateMap();
   g.generateStatics();

--- a/pol-core/poltool/testfiles.cpp
+++ b/pol-core/poltool/testfiles.cpp
@@ -15,10 +15,12 @@ namespace Pol
 {
 namespace PolTool
 {
-FileGenerator::FileGenerator( fs::path basedir, bool hsa, int maxtiles, int width, int height )
+FileGenerator::FileGenerator( fs::path basedir, bool hsa, int maxtiles, int mapid, int width,
+                              int height )
     : _basedir( std::move( basedir ) ),
       _hsa( hsa ),
       _maxtiles( maxtiles ),
+      _mapid( mapid ),
       _width( width ),
       _height( height )
 {
@@ -31,6 +33,7 @@ FileGenerator::FileGenerator( fs::path basedir, bool hsa, int maxtiles, int widt
              << "  basedir: " << _basedir.string() << "\n"
              << "  HSA: " << _hsa << "\n"
              << "  maxtiles: 0x" << fmt::hex( _maxtiles ) << "\n"
+             << "  mapid: " << _mapid << "\n"
              << "  width: " << _width << "\n"
              << "  height: " << _height << "\n";
 
@@ -228,7 +231,7 @@ void FileGenerator::generateTiledata()
 
 void FileGenerator::generateMap()
 {
-  INFO_PRINT << "Generating map0.mul\n";
+  INFO_PRINT << "Generating map" << _mapid << ".mul\n";
   // initialize with grass tiles on z=0
   Plib::USTRUCT_MAPINFO grass{ 0x3, 0 };
   std::vector<std::vector<Plib::USTRUCT_MAPINFO>> map;
@@ -239,7 +242,8 @@ void FileGenerator::generateMap()
   modifyMap( map );
 
   int header = 0;
-  std::ofstream file( _basedir / "map0.mul", std::ofstream::binary | std::ofstream::out );
+  std::ofstream file( _basedir / ( "map" + std::to_string( _mapid ) + ".mul" ),
+                      std::ofstream::binary | std::ofstream::out );
   for ( int x = 0; x < _width / 8; ++x )
   {
     for ( int y = 0; y < _height / 8; ++y )
@@ -283,10 +287,12 @@ void FileGenerator::modifyMap( std::vector<std::vector<Plib::USTRUCT_MAPINFO>>& 
 
 void FileGenerator::generateStatics()
 {
-  INFO_PRINT << "Generating statics0.mul\n";
+  INFO_PRINT << "Generating statics" << _mapid << ".mul\n";
   Plib::USTRUCT_IDX idxempty{ 0xFFffFFff, 0xFFffFFff, 0xFFffFFff };
-  std::ofstream file( _basedir / "statics0.mul", std::ofstream::binary | std::ofstream::out );
-  std::ofstream fileidx( _basedir / "staidx0.mul", std::ofstream::binary | std::ofstream::out );
+  std::ofstream file( _basedir / ( "statics" + std::to_string( _mapid ) + ".mul" ),
+                      std::ofstream::binary | std::ofstream::out );
+  std::ofstream fileidx( _basedir / ( "staidx" + std::to_string( _mapid ) + ".mul" ),
+                         std::ofstream::binary | std::ofstream::out );
 
   // init statics: [y][x][...]
   std::vector<std::vector<std::vector<Plib::USTRUCT_STATIC>>> statics;

--- a/pol-core/poltool/testfiles.h
+++ b/pol-core/poltool/testfiles.h
@@ -15,7 +15,7 @@ namespace fs = std::filesystem;
 class FileGenerator
 {
 public:
-  FileGenerator( fs::path basedir, bool hsa, int maxtiles, int width, int height );
+  FileGenerator( fs::path basedir, bool hsa, int maxtiles, int mapid, int width, int height );
   void generateTiledata();
   void generateMap();
   void generateStatics();
@@ -44,6 +44,7 @@ private:
   fs::path _basedir;
   bool _hsa;
   int _maxtiles;
+  int _mapid;
   int _width;
   int _height;
 };

--- a/testsuite/pol/testpkgs/boat/test_boat.src
+++ b/testsuite/pol/testpkgs/boat/test_boat.src
@@ -52,3 +52,28 @@ exported function move()
   DestroyMulti(res);
   return 1;
 endfunction
+
+/*exported function test_boat_realm_move()
+  // crashed by wrongly converting coordinates between realms
+  var boat:=CreateMultiAtLocation(10,50,-4,0x11000, CRMULTI_FACING_EAST);
+  if (!boat)
+    return ret_error("Failed to create boat "+boat);
+  endif
+
+  var res:=MoveObjectToLocation(boat,1580,150,0,"britannia2",MOVEOBJECT_FORCELOCATION);
+  if (!res || boat.x != 1580 || boat.y != 150 || boat.realm != "britannia2")
+    var err:=$"Failed initial move: {res}:{boat.x},{boat.y},{boat.realm}";
+    DestroyMulti(boat);
+    return ret_error(err);
+  endif
+
+  res:=MoveObjectToLocation(boat,10,10,0,"britannia",MOVEOBJECT_FORCELOCATION);
+  if (!res || boat.x != 10 || boat.y != 10 || boat.realm != "britannia")
+    var err:=$"Failed to move: {res}:{boat.x},{boat.y},{boat.realm}";
+    DestroyMulti(boat);
+    return ret_error(err);
+  endif
+
+  DestroyMulti(boat);
+  return 1;
+endfunction*/

--- a/testsuite/pol/testpkgs/client/communication.inc
+++ b/testsuite/pol/testpkgs/client/communication.inc
@@ -19,6 +19,7 @@ const EVT_TARGET := "target";
 const EVT_DISABLE_ITEM_LOGGING := "disable_item_logging";
 const EVT_NEW_SUBSERVER := "new_subserver";
 const EVT_BOAT_MOVED := "boat_moved";
+const EVT_OWNCREATE := "owncreate";
 
 function clientTestActive()
   var testclient:=GetEnvironmentVariable("POLCORE_TESTCLIENT")=="TRUE";

--- a/testsuite/pol/testpkgs/client/test_client.src
+++ b/testsuite/pol/testpkgs/client/test_client.src
@@ -92,3 +92,26 @@ exported function move_ground()
   endwhile
   return 1;
 endfunction
+
+exported function move_realm()
+  MoveObjectToLocation(char, 100,100,1,flags:=MOVEOBJECT_FORCELOCATION);
+  while (1)
+    var ev:=waitForClient(0, {EVT_OWNCREATE});
+    if (!ev)
+      return ev;
+    endif
+    break;
+  endwhile
+  Clear_Event_Queue();
+  MoveObjectToLocation(char, 100,100,1,"britannia2",MOVEOBJECT_FORCELOCATION);
+  while (1)
+    var ev:=waitForClient(0, {EVT_NEW_SUBSERVER});
+    if (!ev)
+      return ev;
+    endif
+    break;
+  endwhile
+  MoveObjectToLocation(char, 100,100,1,flags:=MOVEOBJECT_FORCELOCATION);
+  Clear_Event_Queue();
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_boat.src
+++ b/testsuite/pol/testpkgs/client/test_client_boat.src
@@ -31,7 +31,7 @@ endprogram
 exported function move_boat()
   var h:=getstandingheight(11,50, boat.z, boat.realm);
   MoveObjectToLocation(char, 11,50,h.z);
-  while (!waitForClient(0, {EVT_NEW_SUBSERVER}))
+  while (!waitForClient(0, {EVT_OWNCREATE}))
   endwhile
   var res:=boat.mobiles.size()==1;
   Clear_Event_Queue();
@@ -74,7 +74,7 @@ exported function move_boat()
     DestroyItem(item);
   endforeach
   MoveObjectToLocation(char, 1,1,1,flags:=MOVEOBJECT_FORCELOCATION);
-  while (!waitForClient(0, {EVT_NEW_SUBSERVER}))
+  while (!waitForClient(0, {EVT_OWNCREATE}))
   endwhile
   Clear_Event_Queue();
   if (!res)
@@ -96,7 +96,7 @@ endfunction
 exported function move_boat_overflow()
   var h:=getstandingheight(11,50, boat.z, boat.realm);
   MoveObjectToLocation(char, 11,50,h.z);
-  while (!waitForClient(0, {EVT_NEW_SUBSERVER}))
+  while (!waitForClient(0, {EVT_OWNCREATE}))
   endwhile
   var res:=boat.mobiles.size()==1;
   Clear_Event_Queue();
@@ -112,7 +112,7 @@ exported function move_boat_overflow()
     DestroyItem(item);
   endforeach
   MoveObjectToLocation(char, 1,1,1,flags:=MOVEOBJECT_FORCELOCATION);
-  while (!waitForClient(0, {EVT_NEW_SUBSERVER}))
+  while (!waitForClient(0, {EVT_OWNCREATE}))
   endwhile
   clientcon.sendevent(struct{todo:=EVT_DISABLE_ITEM_LOGGING, arg:=0, id:=0});
   while (!waitForClient(0, {EVT_DISABLE_ITEM_LOGGING}))

--- a/testsuite/pol/testpkgs/item/test_item.src
+++ b/testsuite/pol/testpkgs/item/test_item.src
@@ -1,0 +1,33 @@
+use uo;
+use os;
+
+include "testutil";
+
+program testitem()
+  return 1;
+endprogram
+
+exported function test_item_realm_move()
+  // crashed by wrongly converting coordinates between realms
+  var item:=CreateItemAtLocation(0,0,0,0xf3f);
+  if (!item)
+    return ret_error("Failed to create item "+item);
+  endif
+
+  MoveObjectToLocation(item,1000,1000,0,"britannia2",MOVEOBJECT_FORCELOCATION);
+  if (item.x != 1000 || item.y != 1000 || item.realm != "britannia2")
+    var res:=$"Failed initial move: {item.x},{item.y},{item.realm}";
+    DestroyItem(item);
+    return ret_error(res);
+  endif
+
+  MoveObjectToLocation(item,10,10,0,"britannia",MOVEOBJECT_FORCELOCATION);
+  if (item.x != 10 || item.y != 10 || item.realm != "britannia")
+    var res:=$"Failed to move: {item.x},{item.y},{item.realm}";
+    DestroyItem(item);
+    return ret_error(res);
+  endif
+
+  DestroyItem(item);
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/npc/test_npc.src
+++ b/testsuite/pol/testpkgs/npc/test_npc.src
@@ -212,3 +212,28 @@ exported function test_load_desc_props()
   npc.kill();
   return 1;
 endfunction
+
+exported function test_npc_realm_move()
+  // crashed by wrongly converting coordinates between realms
+  var npc:=CreateNPCFromTemplate(":testnpc:load_npc",100,100,0);
+  if (!npc)
+    return ret_error("Could not create NPC: "+npc);
+  endif
+
+  MoveObjectToLocation(npc,1000,1000,0,"britannia2",MOVEOBJECT_FORCELOCATION);
+  if (npc.x != 1000 || npc.y != 1000 || npc.realm != "britannia2")
+    var res:=$"Failed initial move: {npc.x},{npc.y},{npc.realm}";
+    npc.kill();
+    return ret_error(res);
+  endif
+
+  MoveObjectToLocation(npc,10,10,0,"britannia",MOVEOBJECT_FORCELOCATION);
+  if (npc.x != 10 || npc.y != 10 || npc.realm != "britannia")
+    var res:=$"Failed to move: {npc.x},{npc.y},{npc.realm}";
+    npc.kill();
+    return ret_error(res);
+  endif
+
+  npc.kill();
+  return 1;
+endfunction

--- a/testsuite/testclient/pyuo/pyuo/brain.py
+++ b/testsuite/testclient/pyuo/pyuo/brain.py
@@ -190,6 +190,7 @@ class Event:
   EVT_REMOVED_OBJ = 9
   EVT_NEW_SUBSERVER = 10
   EVT_BOAT_MOVED = 11
+  EVT_OWNCREATE = 12
 
   EVT_EXIT = 100
   EVT_LIST_OBJS = 101
@@ -242,4 +243,6 @@ class Event:
       return "disable_item_logging"
     elif self.type==Event.EVT_BOAT_MOVED:
       return "boat_moved"
+    elif self.type==Event.EVT_OWNCREATE:
+      return "owncreate"
 

--- a/testsuite/testclient/pyuo/pyuo/client.py
+++ b/testsuite/testclient/pyuo/pyuo/client.py
@@ -586,7 +586,12 @@ class Client(threading.Thread):
     self.net = net.Network(self.server['ip'], self.server['port'])
 
     # Send IP as key (will not use encryption)
-    self.queue(ipaddress.ip_address(self.server['ip']).packed)
+    if int(self.VERSION[0])<=4:
+      self.queue(ipaddress.ip_address(self.server['ip']).packed)
+    else:
+      po = packets.SeedPacket()
+      po.fill(ipaddress.ip_address(self.server['ip']).packed, self.VERSION)
+      self.queue(po)
 
     # Send account login request
     self.log.info('logging in')
@@ -926,6 +931,8 @@ class Client(threading.Thread):
     if pkt.serial in self.objects.keys():
       self.objects[pkt.serial].update(pkt)
       self.log.info("Refreshed mobile: %s", self.objects[pkt.serial])
+      if pkt.serial == self.player.serial:
+        self.brain.event(brain.Event(brain.Event.EVT_OWNCREATE))
     else:
       mob = Mobile(self, pkt)
       self.objects[mob.serial] = mob

--- a/testsuite/testclient/pyuo/pyuo/packets.py
+++ b/testsuite/testclient/pyuo/pyuo/packets.py
@@ -939,6 +939,30 @@ class DrawObjectPacket(Packet):
 #      self.duchar() # unused/closing
 
 
+class SeedPacket(Packet):
+  ''' login seed to server '''
+
+  cmd = 0xEF
+  length = 21
+
+  def fill(self, ip,version):
+    '''!
+    @param version string: The version
+    '''
+
+    self.ip = ip
+    self.version = [int(_) for _ in version.split('.')]
+
+  def encodeChild(self):
+    self.euchar(self.ip[0])
+    self.euchar(self.ip[1])
+    self.euchar(self.ip[2])
+    self.euchar(self.ip[3])
+    self.euint(self.version[0])
+    self.euint(self.version[1])
+    self.euint(self.version[2])
+    self.euint(self.version[3])
+
 class LoginRequestPacket(Packet):
   ''' Login request to server '''
 
@@ -1182,10 +1206,10 @@ class EnableFeaturesPacket(Packet):
   ''' Used to enable client features '''
 
   cmd = 0xb9
-  length = 3
+  length = 5
 
   def decodeChild(self):
-    self.features = self.dushort()
+    self.features =self.duint()
 
 
 class SeasonInfoPacket(Packet):

--- a/testsuite/testclient/pyuo/testclient.py
+++ b/testsuite/testclient/pyuo/testclient.py
@@ -251,6 +251,8 @@ class PolServer:
     elif ev.type==Event.EVT_BOAT_MOVED:
       res['serial']=ev.boat.serial
       res["pos"]=[ev.boat.x, ev.boat.y, ev.boat.z]
+    elif ev.type==Event.EVT_OWNCREATE:
+      pass
     else:
       raise NotImplementedError("Unknown event {}",format(ev.type))
 


### PR DESCRIPTION
Broken due to pos rewrite.
Multis will still crash

Added second realm to the testsuite to be able to test it.
Fixed login seed pkt for testclient.
The core no more sends new subserver pkt when moving a client in the same realm.