### PR TITLE
Fixed ecompile summary output

### DIFF
--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -799,9 +799,9 @@ bool run( int argc, char** argv, int* res )
       tmp << "      - ambiguities: " << (long)summary.profile.ambiguities << "\n";
       tmp << "       - cache hits: " << (long)summary.profile.cache_hits << "\n";
       tmp << "     - cache misses: " << (long)summary.profile.cache_misses << "\n";
-
-      INFO_PRINT << tmp.str();
     }
+
+    INFO_PRINT << tmp.str();
   }
 
   if ( summary.ScriptsWithCompileErrors )


### PR DESCRIPTION
After last updates the ecompile summary will only be printed when the -t parameter is on. I don't think that this needs core-changes entry so only quick fix in code.