### PR TITLE
Add force parameter to CreateNPCFromTemplate()

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,7 +8,7 @@
 		<entry>
 			<date>09-27-2022</date>
 			<author>Brndd:</author>
-			<change type="Added">CreateNPCFromTemplate() now has a &quot;force&quot; parameter, which allows creating NPCs even in invalid locations.</change>
+			<change type="Added">CreateNPCFromTemplate() now has a &quot;forcelocation&quot; parameter, which allows creating NPCs even in invalid locations.</change>
 		</entry>
 		<entry>
 			<date>09-21-2022</date>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>09-21-2022</datemodified>
+		<datemodified>09-27-2022</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>09-27-2022</date>
+			<author>Brndd:</author>
+			<change type="Added">CreateNPCFromTemplate() now has a &quot;force&quot; parameter, which allows creating NPCs even in invalid locations.</change>
+		</entry>
 		<entry>
 			<date>09-21-2022</date>
 			<author>Kevin:</author>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -1349,12 +1349,12 @@ const TE_STYLE_NUMERICAL:= 2;</code></explain>
   <parameter name="z" value="Integer world coordinates" />
   <parameter name="realm" value="String - case-sensitive name of the realm" />
   <parameter name="override_properties" value="A Struct with keys as String members and values as appropriate (see notes)" />
-  <parameter name="forceposition" value="Integer (0/1)" />
+  <parameter name="forcelocation" value="Integer (0/1)" />
   <explain>Creates an NPC from a template (found in NPCDESC.CFG).</explain>
   <explain>Notes: override_properties: a structure containing members to override values in the 
         NPC template. This can be used to override built-in properties (facing, 
         color, gender etc) and custom properties ("CProps" = dictionary {key=cpropname value=cpropvalue})</explain>
-  <explain>forceposition: if true, the NPC will be created even in an invalid location.</explain>
+  <explain>forcelocation: if true, the NPC will be created even in an invalid location.</explain>
   <return>Character Reference on success</return>
   <error>"Invalid parameter type"</error>
   <error>"Parameter 4 must be a Struct or Integer(0)"</error>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -1349,10 +1349,12 @@ const TE_STYLE_NUMERICAL:= 2;</code></explain>
   <parameter name="z" value="Integer world coordinates" />
   <parameter name="realm" value="String - case-sensitive name of the realm" />
   <parameter name="override_properties" value="A Struct with keys as String members and values as appropriate (see notes)" />
+  <parameter name="force" value="Integer (0/1)" />
   <explain>Creates an NPC from a template (found in NPCDESC.CFG).</explain>
   <explain>Notes: override_properties: a structure containing members to override values in the 
         NPC template. This can be used to override built-in properties (facing, 
         color, gender etc) and custom properties ("CProps" = dictionary {key=cpropname value=cpropvalue})</explain>
+  <explain>force: if true, the NPC will be created even in an invalid location.</explain>
   <return>Character Reference on success</return>
   <error>"Invalid parameter type"</error>
   <error>"Parameter 4 must be a Struct or Integer(0)"</error>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -1349,12 +1349,12 @@ const TE_STYLE_NUMERICAL:= 2;</code></explain>
   <parameter name="z" value="Integer world coordinates" />
   <parameter name="realm" value="String - case-sensitive name of the realm" />
   <parameter name="override_properties" value="A Struct with keys as String members and values as appropriate (see notes)" />
-  <parameter name="force" value="Integer (0/1)" />
+  <parameter name="forceposition" value="Integer (0/1)" />
   <explain>Creates an NPC from a template (found in NPCDESC.CFG).</explain>
   <explain>Notes: override_properties: a structure containing members to override values in the 
         NPC template. This can be used to override built-in properties (facing, 
         color, gender etc) and custom properties ("CProps" = dictionary {key=cpropname value=cpropvalue})</explain>
-  <explain>force: if true, the NPC will be created even in an invalid location.</explain>
+  <explain>forceposition: if true, the NPC will be created even in an invalid location.</explain>
   <return>Character Reference on success</return>
   <error>"Invalid parameter type"</error>
   <error>"Parameter 4 must be a Struct or Integer(0)"</error>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,6 @@
 ﻿-- POL100.1.0 --
 09-27-2022 Brndd:
-    Added: CreateNPCFromTemplate() now has a "force" parameter, which allows creating NPCs even in invalid locations.
+    Added: CreateNPCFromTemplate() now has a "forcelocation" parameter, which allows creating NPCs even in invalid locations.
 09-21-2022 Kevin:
     Added: POLCore() member "poldir", returning the directory of the POL executable.
 08-25-2022 Yukiko:

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100.1.0 --
+09-27-2022 Brndd:
+    Added: CreateNPCFromTemplate() now has a "force" parameter, which allows creating NPCs even in invalid locations.
 09-21-2022 Kevin:
     Added: POLCore() member "poldir", returning the directory of the POL executable.
 08-25-2022 Yukiko:

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -1271,7 +1271,7 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
   short z;
   const String* strrealm;
   int forceInt;
-  bool force;
+  bool forceLocation;
   Realms::Realm* realm = find_realm( "britannia" );
 
   if ( !( getStringParam( 0, tmplname ) && getParam( 1, x ) && getParam( 2, y ) &&
@@ -1308,11 +1308,11 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
 
   if ( !getParam( 6, forceInt ))
   {
-    force = false;
+    forceLocation = false;
   }
   else
   {
-    force = forceInt ? true : false;
+    forceLocation = forceInt ? true : false;
   }
 
   Clib::ConfigElem elem;
@@ -1332,10 +1332,10 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
   Item* dummy_walkon = nullptr;
   if ( !realm->walkheight( x, y, z, &newz, &dummy_multi, &dummy_walkon, true, movemode ) )
   {
-    if ( ! force )
+    if ( !forceLocation )
       return new BError( "Not a valid location for an NPC!" );
   }
-  if ( !force )
+  if ( !forceLocation )
     z = newz;
 
 

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -1270,6 +1270,8 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
   unsigned short x, y;
   short z;
   const String* strrealm;
+  int forceInt;
+  bool force;
   Realms::Realm* realm = find_realm( "britannia" );
 
   if ( !( getStringParam( 0, tmplname ) && getParam( 1, x ) && getParam( 2, y ) &&
@@ -1304,6 +1306,15 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
   if ( !realm->valid( x, y, z ) )
     return new BError( "Invalid Coordinates for Realm" );
 
+  if ( !getParam( 6, forceInt ))
+  {
+    force = false;
+  }
+  else
+  {
+    force = forceInt ? true : false;
+  }
+
   Clib::ConfigElem elem;
   START_PROFILECLOCK( npc_search );
   bool found = FindNpcTemplate( tmplname->data(), elem );
@@ -1317,13 +1328,15 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
   Plib::MOVEMODE movemode = Character::decode_movemode( elem.read_string( "MoveMode", "L" ) );
 
   short newz;
-  Multi::UMulti* dummy_multi;
-  Item* dummy_walkon;
+  Multi::UMulti* dummy_multi = nullptr;
+  Item* dummy_walkon = nullptr;
   if ( !realm->walkheight( x, y, z, &newz, &dummy_multi, &dummy_walkon, true, movemode ) )
   {
-    return new BError( "Not a valid location for an NPC!" );
+    if ( ! force )
+      return new BError( "Not a valid location for an NPC!" );
   }
-  z = newz;
+  if ( !force )
+    z = newz;
 
 
   NpcRef npc;
@@ -1346,7 +1359,6 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
     if ( custom_struct != nullptr )
       replace_properties( elem, custom_struct );
     npc->readPropertiesForNewNPC( elem );
-
     ////HASH
     objStorageManager.objecthash.Insert( npc.get() );
     ////
@@ -1357,7 +1369,6 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
     WorldIterator<OnlinePlayerFilter>::InVisualRange(
         npc.get(), [&]( Character* zonechr ) { send_char_data( zonechr->client, npc.get() ); } );
     realm->notify_entered( *npc );
-
     // FIXME: Need to add Walkon checks for multi right here if type is house.
     if ( dummy_multi )
     {
@@ -1383,7 +1394,6 @@ BObjectImp* UOExecutorModule::mf_CreateNpcFromTemplate()
         npc->registered_house = 0;
       }
     }
-
     return new ECharacterRefObjImp( npc.get() );
   }
   catch ( std::exception& ex )

--- a/pol-core/support/scripts/uo.em
+++ b/pol-core/support/scripts/uo.em
@@ -274,7 +274,7 @@ CreateItemInContainer( container, objtype, amount := 1 );
 CreateItemInInventory( container, objtype, amount := 1 );
 CreateMenu( title );
 CreateMultiAtLocation( x, y, z, objtype, flags := 0, realm := _DEFAULT_REALM );
-CreateNpcFromTemplate( template, x, y, z, override_properties := 0, realm := _DEFAULT_REALM);
+CreateNpcFromTemplate( template, x, y, z, override_properties := 0, realm := _DEFAULT_REALM, force := 0);
 DestroyItem( item );
 DestroyMulti( multi );
 Detach();

--- a/pol-core/support/scripts/uo.em
+++ b/pol-core/support/scripts/uo.em
@@ -274,7 +274,7 @@ CreateItemInContainer( container, objtype, amount := 1 );
 CreateItemInInventory( container, objtype, amount := 1 );
 CreateMenu( title );
 CreateMultiAtLocation( x, y, z, objtype, flags := 0, realm := _DEFAULT_REALM );
-CreateNpcFromTemplate( template, x, y, z, override_properties := 0, realm := _DEFAULT_REALM, force := 0);
+CreateNpcFromTemplate( template, x, y, z, override_properties := 0, realm := _DEFAULT_REALM, forcelocation := 0);
 DestroyItem( item );
 DestroyMulti( multi );
 Detach();


### PR DESCRIPTION
There are times where I want to create NPCs in unwalkable locations, such as inside of walls, or in water, or create sea creatures on land. I worked around this in EScript by creating the NPC outside of the map and then force-moving it to its final destination, but I figured it's silly to have to use such workarounds instead of just updating the core. 

This patch seems to work, but I must confess I'm not terribly familiar with the core's workings so there is a chance that I messed something up.

Another option I considered was adding a flag variable to allow for more granular control of exactly what conditions are ignored, but I couldn't think of enough flags that would really be useful. It would've been something like "ignore doors", "ignore movemode", "ignore everything". If that sounds like a better solution to you, I am open to changing this PR to do that instead.