### PR TITLE
fix ci action for nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,14 +185,17 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: Nightly-Linux-g++
+          path: Nightly-Linux-g++
       - name: Download artefacts
         uses: actions/download-artifact@v3
         with:
           name: Nightly-Linux-clang++
+          path: Nightly-Linux-clang++
       - name: Download artefacts
         uses: actions/download-artifact@v3
         with:
           name: Nightly-Windows-cl
+          path: Nightly-Windows-cl
 
       - name: Create Release zip
         run: |


### PR DESCRIPTION
Updating to downloadartefactv3 changed behavior. Before it created a subfolder. With path addition we mimic the old behavior.