### PR TITLE
Fix crash related to item position

### DIFF
--- a/pol-core/pol/module/uomod4.cpp
+++ b/pol-core/pol/module/uomod4.cpp
@@ -202,7 +202,7 @@ BObjectImp* UOExecutorModule::internal_MoveItem( Item* item, Core::Pos4d newpos,
     // in the right place to start with.
     add_item_to_world( item );
   }
-  const Pos4d& oldpos = item->toplevel_pos();
+  const Pos4d oldpos = item->toplevel_pos();
   item->setposition( newpos );
   move_item( item, oldpos );
 


### PR DESCRIPTION
Fix credits goes to @turleypol I'm just creating the PR :) 

This is a fix for random crashes when destroying items after last refactoring.

```
remove_item_from_world: item 0x790E5EB8 at 6104,1183 does not exist in world zone ( Old Serial: 0x790E5EB8 )
Assertion Failed: itr != zone.items.end(),
/home/x/poldev/polserver/pol-core/pol/uworld.cpp, line 62
```