### PR TITLE
Fix crash related to item position in multi houses

### DIFF
--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -832,7 +832,7 @@ Bscript::BObjectImp* UHouse::scripted_create( const Items::ItemDesc& descriptor,
 
 void move_to_ground( Items::Item* item )
 {
-  const Core::Pos4d& oldpos = item->toplevel_pos();
+  const Core::Pos4d oldpos = item->toplevel_pos();
   item->set_dirty();
   item->movable( true );
   item->set_decay_after( 60 );  // just a dummy in case decay=0


### PR DESCRIPTION
This one is for multi -> house as it looks like it was missed when fixing the crashes last time.

Previous fix: https://github.com/polserver/polserver/commit/6f0db1810a9ebbc21528bdca20bf13375a996401
Original refactoring: https://github.com/polserver/polserver/commit/eeb57d489ace48a973459dafde4cdeac1312ba80