### PR TITLE
Include items on exterior stairs of custom houses in MultiRef.items

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-06-2023</datemodified>
+		<datemodified>02-27-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>02-27-2023</date>
+			<author>Kevin:</author>
+			<change type="Fixed">MultiRef.items now correctly includes items on the exterior stairs of custom houses.</change>
+		</entry>
 		<entry>
 			<date>02-06-2023</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 ﻿-- POL100.1.0 --
+02-27-2023 Kevin:
+    Fixed: MultiRef.items now correctly includes items on the exterior stairs of custom houses.
 02-06-2023 Kevin:
     Added: HTTPRequest() now accepts a flags parameter. If HTTPREQUEST_EXTENDED_RESPONSE is passed as flags, returns a Dictionary with members: 'status', the numeric HTTP status code; 'statusText', the reason phrase; 'headers', a Dictionary of key-values for each header; 'body', the response text body.
     Added: http::WriteStatus(code, reason := "") to change the status of an HTTP response from the web server. If no reason is provided, one will be calculated from the code (if possible). This can only used once before WriteHeader(), WriteHtml(), and WriteHtmlRaw().

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -687,6 +687,17 @@ Bscript::ObjArray* CustomHouseDesign::list_parts() const
 
 void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pkts )
 {
+  ItemList itemlist;
+  MobileList moblist;
+  bool was_editing = house->editing;
+  house->editing = false;
+  UHouse::list_contents( house, itemlist, moblist );
+  house->editing = was_editing;
+  CustomHouseStopEditing( chr, house, itemlist, send_pkts );
+}
+
+void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& itemlist, bool send_pkts )
+{
   if ( send_pkts && chr->client )
   {
     Network::PktHelper::PacketOut<Network::PktOut_BF_Sub20> msg;
@@ -710,9 +721,6 @@ void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pk
   house->editing = false;
   if ( send_pkts && chr->client )
   {
-    ItemList itemlist;
-    MobileList moblist;
-    UHouse::list_contents( house, itemlist, moblist );
     while ( !itemlist.empty() )
     {
       Items::Item* item = itemlist.front();
@@ -1167,6 +1175,13 @@ void UHouse::CustomHouseSetInitialState()
 
 void UHouse::CustomHousesQuit( Mobile::Character* chr, bool drop_changes, bool send_pkts )
 {
+  ItemList itemlist;
+  MobileList moblist;
+  bool was_editing = editing;
+  editing = false;
+  UHouse::list_contents( this, itemlist, moblist );
+  editing = was_editing;
+
   if ( drop_changes )
     WorkingDesign = CurrentDesign;
   else
@@ -1182,7 +1197,7 @@ void UHouse::CustomHousesQuit( Mobile::Character* chr, bool drop_changes, bool s
   CurrentCompressed.swap( newvec2 );
   if ( chr )
   {
-    CustomHouseStopEditing( chr, this, send_pkts );
+    CustomHouseStopEditing( chr, this, itemlist, send_pkts );
     if ( chr->client && send_pkts )
       CustomHousesSendFull( this, chr->client, HOUSE_DESIGN_CURRENT );
     if ( Core::gamestate.system_hooks.close_customhouse_hook )

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -685,17 +685,6 @@ Bscript::ObjArray* CustomHouseDesign::list_parts() const
   return arr.release();
 }
 
-void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pkts )
-{
-  ItemList itemlist;
-  MobileList moblist;
-  bool was_editing = house->editing;
-  house->editing = false;
-  UHouse::list_contents( house, itemlist, moblist );
-  house->editing = was_editing;
-  CustomHouseStopEditing( chr, house, itemlist, send_pkts );
-}
-
 void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& itemlist,
                              bool send_pkts )
 {
@@ -1176,12 +1165,7 @@ void UHouse::CustomHouseSetInitialState()
 
 void UHouse::CustomHousesQuit( Mobile::Character* chr, bool drop_changes, bool send_pkts )
 {
-  ItemList itemlist;
-  MobileList moblist;
-  bool was_editing = editing;
-  editing = false;
-  UHouse::list_contents( this, itemlist, moblist );
-  editing = was_editing;
+  ItemList itemlist = get_working_design_items( this );
 
   if ( drop_changes )
     WorkingDesign = CurrentDesign;

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -696,7 +696,8 @@ void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pk
   CustomHouseStopEditing( chr, house, itemlist, send_pkts );
 }
 
-void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& itemlist, bool send_pkts )
+void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& itemlist,
+                             bool send_pkts )
 {
   if ( send_pkts && chr->client )
   {

--- a/pol-core/pol/multi/customhouses.h
+++ b/pol-core/pol/multi/customhouses.h
@@ -80,6 +80,7 @@ typedef std::list<CUSTOM_HOUSE_ELEMENT> HouseFloorZColumn;
 // v v v v v v
 // [][][][][][] - lists of zoffsets
 // [][][][][][]
+typedef std::list<Items::Item*> ItemList;
 
 class CustomHouseElements
 {
@@ -175,7 +176,7 @@ void CustomHousesSendFull( UHouse* house, Network::Client* client,
 void CustomHousesSendFullToInRange( UHouse* house, int design, int range );
 void CustomHousesSendShort( UHouse* house, Network::Client* client );
 void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pkts = true );
-void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, std::list<Items::Item*>& foo,
+void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& foo,
                              bool send_pkts = true );
 }  // namespace Multi
 }  // namespace Pol

--- a/pol-core/pol/multi/customhouses.h
+++ b/pol-core/pol/multi/customhouses.h
@@ -175,6 +175,8 @@ void CustomHousesSendFull( UHouse* house, Network::Client* client,
 void CustomHousesSendFullToInRange( UHouse* house, int design, int range );
 void CustomHousesSendShort( UHouse* house, Network::Client* client );
 void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pkts = true );
+void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, std::list<Items::Item*>& foo,
+                             bool send_pkts = true );
 }  // namespace Multi
 }  // namespace Pol
 #endif

--- a/pol-core/pol/multi/customhouses.h
+++ b/pol-core/pol/multi/customhouses.h
@@ -175,8 +175,7 @@ void CustomHousesSendFull( UHouse* house, Network::Client* client,
                            int design = HOUSE_DESIGN_CURRENT );
 void CustomHousesSendFullToInRange( UHouse* house, int design, int range );
 void CustomHousesSendShort( UHouse* house, Network::Client* client );
-void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, bool send_pkts = true );
-void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& foo,
+void CustomHouseStopEditing( Mobile::Character* chr, UHouse* house, ItemList& itemlist,
                              bool send_pkts = true );
 }  // namespace Multi
 }  // namespace Pol

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -61,6 +61,13 @@ namespace Pol
 {
 namespace Multi
 {
+Core::Range3d UHouse::search_box() const
+{
+  const MultiDef& md = multidef();
+  Core::Vec2d delta = IsCustom() ? Core::Vec2d( 0, 1 ) : Core::Vec2d( 0, 0 );
+  return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz + delta );
+}
+
 void UHouse::list_contents( const UHouse* house, ItemList& items_in, MobileList& chrs_in )
 {
   auto box = house->search_box();

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -63,7 +63,7 @@ namespace Multi
 {
 void UHouse::list_contents( const UHouse* house, ItemList& items_in, MobileList& chrs_in )
 {
-  auto box = house->current_box();
+  auto box = house->search_box();
   Core::WorldIterator<Core::MobileFilter>::InBox(
       box.range(), house->realm(),
       [&]( Mobile::Character* chr )

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -988,6 +988,13 @@ void UHouse::AcceptHouseCommit( Mobile::Character* chr, bool accept )
   waiting_for_accept = false;
   if ( accept )
   {
+    ItemList itemlist;
+    MobileList moblist;
+    bool was_editing = editing;
+    editing = false;
+    UHouse::list_contents( this, itemlist, moblist );
+    editing = was_editing;
+
     revision++;
 
     // commit working design to current design
@@ -997,7 +1004,7 @@ void UHouse::AcceptHouseCommit( Mobile::Character* chr, bool accept )
     std::vector<u8> newvec;
     CurrentCompressed.swap( newvec );
 
-    CustomHouseStopEditing( chr, this );
+    CustomHouseStopEditing( chr, this, itemlist );
 
     // send full house
     CustomHousesSendFullToInRange( this, HOUSE_DESIGN_CURRENT, RANGE_VISUAL_LARGE_BUILDINGS );

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -72,6 +72,17 @@ Core::Range3d UHouse::current_box() const
   return base::current_box();
 }
 
+ItemList UHouse::get_working_design_items( UHouse* house )
+{
+  ItemList itemlist;
+  MobileList moblist;
+  bool was_editing = house->editing;
+  house->editing = false;
+  UHouse::list_contents( house, itemlist, moblist );
+  house->editing = was_editing;
+  return itemlist;
+}
+
 void UHouse::list_contents( const UHouse* house, ItemList& items_in, MobileList& chrs_in )
 {
   auto box = house->current_box();
@@ -988,12 +999,7 @@ void UHouse::AcceptHouseCommit( Mobile::Character* chr, bool accept )
   waiting_for_accept = false;
   if ( accept )
   {
-    ItemList itemlist;
-    MobileList moblist;
-    bool was_editing = editing;
-    editing = false;
-    UHouse::list_contents( this, itemlist, moblist );
-    editing = was_editing;
+    auto itemlist = get_working_design_items( this );
 
     revision++;
 

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -61,16 +61,20 @@ namespace Pol
 {
 namespace Multi
 {
-Core::Range3d UHouse::search_box() const
+Core::Range3d UHouse::current_box() const
 {
-  const MultiDef& md = multidef();
-  Core::Vec2d delta = IsCustom() ? Core::Vec2d( 0, 1 ) : Core::Vec2d( 0, 0 );
-  return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz + delta );
+  if ( IsCustom() )
+  {
+    const MultiDef& md = multidef();
+    return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz + Core::Vec2d( 0, 1 ) );
+  }
+  
+  return base::current_box();
 }
 
 void UHouse::list_contents( const UHouse* house, ItemList& items_in, MobileList& chrs_in )
 {
-  auto box = house->search_box();
+  auto box = house->current_box();
   Core::WorldIterator<Core::MobileFilter>::InBox(
       box.range(), house->realm(),
       [&]( Mobile::Character* chr )

--- a/pol-core/pol/multi/house.h
+++ b/pol-core/pol/multi/house.h
@@ -98,7 +98,7 @@ public:
 
   virtual void walk_on( Mobile::Character* chr ) override;
 
-  virtual Core::Range3d search_box() const override;
+  virtual Core::Range3d current_box() const override;
 
   void ClearSquatters();
   bool add_component( Items::Item* item, s32 xoff, s32 yoff, s16 zoff );

--- a/pol-core/pol/multi/house.h
+++ b/pol-core/pol/multi/house.h
@@ -104,6 +104,7 @@ public:
   bool add_component( Items::Item* item, s32 xoff, s32 yoff, s16 zoff );
   bool add_component( Component component );
   static void list_contents( const UHouse* house, ItemList& items_in, MobileList& chrs_in );
+  static ItemList get_working_design_items( UHouse* house );
   void AcceptHouseCommit( Mobile::Character* chr, bool accept );
   void CustomHousesQuit( Mobile::Character* chr, bool drop_changes, bool send_pkts = true );
 

--- a/pol-core/pol/multi/house.h
+++ b/pol-core/pol/multi/house.h
@@ -98,6 +98,8 @@ public:
 
   virtual void walk_on( Mobile::Character* chr ) override;
 
+  virtual Core::Range3d search_box() const override;
+
   void ClearSquatters();
   bool add_component( Items::Item* item, s32 xoff, s32 yoff, s16 zoff );
   bool add_component( Component component );

--- a/pol-core/pol/multi/multi.h
+++ b/pol-core/pol/multi/multi.h
@@ -89,6 +89,7 @@ public:
   virtual bool readshapes( Plib::MapShapeList& vec, s16 rx, s16 ry, s16 zbase );
   virtual bool readobjects( Plib::StaticList& vec, s16 rx, s16 ry, s16 zbase );
   Core::Range3d current_box() const;
+  Core::Range3d search_box() const;
 
   virtual ~UMulti();
   virtual size_t estimatedSize() const override;

--- a/pol-core/pol/multi/multi.h
+++ b/pol-core/pol/multi/multi.h
@@ -89,7 +89,7 @@ public:
   virtual bool readshapes( Plib::MapShapeList& vec, s16 rx, s16 ry, s16 zbase );
   virtual bool readobjects( Plib::StaticList& vec, s16 rx, s16 ry, s16 zbase );
   Core::Range3d current_box() const;
-  Core::Range3d search_box() const;
+  virtual Core::Range3d search_box() const;
 
   virtual ~UMulti();
   virtual size_t estimatedSize() const override;

--- a/pol-core/pol/multi/multi.h
+++ b/pol-core/pol/multi/multi.h
@@ -88,8 +88,7 @@ public:
   Bscript::BStruct* footprint() const;
   virtual bool readshapes( Plib::MapShapeList& vec, s16 rx, s16 ry, s16 zbase );
   virtual bool readobjects( Plib::StaticList& vec, s16 rx, s16 ry, s16 zbase );
-  Core::Range3d current_box() const;
-  virtual Core::Range3d search_box() const;
+  virtual Core::Range3d current_box() const;
 
   virtual ~UMulti();
   virtual size_t estimatedSize() const override;

--- a/pol-core/pol/multi/multis.cpp
+++ b/pol-core/pol/multi/multis.cpp
@@ -92,6 +92,12 @@ Core::Range3d UMulti::current_box() const
   return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz );
 }
 
+Core::Range3d UMulti::search_box() const
+{
+  const MultiDef& md = multidef();
+  return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz + Core::Vec2d( 0, 1 ) );
+}
+
 Bscript::BObjectImp* UMulti::get_script_member_id( const int id ) const  /// id test
 {
   Bscript::BObjectImp* imp = base::get_script_member_id( id );

--- a/pol-core/pol/multi/multis.cpp
+++ b/pol-core/pol/multi/multis.cpp
@@ -92,11 +92,6 @@ Core::Range3d UMulti::current_box() const
   return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz );
 }
 
-Core::Range3d UMulti::search_box() const
-{
-  return current_box();
-}
-
 Bscript::BObjectImp* UMulti::get_script_member_id( const int id ) const  /// id test
 {
   Bscript::BObjectImp* imp = base::get_script_member_id( id );

--- a/pol-core/pol/multi/multis.cpp
+++ b/pol-core/pol/multi/multis.cpp
@@ -94,8 +94,7 @@ Core::Range3d UMulti::current_box() const
 
 Core::Range3d UMulti::search_box() const
 {
-  const MultiDef& md = multidef();
-  return Core::Range3d( pos() + md.minrxyz, pos() + md.maxrxyz + Core::Vec2d( 0, 1 ) );
+  return current_box();
 }
 
 Bscript::BObjectImp* UMulti::get_script_member_id( const int id ) const  /// id test

--- a/pol-core/pol/realms/realmfunc.cpp
+++ b/pol-core/pol/realms/realmfunc.cpp
@@ -434,12 +434,7 @@ bool Realm::walkheight( const Mobile::Character* chr, const Core::Pos2d& pos, sh
           Multi::UHouse* house = multi->as_house();
           if ( house != nullptr )
           {
-            Multi::ItemList itemlist;
-            Multi::MobileList moblist;
-            bool was_editing = house->editing;
-            house->editing = false;
-            Multi::UHouse::list_contents( house, itemlist, moblist );
-            house->editing = was_editing;
+            Multi::ItemList itemlist = Multi::UHouse::get_working_design_items( house );
             Multi::CustomHouseStopEditing( const_cast<Mobile::Character*>( chr ), house, itemlist );
             Multi::CustomHousesSendFull( house, chr->client, Multi::HOUSE_DESIGN_CURRENT );
           }

--- a/pol-core/pol/realms/realmfunc.cpp
+++ b/pol-core/pol/realms/realmfunc.cpp
@@ -434,7 +434,13 @@ bool Realm::walkheight( const Mobile::Character* chr, const Core::Pos2d& pos, sh
           Multi::UHouse* house = multi->as_house();
           if ( house != nullptr )
           {
-            Multi::CustomHouseStopEditing( const_cast<Mobile::Character*>( chr ), house );
+            Multi::ItemList itemlist;
+            Multi::MobileList moblist;
+            bool was_editing = house->editing;
+            house->editing = false;
+            Multi::UHouse::list_contents( house, itemlist, moblist );
+            house->editing = was_editing;
+            Multi::CustomHouseStopEditing( const_cast<Mobile::Character*>( chr ), house, itemlist );
             Multi::CustomHousesSendFull( house, chr->client, Multi::HOUSE_DESIGN_CURRENT );
           }
         }


### PR DESCRIPTION
Items on exterior stairs of custom houses were not being included in the multi's `item` script member.

Here is a script where I target the robe, check `robe.multi`, and loop through `robe.multi.items`: 

```
    var item := Target(who).multi;
    Broadcast($"multi: {item}");
    foreach child_item in (item.items)
        Broadcast($"  child item: {child_item.objtype} - {child_item.desc}");
    endforeach
```

First iteration shows the robe not included, and second iteration shows robe included:

<img width="409" alt="Screenshot 2023-02-27 at 22 56 04" src="https://user-images.githubusercontent.com/8634912/221699417-7fd2eb09-1502-4928-ad0e-6851079786cc.png">
