### PR TITLE
Diagnostics: Disable Optimizer in analysis mode

### DIFF
--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -146,7 +146,8 @@ std::unique_ptr<CompilerWorkspace> Compiler::analyze( const std::string& pathnam
   if ( workspace )
   {
     register_constants( *workspace, report );
-    optimize( *workspace, report );
+    // We skip optimization so we can still get constants in the AST
+    // optimize( *workspace, report );
     disambiguate( *workspace, report );
     analyze( *workspace, report );
     tokenize( *workspace );

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -439,6 +439,10 @@ void SemanticAnalyzer::visit_identifier( Identifier& node )
   {
     node.variable = global;
   }
+  else if ( auto const_decl = workspace.constants.find( node.name ) )
+  {
+    // Do not show errors on constants
+  }
   else
   {
     report.error( node, "Unknown identifier '", node.name, "'." );

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -79,8 +79,10 @@ void CodeGenerator::generate_instructions( CompilerWorkspace& workspace )
   emitter.debug_file_line( 0, 1 );
 
   std::map<std::string, FlowControlLabel> user_function_labels;
-  InstructionGenerator outer_instruction_generator( emitter, user_function_labels, false );
-  InstructionGenerator function_instruction_generator( emitter, user_function_labels, true );
+  InstructionGenerator outer_instruction_generator( workspace, emitter, user_function_labels,
+                                                    false );
+  InstructionGenerator function_instruction_generator( workspace, emitter, user_function_labels,
+                                                       true );
 
   workspace.top_level_statements->accept( outer_instruction_generator );
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -61,6 +61,7 @@
 #include "bscript/compiler/codegen/DebugBlockGuard.h"
 #include "bscript/compiler/codegen/InstructionEmitter.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
+#include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/FlowControlLabel.h"
 #include "bscript/compiler/model/FunctionLink.h"
 #include "bscript/compiler/model/Variable.h"
@@ -69,12 +70,13 @@
 namespace Pol::Bscript::Compiler
 {
 InstructionGenerator::InstructionGenerator(
-    InstructionEmitter& emitter, std::map<std::string, FlowControlLabel>& user_function_labels,
-    bool in_function )
-  : emitter( emitter ),
-    emit( emitter ),
-    user_function_labels( user_function_labels ),
-    in_function( in_function )
+    CompilerWorkspace& workspace, InstructionEmitter& emitter,
+    std::map<std::string, FlowControlLabel>& user_function_labels, bool in_function )
+    : workspace( workspace ),
+      emitter( emitter ),
+      emit( emitter ),
+      user_function_labels( user_function_labels ),
+      in_function( in_function )
 {
 }
 
@@ -435,6 +437,10 @@ void InstructionGenerator::visit_identifier( Identifier& node )
   if ( auto var = node.variable )
   {
     emit.access_variable( *var );
+  }
+  else if ( auto const_decl = workspace.constants.find( node.name ) )
+  {
+    visit_children( const_decl->expression() );
   }
   else
   {

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -8,6 +8,7 @@
 
 namespace Pol::Bscript::Compiler
 {
+class CompilerWorkspace;
 class FlowControlLabel;
 class InstructionEmitter;
 class SourceLocation;
@@ -15,9 +16,9 @@ class SourceLocation;
 class InstructionGenerator : public NodeVisitor
 {
 public:
-  InstructionGenerator( InstructionEmitter&,
+  InstructionGenerator( CompilerWorkspace&, InstructionEmitter&,
                         std::map<std::string, FlowControlLabel>& user_function_labels,
-                        bool in_function);
+                        bool in_function );
 
   void generate( Node& );
 
@@ -73,6 +74,7 @@ public:
   void visit_conditional_operator( ConditionalOperator& ) override;
 
 private:
+  CompilerWorkspace& workspace;
   // There are two of these because sometimes when calling a method
   // on InstructionEmitter, the variable name reads better as a noun,
   // and sometimes it reads better as a verb.


### PR DESCRIPTION
The optimizer will replace constants _inside_ the AST. The AST must be un-optimized in order to properly find constant references.