### PR TITLE
Fixed core-changes typo

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,14 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-30-2023</datemodified>
+		<datemodified>09-29-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
 		<entry>
 			<date>03-09-2023</date>
 			<author>Ins:</author>
 			<change type="Added">repsys.cfg General section &quot;PartyHarmFullCountsAsCriminal 1/0&quot; default 1.<br/>
-				If 0 OnHarm does not set mobile to criminal when they are in the same party.</change>
+If 0 OnHarm does not set mobile to criminal when they are in the same party.</change>
 		</entry>
 		<entry>
 			<date>08-30-2023</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,7 +1,7 @@
 -- POL100.1.0 --
 03-09-2023 Ins:
-    Added: repsys.cfg General section "PartyHelpFullCountsAsCriminal 1/0" default 1.
-    If 0 OnHarm does not set mobile to criminal when they are in the same party.
+    Added: repsys.cfg General section "PartyHarmFullCountsAsCriminal 1/0" default 1.
+           If 0 OnHarm does not set mobile to criminal when they are in the same party.
 08-30-2023 Kevin:
     Fixed: Client character no longer stutters while moving the character and changing the 'poison' property.
 08-29-2023 Kevin:


### PR DESCRIPTION
- core-changes.txt had different message then the one from xml. It should contain `PartyHarmFullCountsAsCriminal` and not `PartyHelpFullCountsAsCriminal`
- minor formatting fix