### PR TITLE
fixed ReloadConfiguration()

### DIFF
--- a/cmake/core_tests_start.cmake
+++ b/cmake/core_tests_start.cmake
@@ -5,7 +5,7 @@ execute_process(
   COMMAND_ECHO STDOUT
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   RESULT_VARIABLE res
-  TIMEOUT 120
+  TIMEOUT 600
 )
 if(NOT "${res}" STREQUAL "0")
   message(SEND_ERROR "${res}")

--- a/pol-core/pol/globals/uvars.h
+++ b/pol-core/pol/globals/uvars.h
@@ -254,13 +254,14 @@ public:
   Core::Vec2d update_range;  // maximum update range (client view range/multi footprint) used as
                              // "pre-filtering" of objects
 
+  void unload_npc_templates();
+
 private:
   void cleanup_vars();
   void cleanup_scripts();
   void clear_listen_points();
   void unload_intrinsic_weapons();
   void unload_intrinsic_templates();
-  void unload_npc_templates();
 };
 extern GameState gamestate;
 }  // namespace Core

--- a/pol-core/pol/loadunld.cpp
+++ b/pol-core/pol/loadunld.cpp
@@ -254,10 +254,10 @@ void load_data()
   read_npc_templates();
 
 
-  //#ifdef _WIN32
+  // #ifdef _WIN32
   checkpoint( "load console commands" );
   ConsoleCommand::load_console_commands();
-  //#endif
+  // #endif
 
   Module::load_fileaccess_cfg();
 
@@ -269,6 +269,7 @@ void reload_configuration()
 {
   PolConfig::read_pol_config( false );
   Network::read_bannedips_config( false );
+  gamestate.unload_npc_templates();
   load_npc_templates();
   read_npc_templates();  // dave 1/12/3 npc template data wasn't actually being read, just names.
   ConsoleCommand::load_console_commands();

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -11,6 +11,7 @@
 #ifndef POLCFG_H
 #define POLCFG_H
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ struct PolConfig
   std::string world_data_path;
   std::string realm_data_path;
   std::string pidfile_path;
-  bool verbose;
+  std::atomic<bool> verbose;
   unsigned short loglevel;  // 0=nothing 10=lots
   unsigned short select_timeout_usecs;
   unsigned short loginserver_timeout_mins;
@@ -55,10 +56,10 @@ struct PolConfig
   bool enable_secure_trading;
   unsigned int runaway_script_threshold;
   bool ignore_load_errors;
-  unsigned short min_cmdlvl_ignore_inactivity;
-  unsigned short inactivity_warning_timeout;
-  unsigned short inactivity_disconnect_timeout;
-  unsigned short min_cmdlevel_to_login;
+  std::atomic<unsigned short> min_cmdlvl_ignore_inactivity;
+  std::atomic<unsigned short> inactivity_warning_timeout;
+  std::atomic<unsigned short> inactivity_disconnect_timeout;
+  std::atomic<unsigned short> min_cmdlevel_to_login;
   unsigned int max_tile_id;
   unsigned int max_objtype;
 


### PR DESCRIPTION
Datarace of client settings
Memleak of NPC templates
Increased the timeout of shard test, 2minutes is especially for the sanitizer builds now not enough.