### PR TITLE
ReloadConfiguration reloads npctemplates, leaving dangling references in the NPCs

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>11-01-2023</datemodified>
+		<datemodified>11-08-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>11-08-2023</date>
+			<author>Turley:</author>
+			<change type="Fixed">crash due to NPCs after calling ReloadConfiguration</change>
+		</entry>
 		<entry>
 			<date>11-01-2023</date>
 			<author>Kevin:</author>
@@ -14,14 +19,14 @@
 			<date>10-28-2023</date>
 			<author>Ins:</author>
 			<change type="Added">ServSpecOpt &quot;UndoGetItemEnableRangeCheck&quot; 1/0 default 0.<br/>
-				If enabled - on fail to equip item back on character (if it has been taken from character layer)<br/>
-				and on fail to put item back to backpack will check if item has been taken from position/container that is in default_accessible_range.<br/>
-				If origin position/container is not in default_accessible_range will skip try to put item to origin position/container (unless item is no_drop)<br/>
-				and as last resort will drop item at character position (feet). UndoGetItemDropHere executed before UndoGetItemEnableRangeCheck if both are set.</change>
+If enabled - on fail to equip item back on character (if it has been taken from character layer)<br/>
+and on fail to put item back to backpack will check if item has been taken from position/container that is in default_accessible_range.<br/>
+If origin position/container is not in default_accessible_range will skip try to put item to origin position/container (unless item is no_drop)<br/>
+and as last resort will drop item at character position (feet). UndoGetItemDropHere executed before UndoGetItemEnableRangeCheck if both are set.</change>
 			<change type="Added">ServSpecOpt &quot;UndoGetItemDropHere&quot; 1/0 default 0.<br/>
-				If enabled - on fail to equip item back on character (if it has been taken from character layer)<br/>
-				and on fail to put item back to backpack drops item at character position (feet), except no_drop items. Attempt to return item in<br/>
-				origin container will be skipped.</change>
+If enabled - on fail to equip item back on character (if it has been taken from character layer)<br/>
+and on fail to put item back to backpack drops item at character position (feet), except no_drop items. Attempt to return item in<br/>
+origin container will be skipped.</change>
 			<change type="Fixed">Leftover items in corpse on client side.</change>
 			<change type="Changed">Added ServerSpecOpt reload to ReloadConfiguration.</change>
 		</entry>
@@ -44,8 +49,8 @@
 		<entry>
 			<date>09-03-2023</date>
 			<author>Ins:</author>
-			<change type="Added">repsys.cfg General section &quot;PartyHarmFullCountsAsCriminal&quot; 1/0 default 1.<br/>
-				If 0 OnHarm does not set mobile to criminal when they are in the same party.</change>
+			<change type="Added">repsys.cfg General section &quot;PartyHarmFullCountsAsCriminal 1/0&quot; default 1.<br/>
+If 0 OnHarm does not set mobile to criminal when they are in the same party.</change>
 		</entry>
 		<entry>
 			<date>08-30-2023</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+11-08-2023 Turley:
+    Fixed: crash due to NPCs after calling ReloadConfiguration
 11-01-2023 Kevin:
     Added: RestartScript() now can restart item control scripts. Similar to NPC scripts, the existing Item control script will terminate and a new one started.
 10-28-2023 Ins:

--- a/pol-core/pol/globals/uvars.cpp
+++ b/pol-core/pol/globals/uvars.cpp
@@ -403,12 +403,6 @@ void GameState::unload_intrinsic_templates()
 // quick and nasty fix until npcdesc usage is rewritten
 void GameState::unload_npc_templates()
 {
-  for ( auto& templates : npc_templates )
-  {
-    if ( templates.second != nullptr )
-      delete templates.second;
-    templates.second = nullptr;
-  }
   npc_templates.clear();
 
   npc_template_elems.clear();
@@ -427,7 +421,7 @@ GameState::Memory GameState::estimateSize() const
   for ( const auto& ele : npc_templates )
   {
     usage.misc += ele.first.capacity() + sizeof( NpcTemplate* ) + ( sizeof( void* ) * 3 + 1 ) / 2;
-    if ( ele.second != nullptr )
+    if ( ele.second )
       usage.misc += ele.second->estimateSize();
   }
 

--- a/pol-core/pol/globals/uvars.h
+++ b/pol-core/pol/globals/uvars.h
@@ -97,7 +97,7 @@ typedef RegionGroup<LightRegion> LightDef;
 typedef RegionGroup<MusicRegion> MusicDef;
 
 typedef std::map<std::string, NpcTemplateElem, Clib::ci_cmp_pred> NpcTemplatesElems;
-typedef std::map<std::string, NpcTemplate*> NpcTemplates;
+typedef std::map<std::string, std::shared_ptr<NpcTemplate>> NpcTemplates;
 
 typedef ref_ptr<Party> PartyRef;
 typedef std::vector<PartyRef> Parties;

--- a/pol-core/pol/mobile/npc.cpp
+++ b/pol-core/pol/mobile/npc.cpp
@@ -348,7 +348,7 @@ void NPC::printProperties( Clib::StreamWriter& sw ) const
 void NPC::printDebugProperties( Clib::StreamWriter& sw ) const
 {
   base::printDebugProperties( sw );
-  sw() << "# template: " << template_.name << pf_endl;
+  sw() << "# template: " << template_->name << pf_endl;
   if ( anchor.enabled )
   {
     sw() << "# anchor: x=" << anchor.x << " y=" << anchor.y << " dstart=" << anchor.dstart
@@ -363,14 +363,14 @@ void NPC::readNpcProperties( Clib::ConfigElem& elem )
   Items::UWeapon* wpn = static_cast<Items::UWeapon*>(
       Items::find_intrinsic_equipment( elem.rest(), Core::LAYER_HAND1 ) );
   if ( wpn == nullptr )
-    wpn = Items::create_intrinsic_weapon_from_npctemplate( elem, template_.pkg );
+    wpn = Items::create_intrinsic_weapon_from_npctemplate( elem, template_->pkg );
   if ( wpn != nullptr )
     weapon = wpn;
 
   Items::UArmor* sld = static_cast<Items::UArmor*>(
       Items::find_intrinsic_equipment( elem.rest(), Core::LAYER_HAND2 ) );
   if ( sld == nullptr )
-    sld = Items::create_intrinsic_shield_from_npctemplate( elem, template_.pkg );
+    sld = Items::create_intrinsic_shield_from_npctemplate( elem, template_->pkg );
   if ( sld != nullptr )
     shield = sld;
 
@@ -670,7 +670,7 @@ void NPC::start_script()
 {
   passert( ex == nullptr );
   passert( !script.get().empty() );
-  Core::ScriptDef sd( script, template_.pkg, "scripts/ai/" );
+  Core::ScriptDef sd( script, template_->pkg, "scripts/ai/" );
   // Log( "NPC script starting: %s\n", sd.name().c_str() );
 
   ref_ptr<Bscript::EScriptProgram> prog = Core::find_script2( sd );
@@ -1023,8 +1023,8 @@ void NPC::get_hitscript_params( double damage, Items::UArmor** parmor, unsigned 
 
 Items::UWeapon* NPC::intrinsic_weapon()
 {
-  if ( template_.intrinsic_weapon )
-    return template_.intrinsic_weapon;
+  if ( template_->intrinsic_weapon )
+    return template_->intrinsic_weapon;
   else
     return Core::gamestate.wrestling_weapon;
 }

--- a/pol-core/pol/mobile/npc.h
+++ b/pol-core/pol/mobile/npc.h
@@ -23,6 +23,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <memory>
 #include <stddef.h>
 #include <string>
 
@@ -275,7 +276,7 @@ protected:
 
 private:
   Core::CharacterRef master_;
-  const Core::NpcTemplate& template_;
+  std::shared_ptr<Core::NpcTemplate> template_;
 };
 
 inline Character* NPC::master() const
@@ -285,7 +286,7 @@ inline Character* NPC::master() const
 
 inline Core::NpcTemplate::ALIGNMENT NPC::alignment() const
 {
-  return template_.alignment;
+  return template_->alignment;
 }
 
 inline unsigned short NPC::ar() const

--- a/pol-core/pol/npctmpl.cpp
+++ b/pol-core/pol/npctmpl.cpp
@@ -7,7 +7,6 @@
 
 #include "npctmpl.h"
 
-#include <format/format.h>
 #include "../clib/cfgelem.h"
 #include "../clib/cfgfile.h"
 #include "../clib/fileutil.h"
@@ -19,6 +18,8 @@
 #include "item/equipmnt.h"
 #include "item/weapon.h"
 #include "syshookscript.h"
+#include <format/format.h>
+#include <memory>
 
 namespace Pol
 {
@@ -49,10 +50,10 @@ int translate( const std::string& name, TRANSLATION* table )
   return 0;
 }
 
-TRANSLATION xlate_align[] = {{"good", NpcTemplate::GOOD},
-                             {"neutral", NpcTemplate::NEUTRAL},
-                             {"evil", NpcTemplate::EVIL},
-                             {nullptr, 0}};
+TRANSLATION xlate_align[] = { { "good", NpcTemplate::GOOD },
+                              { "neutral", NpcTemplate::NEUTRAL },
+                              { "evil", NpcTemplate::EVIL },
+                              { nullptr, 0 } };
 
 
 NpcTemplate::NpcTemplate( const Clib::ConfigElem& elem, const Plib::Package* pkg )
@@ -114,11 +115,12 @@ size_t NpcTemplate::estimateSize() const
   return size;
 }
 
-const NpcTemplate& create_npc_template( const Clib::ConfigElem& elem, const Plib::Package* pkg )
+std::shared_ptr<NpcTemplate> create_npc_template( const Clib::ConfigElem& elem,
+                                                  const Plib::Package* pkg )
 {
-  NpcTemplate* tmpl = new NpcTemplate( elem, pkg );
+  auto tmpl = std::make_shared<NpcTemplate>( elem, pkg );
   gamestate.npc_templates[tmpl->name] = tmpl;
-  return *tmpl;
+  return tmpl;
 }
 
 void load_npc_templates()
@@ -151,12 +153,12 @@ void load_npc_templates()
   }
 }
 
-const NpcTemplate& find_npc_template( const Clib::ConfigElem& elem )
+std::shared_ptr<NpcTemplate> find_npc_template( const Clib::ConfigElem& elem )
 {
-  NpcTemplates::const_iterator itr = gamestate.npc_templates.find( elem.rest() );
+  auto itr = gamestate.npc_templates.find( elem.rest() );
   if ( itr != gamestate.npc_templates.end() )
   {
-    return *( ( *itr ).second );
+    return itr->second;
   }
   else
   {
@@ -172,5 +174,5 @@ const NpcTemplate& find_npc_template( const Clib::ConfigElem& elem )
     }
   }
 }
-}
-}
+}  // namespace Core
+}  // namespace Pol

--- a/pol-core/pol/npctmpl.h
+++ b/pol-core/pol/npctmpl.h
@@ -9,6 +9,7 @@
 #define NPCTMPL_H
 
 #include <map>
+#include <memory>
 #include <stddef.h>
 #include <string>
 
@@ -25,12 +26,12 @@ namespace Items
 {
 class UArmor;
 class UWeapon;
-}
+}  // namespace Items
 namespace Core
 {
 class ExportScript;
 
-class NpcTemplate
+class NpcTemplate : public std::enable_shared_from_this<NpcTemplate>
 {
 public:
   std::string name;
@@ -54,7 +55,7 @@ public:
   ~NpcTemplate();
 };
 
-const NpcTemplate& find_npc_template( const Clib::ConfigElem& elem );
+std::shared_ptr<NpcTemplate> find_npc_template( const Clib::ConfigElem& elem );
 bool FindNpcTemplate( const char* template_name, Clib::ConfigElem& elem );
 bool FindNpcTemplate( const char* template_name, Clib::ConfigFile& cf, Clib::ConfigElem& elem );
 
@@ -85,6 +86,6 @@ private:
   NpcTemplateConfigSource _source;
   Clib::ConfigElem _elem;
 };
-}
-}
+}  // namespace Core
+}  // namespace Pol
 #endif

--- a/pol-core/pol/repsys.cpp
+++ b/pol-core/pol/repsys.cpp
@@ -1031,7 +1031,7 @@ unsigned char NPC::hilite_color_idx( const Character* seen_by ) const
   }
   else
   {
-    switch ( template_.alignment )
+    switch ( template_->alignment )
     {
     case Core::NpcTemplate::NEUTRAL:
       return CHAR_HILITE_ATTACKABLE;
@@ -1072,7 +1072,7 @@ unsigned short NPC::name_color( const Character* seen_by ) const
   }
   else
   {
-    switch ( template_.alignment )
+    switch ( template_->alignment )
     {
     case Core::NpcTemplate::NEUTRAL:
       return Core::settingsManager.repsys_cfg.NameColoring.Attackable;

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -3522,7 +3522,7 @@ BObjectImp* NPC::get_script_member_id( const int id ) const
     return new BLong( run_speed );
     break;
   case MBR_ALIGNMENT:
-    return new BLong( this->template_.alignment );
+    return new BLong( template_->alignment );
     break;
   case MBR_SAVEONEXIT:
     return new BLong( saveonexit() );
@@ -3641,12 +3641,12 @@ BObjectImp* NPC::script_method( const char* methodname, Core::UOExecutor& execut
 
 BObjectImp* NPC::custom_script_method( const char* methodname, Core::UOExecutor& executor )
 {
-  if ( template_.method_script != nullptr )
+  if ( template_->method_script != nullptr )
   {
     unsigned PC;
-    if ( template_.method_script->FindExportedFunction(
+    if ( template_->method_script->FindExportedFunction(
              methodname, static_cast<unsigned int>( executor.numParams() + 1 ), PC ) )
-      return template_.method_script->call( PC, make_ref(), executor.fparams );
+      return template_->method_script->call( PC, make_ref(), executor.fparams );
   }
   return Core::gamestate.system_hooks.call_script_method( methodname, &executor, this );
 }


### PR DESCRIPTION
NPCs now hold a shared_ptr of the template.
(the only attribute which would change due to reloading is the alignment, so keeping the old shared_ptr is no feature loss..)