### PR TITLE
Test for destroyitem in a controlscript

### DIFF
--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -61,6 +61,7 @@
 #include "../core.h"
 #include "../exscrobj.h"
 #include "../globals/memoryusage.h"
+#include "../globals/object_storage.h"
 #include "../globals/script_internals.h"
 #include "../globals/state.h"
 #include "../globals/uvars.h"
@@ -2016,6 +2017,10 @@ BObjectImp* PolCore::call_polmethod( const char* methodname, UOExecutor& ex )
           return new BLong( 0 );
         Core::scriptScheduler.logScriptVariables( script->data() );
         return new BLong( 1 );
+      }
+      else if ( type == 7 )
+      {
+        Core::objStorageManager.objecthash.Clear( false );
       }
       return new BLong( 1 );
     }

--- a/pol-core/pol/objecthash.cpp
+++ b/pol-core/pol/objecthash.cpp
@@ -180,30 +180,30 @@ void ObjectHash::Reap()
   }
 }
 
-void ObjectHash::Clear()
+void ObjectHash::Clear( bool shutdown )
 {
   bool any;
   do
   {
     any = false;
-    unsigned skipped = 0;
     for ( OH_iterator itr = hash.begin(), itrend = hash.end(); itr != itrend; )
     {
-      UObject* obj = ( *itr ).second.get();
+      UObject* obj = itr->second.get();
 
       if ( obj->orphan() && obj->ref_counted_count() == 1 )
       {
-        hash.erase( itr++ );
+        itr = hash.erase( itr );
         any = true;
       }
       else
       {
-        ++skipped;
         ++itr;
       }
     }
   } while ( any );
-  if ( !hash.empty() )
+
+  reap_iterator = hash.begin();  // set itr for ::Reap back to the beginning
+  if ( shutdown && !hash.empty() )
   {
     INFO_PRINT << "Leftover objects in objecthash: " << hash.size() << "\n";
 
@@ -213,7 +213,6 @@ void ObjectHash::Clear()
     INFO_PRINT << "Leaking a copy of the objecthash in order to avoid a crash.\n";
     new hs( hash );
   }
-  //    hash.clear();
 }
 
 
@@ -272,5 +271,5 @@ void ObjectHash::RegisterCleanDeletedSerial( u32 serial )
 {
   clean_deleted.insert( serial );
 }
-}
-}
+}  // namespace Core
+}  // namespace Pol

--- a/pol-core/pol/objecthash.h
+++ b/pol-core/pol/objecthash.h
@@ -51,7 +51,7 @@ public:
 
   bool Insert( UObject* obj );
   bool Remove( u32 serial );
-  void Clear();
+  void Clear( bool shutdown = true );
   void Reap();
 
   UObject* Find( u32 serial );
@@ -78,6 +78,6 @@ private:
   ds dirty_deleted;
   ds clean_deleted;
 };
-}
-}
+}  // namespace Core
+}  // namespace Pol
 #endif

--- a/testsuite/pol/testpkgs/item/control_destroy.src
+++ b/testsuite/pol/testpkgs/item/control_destroy.src
@@ -1,0 +1,9 @@
+use uo;
+use os;
+
+program control_destroy(item)
+  sleepms(10);
+  DestroyItem(item);
+  item:=0; // clear reference
+  Polcore().internal(7); //destroy all orphan objects
+endprogram

--- a/testsuite/pol/testpkgs/item/itemdesc.cfg
+++ b/testsuite/pol/testpkgs/item/itemdesc.cfg
@@ -57,3 +57,10 @@ Item 0x400002
   Graphic 0x1
   ControlScript control_restartable
 }
+
+Item 0x400003
+{
+  Name DestroyItem
+  Graphic 0x1
+  ControlScript control_destroy
+}

--- a/testsuite/pol/testpkgs/item/test_item.src
+++ b/testsuite/pol/testpkgs/item/test_item.src
@@ -175,3 +175,13 @@ function get_pid_from_control_script(byref err, item, label)
 
   return control_script_pid;
 endfunction
+
+
+// controlscript needs to be the last holder of itemref and destroy it
+// crash test/AddressSanitizer
+exported function test_item_controlscript_destroy()
+  var item:=CreateItemAtLocation(0,0,0,0x400003);
+  item:=0;
+  sleepms(30);
+  return 1;
+endfunction


### PR DESCRIPTION
Via polcore().internal(7) its now possible to explicitly destroy all orphan objects