### PR TITLE
Testsystem performance

### DIFF
--- a/pol-core/poltool/baredistrofiles.cpp
+++ b/pol-core/poltool/baredistrofiles.cpp
@@ -283,7 +283,7 @@ void BareDistro::distro_files( std::map<fs::path, std::vector<std::string>>& dis
 "#                   double click an object again.",
 "# Default is 1",
 "#",
-"DoubleClickWait=1",
+"DoubleClickWait=0",
 "",
 "#",
 "# DefaultLightLevel - Default light level for regions with no level defined.",

--- a/testsuite/pol/scripts/busyloop.src
+++ b/testsuite/pol/scripts/busyloop.src
@@ -1,0 +1,15 @@
+/*
+busyloop for our scriptscheduler
+The scheduler, if no script has to run, sleeps until the next
+script is scheduled for wakeup.
+
+For our testsystem that is not what we want, since almost no scripts are running the delays are quite huge.
+
+So trick the scheduler by having this script run endless with a minimum of delay
+*/
+use os;
+
+print("starting busyloop");
+while (1)
+  sleepms(1);
+endwhile

--- a/testsuite/pol/scripts/start.src
+++ b/testsuite/pol/scripts/start.src
@@ -2,4 +2,5 @@ use os;
 program start()
   print("POL initialization complete.");
   start_script("tests");
+  start_script("busyloop");
 endprogram

--- a/testsuite/pol/scripts/tests.src
+++ b/testsuite/pol/scripts/tests.src
@@ -44,11 +44,13 @@ program tests()
       continue;
     endif
 
-    syslog(pkg[2],0,"\x1B[1;32m");
+    var pkgstartms:=ReadMillisecondClock();
+    syslog(pkg[2],0,CONSOLE_COLOR_MAGENTA);
     var scripts:=listdirectory(":{}:".format(pkg[1]),"ecl");
     scripts.sort();
     if ("setup.ecl" in scripts)
       syslog("  Calling setup.ecl..",0,CONSOLE_COLOR_GREEN);
+      var startms:=ReadMillisecondClock();
       var res:=run_script(":{}:setup.ecl".format(pkg[1]));
       if (res == IGNORE_TEST)
         continue;
@@ -57,11 +59,13 @@ program tests()
         exitcode:=1;
         continue;
       endif
+      syslog("  ..{}ms".format(ReadMillisecondClock()-startms),0,CONSOLE_COLOR_GREEN);
     endif
     foreach file in scripts
       if (file.find("test") != 1)
         continue;
       endif
+      var scriptstartms:=ReadMillisecondClock();
       syslog("  Calling {}..".format(file),0,CONSOLE_COLOR_GREEN);
       var script:=LoadExportedScript(":{}:{}".format(pkg[1], file));
       if (!script[2])
@@ -74,6 +78,7 @@ program tests()
       endif
  
       foreach func in (script[1].exported_functions)
+        var startms:=ReadMillisecondClock();
         syslog("    Calling {}..".format(func),0,CONSOLE_COLOR_GREEN);
         var res:=script[1].call(func);  
         if (res != 1)
@@ -81,12 +86,17 @@ program tests()
           exitcode:=1;
           continue;
         endif
+        syslog("    ..{}ms".format(ReadMillisecondClock()-startms),0,CONSOLE_COLOR_GREEN);
       endforeach
+      syslog("  ..{}ms".format(ReadMillisecondClock()-scriptstartms),0,CONSOLE_COLOR_GREEN);
     endforeach
     if ("cleanup.ecl" in scripts)
       syslog("  Calling cleanup.ecl..",0,CONSOLE_COLOR_GREEN);
+      var startms:=ReadMillisecondClock();
       run_script(":{}:cleanup.ecl".format(pkg[1]));
+      syslog("  ..{}ms".format(ReadMillisecondClock()-startms),0,CONSOLE_COLOR_GREEN);
     endif
+    syslog("..{}ms".format(ReadMillisecondClock()-pkgstartms),0,CONSOLE_COLOR_MAGENTA);
   endforeach
   
   var result:=$"{CONSOLE_COLOR_GREEN}success";

--- a/testsuite/pol/testpkgs/client/test_client_item_move.src
+++ b/testsuite/pol/testpkgs/client/test_client_item_move.src
@@ -31,6 +31,10 @@ endprogram
 
 /**
  * Tests
+ * TODO: there is no lift "success" pkt
+ *       currently it waits for 1s if a reject pkt is send
+ *       this sync is needed because the chr itself gets moved out of range
+ *       if the drop target is moved out of range this 1s delay shouldnt be needed
  */
 
 // 1. Move item from ground into backpack
@@ -708,8 +712,8 @@ function lift_item_succeeded(byref err, serial)
     endif
     break;
   endwhile
-  return 1;
 
+  // TODO: see top
   ev:=waitForClient(0, {EVT_MOVE_ITEM_REJECTED}, 1);
   if (ev)
     return err := ret_error($"Got unexpected move (lift) item rejected: reason = {ev.reason}");;


### PR DESCRIPTION
Scriptscheduler has almost nothing to do in our Testframework, which means it sleeps quite long delaying newly started scripts