### PR TITLE
Packet hook deadlock

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>11-12-2023</datemodified>
+		<datemodified>11-19-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>11-19-2023</date>
+			<author>Turley:</author>
+			<change type="Fixed">possible deadlock in packethooks</change>
+		</entry>
 		<entry>
 			<date>11-12-2023</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+11-19-2023 Turley:
+    Fixed: possible deadlock in packethooks
 11-12-2023 Kevin:
     Fixed: crash when control scripts end for a destroyed item
 11-08-2023 Turley:

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -521,7 +521,7 @@ void ThreadedClient::xmit( const void* data, unsigned short datalen )
 
 void ThreadedClient::send_queued_data()
 {
-  std::lock_guard<std::mutex> lock( _SocketMutex );
+  std::lock_guard<std::mutex> lock( _socketMutex );
   Core::XmitBuffer* xbuffer;
   // hand off data to the sockets layer until it won't take any more.
   // note if a buffer is sent in full, we try to send the next one, ad infinitum
@@ -718,7 +718,7 @@ size_t Client::estimatedSize() const
 
 void ThreadedClient::closeConnection()
 {
-  std::lock_guard<std::mutex> lock( _SocketMutex );
+  std::lock_guard<std::mutex> lock( _socketMutex );
   if ( csocket != INVALID_SOCKET )
   {
 #ifdef _WIN32

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -182,7 +182,7 @@ public:
   std::atomic<Core::polclock_t> last_activity_at;
   std::atomic<Core::polclock_t> last_packet_at;
 
-  mutable std::mutex _SocketMutex;
+  mutable std::mutex _socketMutex;
 
   enum e_recv_states
   {
@@ -380,7 +380,7 @@ inline void ThreadedClient::forceDisconnect()
 // Checks whether the client is disconnected, and not only marked for disconnection
 inline bool ThreadedClient::isReallyConnected() const
 {
-  std::lock_guard<std::mutex> lock( _SocketMutex );
+  std::lock_guard<std::mutex> lock( _socketMutex );
   return !this->disconnect && this->csocket != INVALID_SOCKET;
 }
 

--- a/pol-core/pol/network/clientio.cpp
+++ b/pol-core/pol/network/clientio.cpp
@@ -98,7 +98,7 @@ void ThreadedClient::recv_remaining( int total_expected )
   int max_expected = total_expected - bytes_received;
 
   {
-    std::lock_guard<std::mutex> lock( _SocketMutex );
+    std::lock_guard<std::mutex> lock( _socketMutex );
     count = cryptengine->Receive( &buffer[bytes_received], max_expected, csocket );
   }
 
@@ -127,7 +127,7 @@ void ThreadedClient::recv_remaining_nocrypt( int total_expected )
   int count;
 
   {
-    std::lock_guard<std::mutex> lock( _SocketMutex );
+    std::lock_guard<std::mutex> lock( _socketMutex );
     count = recv( csocket, (char*)&buffer[bytes_received], total_expected - bytes_received, 0 );
   }
   if ( count > 0 )
@@ -255,7 +255,6 @@ void Client::transmit( const void* data, int len )
     if ( handled )
     {
       Core::PolLock lock;
-      std::lock_guard<std::mutex> guard( _SocketMutex );
       CallOutgoingPacketExportedFunction( this, data, len, p, phd, handled );
     }
   }
@@ -276,7 +275,7 @@ void Client::transmit( const void* data, int len )
     }
   }
 
-  std::lock_guard<std::mutex> guard( _SocketMutex );
+  std::lock_guard<std::mutex> guard( _socketMutex );
   if ( disconnect )
   {
     POLLOG_INFO << "Warning: Trying to send to a disconnected client! \n";

--- a/testsuite/pol/testpkgs/client/packethook.src
+++ b/testsuite/pol/testpkgs/client/packethook.src
@@ -1,10 +1,6 @@
 use uo;
-program p()
+
+program packethook()
   return 1;
 endprogram
 
-exported function UpdatePlayer_0x77(who, byref packet)
-  print("Temporary Deadlocktest");
-  sendsysmessage(who,"Temporary Deadlocktest");
-  return 0;
-endfunction

--- a/testsuite/pol/testpkgs/client/packethook.src
+++ b/testsuite/pol/testpkgs/client/packethook.src
@@ -1,0 +1,10 @@
+use uo;
+program p()
+  return 1;
+endprogram
+
+exported function UpdatePlayer_0x77(who, byref packet)
+  print("Temporary Deadlocktest");
+  sendsysmessage(who,"Temporary Deadlocktest");
+  return 0;
+endfunction

--- a/testsuite/pol/testpkgs/client/uopacket.cfg
+++ b/testsuite/pol/testpkgs/client/uopacket.cfg
@@ -1,0 +1,5 @@
+Packet 0x77
+{
+    Length 17
+    SendFunction packethook:UpdatePlayer_0x77
+}

--- a/testsuite/pol/testpkgs/client/uopacket.cfg
+++ b/testsuite/pol/testpkgs/client/uopacket.cfg
@@ -1,5 +1,6 @@
-Packet 0x77
-{
-    Length 17
-    SendFunction packethook:UpdatePlayer_0x77
-}
+# TODO find a pkt to test pkthooks
+#Packet 0x77
+#{
+#    Length 17
+#    SendFunction packethook:UpdatePlayer_0x77
+#


### PR DESCRIPTION
During pkthooks the socketmutex was hold leading to a deadlock when is_active() gets checked. Eg SendSysMessage would check that.
Holding the lock makes in my opinion no sense. So removed it