### PR TITLE
Add value parameter validation for PerformAction

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>12-10-2023</datemodified>
+		<datemodified>12-16-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>12-16-2023</date>
+			<author>Kukkino:</author>
+			<change type="Changed">PerformAction( character, action, framecount := 5, repeatcount := 1, backward := ACTION_DIR_FORWARD, repeatflag := ACTION_NOREPEAT, delay := 1 ):<br/>
+Now validates 'action' parameter against UACTION</change>
+		</entry>
 		<entry>
 			<date>12-10-2023</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.1.0 --
+12-16-2023 Kukkino:
+  Changed: PerformAction( character, action, framecount := 5, repeatcount := 1, backward := ACTION_DIR_FORWARD, repeatflag := ACTION_NOREPEAT, delay := 1 ):
+           Now validates 'action' parameter against UACTION
 12-10-2023 Turley:
     Fixed: https support on windows for HttpRequest (broken since august)
     Fixed: unpack of big double values on windows when it used e notation. (broken since...)

--- a/pol-core/pol/bowsalut.cpp
+++ b/pol-core/pol/bowsalut.cpp
@@ -184,6 +184,13 @@ void send_action_to_inrange( const Mobile::Character* obj, UACTION action,
                              REPEAT_FLAG_OLD repeatflag /*=PKTOUT_6E::NOREPEAT*/,
                              unsigned char delay /*=0x01*/ )
 {
+  if ( !UACTION_IS_VALID( static_cast<u16>( action ) ) )
+  {
+    ERROR_PRINT << "Warning: attempt to send invalid action 0x" << fmt::hexu( action )
+                << " to character 0x" << fmt::hexu( obj->serial ) << "\n";
+    return;
+  }
+
   bool build = false;
   Network::MobileAnimationMsg msg( obj->serial_ext );
   WorldIterator<OnlinePlayerFilter>::InVisualRange( obj, [&]( Mobile::Character* zonechr ) {

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -1514,6 +1514,11 @@ BObjectImp* UOExecutorModule::mf_PerformAction()
        getParam( 3, repeatcount ) && getParam( 4, backward ) && getParam( 5, repeatflag ) &&
        getParam( 6, delay ) )
   {
+    if ( !UACTION_IS_VALID( actionval ) )
+    {
+      return new BError( "Invalid parameter 'action'" );
+    }
+
     UACTION action = static_cast<UACTION>( actionval );
     send_action_to_inrange(
         chr, action, framecount, repeatcount, static_cast<DIRECTION_FLAG_OLD>( backward ),


### PR DESCRIPTION
Using invalid values in `PerformAction` could crash core under some circumstances (win x64, `PerformAction(x, 195)`). This is caused by access to fixed array `old_anim` using passed in value parameter without bounds checks. This PR prevents using out of bounds parameters completely.

During discussion on discord one concern was noted about custom new/clients however in my opinion function `send_action_to_inrange` simply doesn't really support those scenarios properly anyway:

1. it always assumes the action is valid for old animation packet (this is for custom clients with additional actions maybe?)
2. translation buffers are fixed size to `ACTION__HIGHEST` but translation is still attempted so it overflows (source of the potential crash)
3. when `gamestate.animation_translates` is being loaded the map is loaded only up to `ACTION__HIGHEST` so for custom values translations to new packet isn't supported at all

Due to this I have decided to completely prevent passing in values above `ACTION__HIGHEST`. If this is decided to be a problem I'll try to prepare alternative PR that will just avoid crashing (translate only when action is below `ACTION__HIGHEST`) while preserving rest of current behavior.