### PR TITLE
Unpack of bigger double values on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: "windows-latest"
+          - os: "windows-2019"
             cxx-compiler: cl
             c-compiler: cl
             compiler-version: default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,17 +53,17 @@ jobs:
         uses: actions/cache@v3
         with:
           path: lib/curl-8.2.1
-          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-curl-8.2.1-1
+          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-curl-8.2.1-2
       - name: Cache antlr
         uses: actions/cache@v3
         with:
           path: lib/antlr
-          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-antlr-4.8
+          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-antlr-4.8-1
       - name: Cache boost
         uses: actions/cache@v3
         with:
           path: lib/boost_1_83_0
-          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-boost-1.83.0
+          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-boost-1.83.0-1
       - name: Install Compiler and Dependencies
         if: matrix.config.os == 'ubuntu-latest'
         shell: pwsh

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,5 +1,4 @@
 #clang-format all modified/new cpp/h/hpp files in given directory (pol-core)
-cmake_minimum_required(VERSION 3.2)
 if(NOT DEFINED GIT)
   message(FATAL_ERROR "git not defined")
 endif()

--- a/cmake/core_tests_ecompile_cfg.cmake
+++ b/cmake/core_tests_ecompile_cfg.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.2)
-
 if(NOT DEFINED ecompile_cfg)
   message(FATAL_ERROR "ecompile_cfg not defined")
 endif()

--- a/cmake/escripttest.cmake
+++ b/cmake/escripttest.cmake
@@ -1,6 +1,5 @@
 #EScript test suite
 
-cmake_minimum_required(VERSION 3.2)
 if(NOT DEFINED testdir)
   message(FATAL_ERROR "testdir not defined")
 endif()

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -9,6 +9,7 @@
 			<date>12-10-2023</date>
 			<author>Turley:</author>
 			<change type="Fixed">https support on windows for HttpRequest (broken since august)</change>
+			<change type="Fixed">unpack of big double values on windows when it used e notation. (broken since...)</change>
 		</entry>
 		<entry>
 			<date>12-06-2023</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,7 @@
 -- POL100.1.0 --
 12-10-2023 Turley:
     Fixed: https support on windows for HttpRequest (broken since august)
+    Fixed: unpack of big double values on windows when it used e notation. (broken since...)
 12-06-2023 Brndd:
     Fixed: crash due to character.clearBuffs()
 12-03-2023 Brndd:

--- a/testsuite/escript/pack/pack010-double-exponent.out
+++ b/testsuite/escript/pack/pack010-double-exponent.out
@@ -4,3 +4,9 @@ Result representation:   r7.6e-13
 Successful!
 Unpacked: 7.6e-13
 Unpack matches!
+Testing Pack for: 6e+06
+Expected representation: r6e+06
+Result representation:   r6e+06
+Successful!
+Unpacked: 6e+06
+Unpack matches!

--- a/testsuite/escript/pack/pack010-double-exponent.src
+++ b/testsuite/escript/pack/pack010-double-exponent.src
@@ -3,3 +3,7 @@ include "packtst";
 var ob := 0.00000000000076;
 var rep := "r7.6e-13";
 test_pack( ob, rep );
+
+ob := 6000000.0;
+rep := "r6e+06";
+test_pack( ob, rep );


### PR DESCRIPTION
Compiler bug in VS2022 found..
Switched back to vs2019 and added test