### PR TITLE
WIP: Increase precision when packing doubles

### DIFF
--- a/pol-core/bscript/dbl.cpp
+++ b/pol-core/bscript/dbl.cpp
@@ -5,6 +5,7 @@
 
 
 #include <cmath>
+#include <iomanip>
 #include <sstream>
 #include <string>
 
@@ -20,13 +21,19 @@ namespace Bscript
 std::string Double::pack() const
 {
   OSTRINGSTREAM os;
+  std::streamsize origprecision = os.precision();
+  os.precision(15);
   os << "r" << dval_;
+  os.precision(origprecision);
   return OSTRINGSTREAM_STR( os );
 }
 
 void Double::packonto( std::ostream& os ) const
 {
+  std::streamsize origprecision = os.precision();
+  os.precision(15);
   os << "r" << dval_;
+  os.precision(origprecision);
 }
 
 BObjectImp* Double::unpack( std::istream& is )


### PR DESCRIPTION
This proof of concept, not intended for merging just yet. This is an attempt to fix very early rounding when packing double numbers, see below. I believe double should be precise to up to 15 digits, currently it's 6.

```
var v := 12345678.0;
SendSysMessage(who, "test set: " + CInt(v));
SetObjProperty(who, "numtest", v);
v := GetObjProperty(who, "numtest");
SendSysMessage(who, "test get: " + CInt(v));
```

![image](https://github.com/polserver/polserver/assets/737093/5a59d8af-cd56-4ffc-acbd-fdb651bc46f7)

This means that after 11 days saving value of `ReadMillisecondClock` has only 10 second precision which breaks a lot of usages.
