### PR TITLE
Diagnostics: Add support for finding hidden tokens (comments)

### DIFF
--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.cpp
@@ -38,6 +38,13 @@ LocalVariableScope::~LocalVariableScope()
 std::shared_ptr<Variable> LocalVariableScope::create( const std::string& name, WarnOn warn_on,
                                                       const SourceLocation& source_location )
 {
+  return create( name, warn_on, source_location, source_location );
+}
+
+std::shared_ptr<Variable> LocalVariableScope::create( const std::string& name, WarnOn warn_on,
+                                                      const SourceLocation& source_location,
+                                                      const SourceLocation& var_decl_location )
+{
   if ( auto existing = scopes.local_variables.find( name ) )
   {
     if ( existing->block_depth == block_depth )
@@ -48,8 +55,8 @@ std::shared_ptr<Variable> LocalVariableScope::create( const std::string& name, W
     }
     shadowing.push_back( existing );
   }
-  auto local = scopes.local_variables.create( name, block_depth, warn_on,
-                                              source_location );
+  auto local = scopes.local_variables.create( name, block_depth, warn_on, source_location,
+                                              var_decl_location );
 
   local_variable_scope_info.variables.push_back( local );
 

--- a/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
+++ b/pol-core/bscript/compiler/analyzer/LocalVariableScope.h
@@ -23,6 +23,8 @@ public:
                                LocalVariableScopeInfo& );
   ~LocalVariableScope();
 
+  std::shared_ptr<Variable> create( const std::string& name, WarnOn, const SourceLocation&,
+                                    const SourceLocation& );
   std::shared_ptr<Variable> create( const std::string& name, WarnOn, const SourceLocation& );
 
 private:

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -532,11 +532,12 @@ void SemanticAnalyzer::visit_var_statement( VarStatement& node )
     return;
   }
 
-  report_function_name_conflict(node.source_location, node.name, "variable");
+  report_function_name_conflict( node.source_location, node.name, "variable" );
 
   if ( auto local_scope = local_scopes.current_local_scope() )
   {
-    node.variable = local_scope->create( node.name, WarnOn::Never, node.source_location );
+    node.variable = local_scope->create( node.name, WarnOn::Never, node.source_location,
+                                         node.var_decl_location );
   }
   else
   {
@@ -547,7 +548,8 @@ void SemanticAnalyzer::visit_var_statement( VarStatement& node )
       return;
     }
 
-    node.variable = globals.create( node.name, 0, WarnOn::Never, node.source_location );
+    node.variable =
+        globals.create( node.name, 0, WarnOn::Never, node.source_location, node.var_decl_location );
   }
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/analyzer/Variables.cpp
+++ b/pol-core/bscript/compiler/analyzer/Variables.cpp
@@ -9,14 +9,17 @@ namespace Pol::Bscript::Compiler
 Variables::Variables( VariableScope scope, Report& report ) : scope( scope ), report( report ) {}
 
 std::shared_ptr<Variable> Variables::create( const std::string& name, BlockDepth block_depth,
-                                             WarnOn warn_on, const SourceLocation& source_location )
+                                             WarnOn warn_on, const SourceLocation& source_location,
+                                             const SourceLocation& var_decl_location )
 {
   auto index = names_by_index.size();
-  if ( index > std::numeric_limits<VariableIndex>::max() ) {
-    report.error(source_location, "Too many variables");
+  if ( index > std::numeric_limits<VariableIndex>::max() )
+  {
+    report.error( source_location, "Too many variables" );
   }
-  auto variable = std::make_shared<Variable>(
-      scope, name, block_depth, static_cast<VariableIndex>( index ), warn_on, source_location );
+  auto variable =
+      std::make_shared<Variable>( scope, name, block_depth, static_cast<VariableIndex>( index ),
+                                  warn_on, source_location, var_decl_location );
   variables_by_name[name] = variable;
   names_by_index.push_back( name );
   return variable;

--- a/pol-core/bscript/compiler/analyzer/Variables.h
+++ b/pol-core/bscript/compiler/analyzer/Variables.h
@@ -23,7 +23,7 @@ public:
   Variables( VariableScope, Report& );
 
   std::shared_ptr<Variable> create( const std::string& name, BlockDepth, WarnOn,
-                                    const SourceLocation& );
+                                    const SourceLocation&, const SourceLocation& );
 
   [[nodiscard]] std::shared_ptr<Variable> find( const std::string& name ) const;
 

--- a/pol-core/bscript/compiler/ast/VarStatement.cpp
+++ b/pol-core/bscript/compiler/ast/VarStatement.cpp
@@ -8,27 +8,27 @@
 
 namespace Pol::Bscript::Compiler
 {
-VarStatement::VarStatement( const SourceLocation& source_location,
+VarStatement::VarStatement( const SourceLocation& identifier_location,
                             const SourceLocation& var_decl_location, std::string name,
                             std::unique_ptr<Expression> initializer )
-    : Statement( source_location, std::move( initializer ) ),
+    : Statement( identifier_location, std::move( initializer ) ),
       name( std::move( name ) ),
       var_decl_location( var_decl_location )
 {
 }
 
-VarStatement::VarStatement( const SourceLocation& source_location,
+VarStatement::VarStatement( const SourceLocation& identifier_location,
                             const SourceLocation& var_decl_location, std::string name )
-    : Statement( source_location ),
+    : Statement( identifier_location ),
       name( std::move( name ) ),
       var_decl_location( var_decl_location )
 {
 }
 
-VarStatement::VarStatement( const SourceLocation& source_location,
+VarStatement::VarStatement( const SourceLocation& identifier_location,
                             const SourceLocation& var_decl_location, std::string name,
                             bool initialize_as_empty_array )
-    : Statement( source_location ),
+    : Statement( identifier_location ),
       name( std::move( name ) ),
       initialize_as_empty_array( initialize_as_empty_array ),
       var_decl_location( var_decl_location )

--- a/pol-core/bscript/compiler/ast/VarStatement.cpp
+++ b/pol-core/bscript/compiler/ast/VarStatement.cpp
@@ -8,22 +8,30 @@
 
 namespace Pol::Bscript::Compiler
 {
-VarStatement::VarStatement( const SourceLocation& source_location, std::string name,
+VarStatement::VarStatement( const SourceLocation& source_location,
+                            const SourceLocation& var_decl_location, std::string name,
                             std::unique_ptr<Expression> initializer )
-    : Statement( source_location, std::move( initializer ) ), name( std::move( name ) )
+    : Statement( source_location, std::move( initializer ) ),
+      name( std::move( name ) ),
+      var_decl_location( var_decl_location )
 {
 }
 
-VarStatement::VarStatement( const SourceLocation& source_location, std::string name )
-    : Statement( source_location ), name( std::move( name ) )
+VarStatement::VarStatement( const SourceLocation& source_location,
+                            const SourceLocation& var_decl_location, std::string name )
+    : Statement( source_location ),
+      name( std::move( name ) ),
+      var_decl_location( var_decl_location )
 {
 }
 
-VarStatement::VarStatement( const SourceLocation& source_location, std::string name,
+VarStatement::VarStatement( const SourceLocation& source_location,
+                            const SourceLocation& var_decl_location, std::string name,
                             bool initialize_as_empty_array )
     : Statement( source_location ),
       name( std::move( name ) ),
-      initialize_as_empty_array( initialize_as_empty_array )
+      initialize_as_empty_array( initialize_as_empty_array ),
+      var_decl_location( var_decl_location )
 {
 }
 

--- a/pol-core/bscript/compiler/ast/VarStatement.h
+++ b/pol-core/bscript/compiler/ast/VarStatement.h
@@ -12,11 +12,12 @@ class Variable;
 class VarStatement : public Statement
 {
 public:
-  VarStatement( const SourceLocation&, const SourceLocation&, std::string name,
-                std::unique_ptr<Expression> initializer );
-  VarStatement( const SourceLocation&, const SourceLocation&, std::string name );
-  VarStatement( const SourceLocation&, const SourceLocation&, std::string name,
-                bool initialize_as_empty_array );
+  VarStatement( const SourceLocation& identifier_location, const SourceLocation& var_decl_location,
+                std::string name, std::unique_ptr<Expression> initializer );
+  VarStatement( const SourceLocation& identifier_location, const SourceLocation& var_decl_location,
+                std::string name );
+  VarStatement( const SourceLocation& identifier_location, const SourceLocation& var_decl_location,
+                std::string name, bool initialize_as_empty_array );
 
   void accept( NodeVisitor& ) override;
   void describe_to( fmt::Writer& ) const override;

--- a/pol-core/bscript/compiler/ast/VarStatement.h
+++ b/pol-core/bscript/compiler/ast/VarStatement.h
@@ -12,9 +12,11 @@ class Variable;
 class VarStatement : public Statement
 {
 public:
-  VarStatement( const SourceLocation&, std::string name, std::unique_ptr<Expression> initializer );
-  VarStatement( const SourceLocation&, std::string name );
-  VarStatement( const SourceLocation&, std::string name, bool initialize_as_empty_array );
+  VarStatement( const SourceLocation&, const SourceLocation&, std::string name,
+                std::unique_ptr<Expression> initializer );
+  VarStatement( const SourceLocation&, const SourceLocation&, std::string name );
+  VarStatement( const SourceLocation&, const SourceLocation&, std::string name,
+                bool initialize_as_empty_array );
 
   void accept( NodeVisitor& ) override;
   void describe_to( fmt::Writer& ) const override;
@@ -23,6 +25,7 @@ public:
   const bool initialize_as_empty_array = false;
 
   std::shared_ptr<Variable> variable;
+  const SourceLocation var_decl_location;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -37,8 +37,9 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileLoader& source_loa
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
     const std::string& pathname, UserFunctionInclusion user_function_inclusion )
 {
-  auto compiler_workspace = std::make_unique<CompilerWorkspace>( report );
-  BuilderWorkspace workspace( *compiler_workspace, em_cache, inc_cache, profile, report );
+  auto compiler_workspace =
+      std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache, profile );
+  auto& workspace = compiler_workspace->builder_workspace;
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );
 
@@ -82,8 +83,9 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build_module(
     const std::string& pathname )
 {
-  auto compiler_workspace = std::make_unique<CompilerWorkspace>( report );
-  BuilderWorkspace workspace( *compiler_workspace, em_cache, inc_cache, profile, report );
+  auto compiler_workspace =
+      std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache, profile );
+  auto& workspace = compiler_workspace->builder_workspace;
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );
 

--- a/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SimpleStatementBuilder.cpp
@@ -38,9 +38,11 @@ void SimpleStatementBuilder::add_var_statements(
 {
   if ( auto variable_declaration_list = ctx->variableDeclarationList() )
   {
+    auto has_multiple_decls = variable_declaration_list->variableDeclaration().size() > 1;
     for ( auto decl : variable_declaration_list->variableDeclaration() )
     {
       auto loc = location_for( *decl );
+      auto var_decl_location = has_multiple_decls ? loc : location_for( *ctx->VAR() );
       std::string name = text( decl->IDENTIFIER() );
       std::unique_ptr<VarStatement> var_ast;
 
@@ -48,18 +50,19 @@ void SimpleStatementBuilder::add_var_statements(
       {
         if ( initializer_context->ARRAY() )
         {
-          var_ast = std::make_unique<VarStatement>( loc, std::move( name ), true );
+          var_ast =
+              std::make_unique<VarStatement>( loc, var_decl_location, std::move( name ), true );
         }
         else
         {
           auto initializer = variable_initializer( initializer_context );
-          var_ast =
-              std::make_unique<VarStatement>( loc, std::move( name ), std::move( initializer ) );
+          var_ast = std::make_unique<VarStatement>( loc, var_decl_location, std::move( name ),
+                                                    std::move( initializer ) );
         }
       }
       else
       {
-        var_ast = std::make_unique<VarStatement>( loc, std::move( name ) );
+        var_ast = std::make_unique<VarStatement>( loc, var_decl_location, std::move( name ) );
       }
       statements.push_back( std::move( var_ast ) );
     }

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -144,6 +144,36 @@ EscriptGrammar::EscriptParser::ModuleUnitContext* SourceFile::get_module_unit(
   return module_unit;
 }
 
+std::vector<antlr4::Token*> SourceFile::get_hidden_tokens_before( const Position& position )
+{
+  auto tokens = get_all_tokens();
+  size_t token_index = 0;
+  for ( const auto& token : tokens )
+  {
+    if ( token->getLine() == position.line_number &&
+         token->getCharPositionInLine() + 1 <= position.character_column &&
+         token->getCharPositionInLine() + 1 + token->getText().length() >=
+             position.character_column )
+    {
+      break;
+    }
+    token_index++;
+  }
+
+  if ( token_index < tokens.size() )
+  {
+    return get_hidden_tokens_before( token_index );
+  }
+
+  return std::vector<antlr4::Token*>();
+}
+
+std::vector<antlr4::Token*> SourceFile::get_hidden_tokens_before( size_t tokenIndex )
+{
+  token_stream.reset();
+  return token_stream.getHiddenTokensToLeft( tokenIndex );
+}
+
 std::unique_ptr<antlr4::Token> SourceFile::get_token_at( const Position& position )
 {
   auto tokens = get_all_tokens();

--- a/pol-core/bscript/compiler/file/SourceFile.h
+++ b/pol-core/bscript/compiler/file/SourceFile.h
@@ -51,6 +51,8 @@ public:
   SemanticTokens get_tokens();
   std::unique_ptr<antlr4::Token> get_token_at( const Position& position );
   std::vector<std::unique_ptr<antlr4::Token>> get_all_tokens();
+  std::vector<antlr4::Token*> get_hidden_tokens_before( const Position& position );
+  std::vector<antlr4::Token*> get_hidden_tokens_before( size_t tokenIndex );
 
   const std::string pathname;
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -6,11 +6,18 @@
 #include "bscript/compiler/ast/Program.h"
 #include "bscript/compiler/ast/TopLevelStatements.h"
 #include "bscript/compiler/ast/UserFunction.h"
+#include "bscript/compiler/astbuilder/BuilderWorkspace.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 
 namespace Pol::Bscript::Compiler
 {
-CompilerWorkspace::CompilerWorkspace( Report& report ) : constants( report ), scope_tree( *this ) {}
+CompilerWorkspace::CompilerWorkspace( Report& report, SourceFileCache& em_cache,
+                                      SourceFileCache& inc_cache, Profile& profile )
+    : constants( report ),
+      scope_tree( *this ),
+      builder_workspace( *this, em_cache, inc_cache, profile, report )
+{
+}
 
 CompilerWorkspace::~CompilerWorkspace() = default;
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -8,6 +8,7 @@
 
 #include "bscript/compiler/analyzer/Constants.h"
 #include "bscript/compiler/ast/Node.h"
+#include "bscript/compiler/astbuilder/BuilderWorkspace.h"
 #include "bscript/compiler/model/ScopeTree.h"
 #include "bscript/compiler/model/SemanticTokens.h"
 #include "clib/maputil.h"
@@ -15,11 +16,13 @@
 namespace Pol::Bscript::Compiler
 {
 class Block;
+class BuilderWorkspace;
 class ConstDeclaration;
 class ModuleFunctionDeclaration;
 class Program;
 class Report;
 class SourceFile;
+class SourceFileCache;
 class SourceFileIdentifier;
 class TopLevelStatements;
 class UserFunction;
@@ -27,7 +30,8 @@ class UserFunction;
 class CompilerWorkspace
 {
 public:
-  explicit CompilerWorkspace( Report& );
+  explicit CompilerWorkspace( Report&, SourceFileCache& em_cache, SourceFileCache& inc_cache,
+                              Profile& profile );
   ~CompilerWorkspace();
 
   void accept( NodeVisitor& );
@@ -52,6 +56,7 @@ public:
   std::vector<std::string> global_variable_names;
   ScopeTree scope_tree;
   SemanticTokens tokens;
+  BuilderWorkspace builder_workspace;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/Variable.cpp
+++ b/pol-core/bscript/compiler/model/Variable.cpp
@@ -5,14 +5,16 @@
 namespace Pol::Bscript::Compiler
 {
 Variable::Variable( VariableScope scope, std::string name, BlockDepth block_depth,
-                    VariableIndex index, WarnOn warn_on, const SourceLocation& source_location )
-  : scope( scope ),
-    name( std::move( name ) ),
-    block_depth( block_depth ),
-    index( index ),
-    warn_on( warn_on ),
-    source_location( source_location ),
-    used( false )
+                    VariableIndex index, WarnOn warn_on, const SourceLocation& source_location,
+                    const SourceLocation& var_decl_location )
+    : scope( scope ),
+      name( std::move( name ) ),
+      block_depth( block_depth ),
+      index( index ),
+      warn_on( warn_on ),
+      source_location( source_location ),
+      var_decl_location( var_decl_location ),
+      used( false )
 {
 }
 

--- a/pol-core/bscript/compiler/model/Variable.h
+++ b/pol-core/bscript/compiler/model/Variable.h
@@ -15,7 +15,7 @@ class Variable
 {
 public:
   Variable( VariableScope, std::string name, BlockDepth, VariableIndex, WarnOn,
-            const SourceLocation& source_location );
+            const SourceLocation& source_location, const SourceLocation& var_decl_location );
 
   void mark_used();
   [[nodiscard]] bool was_used() const;
@@ -26,6 +26,7 @@ public:
   const VariableIndex index;
   const WarnOn warn_on;
   const SourceLocation& source_location;
+  const SourceLocation& var_decl_location;
 
 private:
   bool used;


### PR DESCRIPTION
Comments are stored as hidden tokens on the parser's token stream. In order to find the hidden tokens before a given token, access to the token stream is needed. The `SourceFile` is what keeps the parser, and the compilations `SourceFile`s are held by the `BuilderWorkspace` in its `source_files` member. 

The `BuilderWorkspace` was a heap variable inside `CompilerWorkspaceBuilder::build` but has now been moved to be a class member of the "root" `CompilerWorkspace`, so applications can grab the `SourceFile` for a given compiled file and call `sf->get_hidden_tokens_before()` like so:

```cpp
void HoverBuilder::append_comment( const SourceLocation& source_location, std::string& result )
{
  std::string comment;
  const auto& pathname = source_location.source_file_identifier->pathname;
  auto itr = workspace.builder_workspace.source_files.find( pathname );
  auto tokens = workspace.source->get_all_tokens();
  if ( itr != workspace.builder_workspace.source_files.end() )
  {
    auto sf = itr->second;
    auto hidden_tokens = sf->get_hidden_tokens_before( source_location.range.start );

    for ( auto const* token : hidden_tokens )
    {
      auto token_text = Pol::Clib::strtrim( token->getText() );
      if ( token_text.length() == 0 )
      {
        continue;
      }

      comment += "\n" + token_text;
    }
  }
  if ( !comment.empty() )
  {
    result += "\n" + comment;
  }
}
```