### PR TITLE
AuxConnection transmit race

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>12-22-2023</datemodified>
+		<datemodified>12-29-2023</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>12-29-2023</date>
+			<author>Turley:</author>
+			<change type="Fixed">os::OpenConnection when sending multiple messages there was a (very low) chance that the messages where send in the wrong order.</change>
+		</entry>
 		<entry>
 			<date>12-22-2023</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+12-29-2023 Turley:
+    Fixed: os::OpenConnection when sending multiple messages there was a (very low) chance that the messages where send in the wrong order.
 12-22-2023 Turley:
     Fixed: Multis get now send/removed based on their footprint. Especially big multis had the problem (bigger then 32x32)
     Fixed: login near 0,0 did not send items/mobiles nearby

--- a/pol-core/pol/network/auxclient.cpp
+++ b/pol-core/pol/network/auxclient.cpp
@@ -237,6 +237,9 @@ void AuxClientThread::run()
     std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
 
   Core::PolLock lock;
+  // hold also the transmit mutex, the counter syncs but not in a way that the threadsanitizer
+  // recognizes is.
+  std::unique_lock<std::mutex> lock( _transmit_mutex );
   _auxconnection->disconnect();
   // the auxconnection is probably referenced by another ref_ptr,
   // so its deletion must be protected by the lock.

--- a/pol-core/pol/network/auxclient.cpp
+++ b/pol-core/pol/network/auxclient.cpp
@@ -239,7 +239,7 @@ void AuxClientThread::run()
   Core::PolLock lock;
   // hold also the transmit mutex, the counter syncs but not in a way that the threadsanitizer
   // recognizes is.
-  std::unique_lock<std::mutex> lock( _transmit_mutex );
+  std::unique_lock<std::mutex> transmitlock( _transmit_mutex );
   _auxconnection->disconnect();
   // the auxconnection is probably referenced by another ref_ptr,
   // so its deletion must be protected by the lock.

--- a/pol-core/pol/network/auxclient.h
+++ b/pol-core/pol/network/auxclient.h
@@ -8,15 +8,12 @@
 #ifndef AUXCLIENT_H_
 #define AUXCLIENT_H_
 
-
-#ifndef BSCRIPT_BOBJECT_H
-#include "../../bscript/bobject.h"
-#endif
-
 #include <atomic>
+#include <mutex>
 #include <string>
 #include <vector>
 
+#include "../../bscript/bobject.h"
 #include "../../clib/network/socketsvc.h"
 #include "../../clib/refptr.h"
 #include "../../clib/weakptr.h"
@@ -122,6 +119,7 @@ private:
   std::atomic<int> _transmit_counter;
   bool _keep_alive;
   bool _ignore_line_breaks;
+  std::mutex _transmit_mutex;
 };
 }  // namespace Network
 }  // namespace Pol


### PR DESCRIPTION
Since the actual transmit is done by a threadpool to not block the script there was a chance that the messages where send in wrong order. Especially when using the newline version (this called 2 times send). 
Happend on very rare occasions in our CI builds with the connection to the client.