### PR TITLE
Character buffs

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,17 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-10-2024</datemodified>
+		<datemodified>01-12-2024</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>01-12-2024</date>
+			<author>Turley:</author>
+			<change type="Added">chr.buffs member. Returns the current active buffs added via addBuff as dictionary.<br/>
+Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}</change>
+			<change type="Changed">addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string arguments_desc, [string arguments_name]) new optional argument arguments_name.<br/>
+Needs a client higher then 5.x and modifies the cliloc_name like argument_desc does for cliloc_descr.</change>
+		</entry>
 		<entry>
 			<date>01-10-2024</date>
 			<author>Kevin:</author>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -25,7 +25,7 @@
 <fileheader>
 <header>Class Hierarchy</header>
 <!-- objref.svg will be inserted here -->
-<datemodified>01/07/2024</datemodified>
+<datemodified>01/12/2024</datemodified>
 </fileheader>
 
 
@@ -335,7 +335,7 @@
 <method proto="clearLawfullydamagedTo(MobileRef chr)" returns="true/error" desc="clears lawfullydamaged entry for given chr" />
 <method proto="deaf(int duration)" returns="int/error" desc="character cannot hear for 'duration' seconds. -1 means forever. 0 clears the deaf" />
 <method proto="setseason(int season_id,int playsound )" returns="int/error" desc="Used to send the Season packet 0xBC to a single character, doesnt resend the lightlevel or weather." />
-<method proto="addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string arguments_desc, [string arguments_name)" returns="true/error" desc="Adds a buff to Character's buff bar. Duration is in seconds: countdown is done by the client, but the icon is never automatically removed. Arguments is an Unicode string; separated by a single tab character. Example: who.addBuff(1029, 30, 1075814, 1075815, &quot;1234 5678&quot;); Optional arguments_name parameters needs a client higher then 5.x and modifies the cliloc_name." />
+<method proto="addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string arguments_desc, [string arguments_name])" returns="true/error" desc="Adds a buff to Character's buff bar. Duration is in seconds: countdown is done by the client, but the icon is never automatically removed. Arguments is an Unicode string; separated by a single tab character. Example: who.addBuff(1029, 30, 1075814, 1075815, &quot;1234 5678&quot;); Optional arguments_name parameters needs a client higher then 5.x and modifies the cliloc_name." />
 <method proto="clearBuffs()" returns="true/error" desc="Removes all buffs from Character's buff bar." />
 <method proto="delBuff(int icon_id)" returns="true/error" desc="Removes a buff from Character's buff bar." />
 <method proto="disableSkillsFor(int duration)" returns="duration/error" desc="Disables skill scripts for given seconds" />

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -25,7 +25,7 @@
 <fileheader>
 <header>Class Hierarchy</header>
 <!-- objref.svg will be inserted here -->
-<datemodified>08/20/2020</datemodified>
+<datemodified>01/07/2024</datemodified>
 </fileheader>
 
 
@@ -305,6 +305,7 @@
 <member mname="faster_cast_recovery_mod" type="Integer" access="r/w" mdesc="Modifier for property, added to base property." />
 <member mname="luck_mod" type="Integer" access="r/w" mdesc="Modifier for property, added to base property." />
 <member mname="swing_speed_increase_mod" type="Integer" access="r/w" mdesc="Modifier for property, added to base property." />
+<member mname="buffs" type="dictionary" access="r/o" mdesc="Returns the current active buffs added via addBuff as dictionary. Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}." />
 
 <method proto="setpoisoned(bool)" returns="true/error" desc="sets the character poisoned, controller of calling script is flagged as in repsystem" />
 <method proto="setparalyzed(bool)" returns="true/error" desc="sets the character paralyzed, controller of calling script is flagged as in repsystem" />
@@ -334,7 +335,7 @@
 <method proto="clearLawfullydamagedTo(MobileRef chr)" returns="true/error" desc="clears lawfullydamaged entry for given chr" />
 <method proto="deaf(int duration)" returns="int/error" desc="character cannot hear for 'duration' seconds. -1 means forever. 0 clears the deaf" />
 <method proto="setseason(int season_id,int playsound )" returns="int/error" desc="Used to send the Season packet 0xBC to a single character, doesnt resend the lightlevel or weather." />
-<method proto="addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, array arguments)" returns="true/error" desc="Adds a buff to Character's buff bar. Duration is in seconds: countdown is done by the client, but the icon is never automatically removed. Arguments is an Unicode string (array of int); separated by a single tab character. Example: who.addBuff(1029, 30, 1075814, 1075815, CAscZ(&quot;1234 5678&quot;));" />
+<method proto="addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string arguments_desc, [string arguments_name)" returns="true/error" desc="Adds a buff to Character's buff bar. Duration is in seconds: countdown is done by the client, but the icon is never automatically removed. Arguments is an Unicode string; separated by a single tab character. Example: who.addBuff(1029, 30, 1075814, 1075815, &quot;1234 5678&quot;); Optional arguments_name parameters needs a client higher then 5.x and modifies the cliloc_name." />
 <method proto="clearBuffs()" returns="true/error" desc="Removes all buffs from Character's buff bar." />
 <method proto="delBuff(int icon_id)" returns="true/error" desc="Removes a buff from Character's buff bar." />
 <method proto="disableSkillsFor(int duration)" returns="duration/error" desc="Disables skill scripts for given seconds" />

--- a/pol-core/bscript/objaccess.cpp
+++ b/pol-core/bscript/objaccess.cpp
@@ -266,18 +266,20 @@ ObjMember object_members[] = {
     { MBR_PACKAGE, "package", true },
     { MBR_SWING_SPEED_INCREASE, "swing_speed_increase", true },
     { MBR_SWING_SPEED_INCREASE_MOD, "swing_speed_increase_mod", false },
-    { MBR_EXPORTED_FUNCTIONS, "exported_functions", false }, // 250
+    { MBR_EXPORTED_FUNCTIONS, "exported_functions", false },  // 250
     { MBR_DISABLE_INACTIVITY_TIMEOUT, "disable_inactivity_timeout", false },
     { MBR_CURSED, "cursed", false },
     { MBR_SNOOPSCRIPT, "snoopscript", false },
     { MBR_CHARACTER_OWNER, "character_owner", true },
     { MBR_PARRYCHANCE_MOD, "parrychance_mod", false },  // 255
     { MBR_PILOT, "pilot", false },
+    { MBR_BUFFS, "buffs", false },
 };
 int n_objmembers = sizeof object_members / sizeof object_members[0];
 ObjMember* getKnownObjMember( const char* token )
 {
-  static auto cache = []() -> std::unordered_map<std::string, ObjMember*> {
+  static auto cache = []() -> std::unordered_map<std::string, ObjMember*>
+  {
     std::unordered_map<std::string, ObjMember*> m;
     for ( int i = 0; i < n_objmembers; ++i )
     {
@@ -464,7 +466,8 @@ int n_objmethods = sizeof object_methods / sizeof object_methods[0];
 ObjMethod* getKnownObjMethod( const char* token )
 {
   // cache needs to hold a pointer to the original structure! eprog_read sets the override member
-  static auto cache = []() -> std::unordered_map<std::string, ObjMethod*> {
+  static auto cache = []() -> std::unordered_map<std::string, ObjMethod*>
+  {
     std::unordered_map<std::string, ObjMethod*> m;
     for ( int i = 0; i < n_objmethods; ++i )
     {

--- a/pol-core/bscript/objmembers.h
+++ b/pol-core/bscript/objmembers.h
@@ -298,6 +298,7 @@ enum MemberID
   MBR_CHARACTER_OWNER,  // 255
   MBR_PARRYCHANCE_MOD,
   MBR_PILOT,
+  MBR_BUFFS,
 };
 
 inline auto format_as( MemberID id )

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 -- POL100.1.0 --
+01-12-2024 Turley:
+    Added: chr.buffs member. Returns the current active buffs added via addBuff as dictionary.
+           Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}
+  Changed: addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string arguments_desc, [string arguments_name]) new optional argument arguments_name.
+           Needs a client higher then 5.x and modifies the cliloc_name like argument_desc does for cliloc_descr.
 01-10-2024 Kevin:
     Added: Boat item descriptor `AlternateMultiID` and boat method `boat.set_alternate_multiid(position)` to facilitate changing a boat's graphic, for example switching a boat from a "normal" to a "damaged" graphic.
 01-07-2024 Kevin:

--- a/pol-core/pol/mobile/charactr.h
+++ b/pol-core/pol/mobile/charactr.h
@@ -206,8 +206,9 @@ struct Buff
   u32 cl_name;
   // Description cliloc ID
   u32 cl_descr;
-  // Unicode string, arguments to be replaced in cl_descr, separated by tabs
-  std::string arguments;
+  // Unicode string, arguments to be replaced in cl_name/cl_descr, separated by tabs
+  std::string name_arguments;
+  std::string desc_arguments;
 };
 
 struct reportable_t
@@ -720,7 +721,8 @@ public:
 
   // BUFF/DEBUFF BAR
 public:
-  void addBuff( u16 icon, u16 duration, u32 cl_name, u32 cl_descr, const std::string& arguments );
+  void addBuff( u16 icon, u16 duration, u32 cl_name, const std::string& name_arguments,
+                u32 cl_descr, const std::string& desc_arguments );
   bool delBuff( u16 icon );
   void clearBuffs();
   void send_buffs();

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -2169,32 +2169,34 @@ void sendCharProfile( Character* chr, Character* of_who, const std::string& titl
  * @param arguments arguments for cl_descr as string, separated by spaces
  */
 void send_buff_message( Character* chr, u16 icon, bool show, u16 duration, u32 cl_name,
-                        u32 cl_descr, const std::string& arguments )
+                        const std::string& name_arguments, u32 cl_descr,
+                        const std::string& desc_arguments )
 {
   PktHelper::PacketOut<PktOut_DF> msg;
   msg->offset += 2;  // length will be written later
   msg->Write<u32>( chr->serial_ext );
   msg->WriteFlipped<u16>( icon );
-  msg->Write<u8>( 0u );  // unknown, always 0
-  msg->Write<u8>( show ? 1u : 0u );
+  msg->WriteFlipped<u16>( show ? 1u : 0u );
   if ( show )
   {
     msg->Write<u32>( 0u );  // unknown, always 0
     msg->WriteFlipped<u16>( icon );
-    msg->Write<u8>( 0u );   // unknown, always 0
-    msg->Write<u8>( 1u );   // unknown, always 1
-    msg->Write<u32>( 0u );  // unknown, always 0
+    msg->WriteFlipped<u16>( 1u );  // unknown, always 1
+    msg->Write<u32>( 0u );         // unknown, always 0
     msg->WriteFlipped<u16>( duration );
     msg->Write<u16>( 0u );  // unknown, always 0
     msg->Write<u8>( 0u );   // unknown, always 0
     msg->WriteFlipped<u32>( cl_name );
     msg->WriteFlipped<u32>( cl_descr );
-    msg->Write<u32>( 0u );   // unknown, always 0
-    msg->Write<u8>( 0u );    // unknown, always 0
-    msg->Write<u8>( 1u );    // unknown, always 1
-    msg->Write<u16>( 20u );  // a space character
-    msg->Write<u16>( 20u );  // a space character
-    msg->Write( Bscript::String::toUTF16( arguments ) );
+    msg->Write<u32>( 0u );  // 3rd cliloc?
+    auto nameargs = Bscript::String::toUTF16( name_arguments );
+    msg->WriteFlipped<u16>( nameargs.size() + 1 );
+    msg->Write( nameargs );
+    auto descargs = Bscript::String::toUTF16( desc_arguments );
+    msg->WriteFlipped<u16>( descargs.size() + 1 );
+    msg->Write( descargs );
+    msg->WriteFlipped<u16>( 1u );  // 3rd arg length?
+    msg->Write<u16>( 0u );
   }
 
   u16 len = msg->offset;

--- a/pol-core/pol/ufunc.h
+++ b/pol-core/pol/ufunc.h
@@ -240,8 +240,8 @@ void sendCharProfile( Mobile::Character* chr, Mobile::Character* of_who, const s
                       const std::string& utext, const std::string& etext );
 
 void send_buff_message( Mobile::Character* chr, u16 icon, bool show, u16 duration = 0,
-                        u32 cl_name = 0, u32 cl_descr = 0,
-                        const std::string& arguments = std::string() );
+                        u32 cl_name = 0, const std::string& name_arguments = std::string(),
+                        u32 cl_descr = 0, const std::string& desc_arguments = std::string() );
 }  // namespace Core
 }  // namespace Pol
 #endif

--- a/testsuite/pol/testpkgs/char/test_chr.src
+++ b/testsuite/pol/testpkgs/char/test_chr.src
@@ -92,18 +92,24 @@ endfunction
 
 exported function test_buffs()
   var err;
-  err := char.addBuff(1029, 30, 1075814, 1075815, CAscZ("1234 5678"));
+  err := char.addBuff(1029, 30, 1075814, 1075815, "1234 5678");
   if (err == error)
     return ret_error($"Could not add buff: {err}");
   endif
+  if (char.buffs.size() != 1 || !char.buffs.exists(1029))
+    return ret_error($"Active buff not listed: {char.buffs}");
+  endif
+    
   err := char.delBuff(1029);
   if (err == error)
     return ret_error($"Could not delete buff: {err}");
   endif
+  if (char.buffs.size() != 0)
+    return ret_error($"Active buffs not empty: {char.buffs}");
+  endif
   
   //Try clearing buffs
-  err := char.addBuff(1029, 30, 1075814, 1075815, CAscZ("1234 5678"));
-  print($"addBuff: {err}");
+  err := char.addBuff(1029, 30, 1075814, 1075815, "1234 5678");
   if (err == error)
     return ret_error($"Could not add buff: {err}");
   endif


### PR DESCRIPTION
it's now possible to set for the first cliloc arguments
* addBuff(int icon_id, int duration, int cliloc_name, int cliloc_descr, string desc_arguments, [string name_arguments])
* optional last parameter
added chr.buffs member to return the current buffs as dictionary (iconid, struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args})

Todo: as last optional param it's a non breaking change, but the order is a bit messy.. breaking change? New method version eg "addBuffEx"? Keep it in that order?

