### PR TITLE
Prevent sending name on singleclick on hidden character

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-12-2024</datemodified>
+		<datemodified>01-18-2024</datemodified>
 	</header>
 	<version name="POL100.1.0">
+		<entry>
+			<date>01-18-2024</date>
+			<author>Kukkino:</author>
+			<change type="Changed">A player that single-clicks a hidden mobile will no longer receive a &quot;You see&quot; message for that mobile.</change>
+		</entry>
 		<entry>
 			<date>01-12-2024</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.1.0 --
+01-18-2024 Kukkino:
+  Changed: A player that single-clicks a hidden mobile will no longer receive a "You see" message for that mobile.
 01-12-2024 Turley:
     Added: chr.buffs member. Returns the current active buffs added via addBuff as dictionary.
            Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}

--- a/pol-core/pol/sngclick.cpp
+++ b/pol-core/pol/sngclick.cpp
@@ -99,8 +99,7 @@ void singleclick( Network::Client* client, u32 serial )
     else
       chr = find_character( serial );
 
-    if ( chr != nullptr && client->chr->in_visual_range( chr ) &&
-         !client->chr->is_concealed_from_me( chr ) )
+    if ( chr != nullptr && client->chr->is_visible_to_me( chr ) )
     {
       if ( chr->has_title_guild() && ( settingsManager.ssopt.core_handled_tags & 0x1 ) )
         send_nametext( client, chr, "[" + chr->title_guild() + "]" );


### PR DESCRIPTION
When player1 sends 0x09 single click packet with serial of player2 who is nearby but hidden a name is sent back revealing information that there is player2 hidden nearby. This PR fixes the issue by using `is_visible_to_me` instead of `!is_concealed_from_me`. Range check is done withing `is_visible_to_me` so it was removed from the main condition as well.