### PR TITLE
Diagnostics: Continue analysis after error

### DIFF
--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -115,7 +115,7 @@ bool Compiler::compile_file( const std::string& filename )
 
 void Compiler::compile_file_steps( const std::string& pathname, Report& report )
 {
-  std::unique_ptr<CompilerWorkspace> workspace = build_workspace( pathname, report, false );
+  std::unique_ptr<CompilerWorkspace> workspace = build_workspace( pathname, report, false, false );
   if ( report.error_count() )
     return;
 
@@ -139,10 +139,11 @@ void Compiler::compile_file_steps( const std::string& pathname, Report& report )
 }
 
 std::unique_ptr<CompilerWorkspace> Compiler::analyze( const std::string& pathname, Report& report,
-                                                      bool is_module )
+                                                      bool is_module, bool continue_on_error )
 {
   // Let's see how this explodes...
-  std::unique_ptr<CompilerWorkspace> workspace = build_workspace( pathname, report, is_module );
+  std::unique_ptr<CompilerWorkspace> workspace =
+      build_workspace( pathname, report, is_module, continue_on_error );
   if ( workspace )
   {
     register_constants( *workspace, report );
@@ -156,10 +157,11 @@ std::unique_ptr<CompilerWorkspace> Compiler::analyze( const std::string& pathnam
 }
 
 std::unique_ptr<CompilerWorkspace> Compiler::build_workspace( const std::string& pathname,
-                                                              Report& report, bool is_module )
+                                                              Report& report, bool is_module, bool continue_on_error )
 {
   Pol::Tools::HighPerfTimer timer;
-  CompilerWorkspaceBuilder workspace_builder( source_loader, em_cache, inc_cache, profile, report );
+  CompilerWorkspaceBuilder workspace_builder( source_loader, em_cache, inc_cache, continue_on_error,
+                                              profile, report );
   auto workspace = is_module ? workspace_builder.build_module( pathname )
                              : workspace_builder.build( pathname, user_function_inclusion );
   profile.build_workspace_micros += timer.ellapsed().count();

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -157,7 +157,8 @@ std::unique_ptr<CompilerWorkspace> Compiler::analyze( const std::string& pathnam
 }
 
 std::unique_ptr<CompilerWorkspace> Compiler::build_workspace( const std::string& pathname,
-                                                              Report& report, bool is_module, bool continue_on_error )
+                                                              Report& report, bool is_module,
+                                                              bool continue_on_error )
 {
   Pol::Tools::HighPerfTimer timer;
   CompilerWorkspaceBuilder workspace_builder( source_loader, em_cache, inc_cache, continue_on_error,

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -32,11 +32,12 @@ public:
   void set_include_compile_mode();
 
   void compile_file_steps( const std::string& pathname, Report& );
-  std::unique_ptr<CompilerWorkspace> analyze( const std::string& pathname, Report&,
-                                              bool is_module );
+  std::unique_ptr<CompilerWorkspace> analyze( const std::string& pathname, Report&, bool is_module,
+                                              bool continue_on_error );
 
 private:
-  std::unique_ptr<CompilerWorkspace> build_workspace( const std::string&, Report&, bool );
+  std::unique_ptr<CompilerWorkspace> build_workspace( const std::string&, Report&, bool is_module,
+                                                      bool continue_on_error );
   void register_constants( CompilerWorkspace&, Report& );
   void optimize( CompilerWorkspace&, Report& );
   void disambiguate( CompilerWorkspace&, Report& );

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.cpp
@@ -9,13 +9,14 @@ namespace Pol::Bscript::Compiler
 {
 BuilderWorkspace::BuilderWorkspace( CompilerWorkspace& compiler_workspace,
                                     SourceFileCache& em_cache, SourceFileCache& inc_cache,
-                                    Profile& profile, Report& report )
-  : compiler_workspace( compiler_workspace ),
-    em_cache( em_cache ),
-    inc_cache( inc_cache ),
-    profile( profile ),
-    report( report ),
-    function_resolver( report )
+                                    bool continue_on_error, Profile& profile, Report& report )
+    : compiler_workspace( compiler_workspace ),
+      em_cache( em_cache ),
+      inc_cache( inc_cache ),
+      continue_on_error( continue_on_error ),
+      profile( profile ),
+      report( report ),
+      function_resolver( report )
 {
 }
 

--- a/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
+++ b/pol-core/bscript/compiler/astbuilder/BuilderWorkspace.h
@@ -21,13 +21,15 @@ class BuilderWorkspace
 {
 public:
   BuilderWorkspace( CompilerWorkspace&, SourceFileCache& em_cache, SourceFileCache& inc_cache,
-                    Profile& profile, Report& report );
+                    bool continue_on_error, Profile& profile, Report& report );
   ~BuilderWorkspace();
 
   CompilerWorkspace& compiler_workspace;
 
   SourceFileCache& em_cache;
   SourceFileCache& inc_cache;
+
+  const bool continue_on_error;
 
   Profile& profile;
   Report& report;

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -24,11 +24,13 @@ namespace Pol::Bscript::Compiler
 {
 CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileLoader& source_loader,
                                                     SourceFileCache& em_cache,
-                                                    SourceFileCache& inc_cache, Profile& profile,
+                                                    SourceFileCache& inc_cache,
+                                                    bool continue_on_error, Profile& profile,
                                                     Report& report )
     : source_loader( source_loader ),
       em_cache( em_cache ),
       inc_cache( inc_cache ),
+      continue_on_error( continue_on_error ),
       profile( profile ),
       report( report )
 {
@@ -37,8 +39,8 @@ CompilerWorkspaceBuilder::CompilerWorkspaceBuilder( SourceFileLoader& source_loa
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
     const std::string& pathname, UserFunctionInclusion user_function_inclusion )
 {
-  auto compiler_workspace =
-      std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache, profile );
+  auto compiler_workspace = std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache,
+                                                                 continue_on_error, profile );
   auto& workspace = compiler_workspace->builder_workspace;
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );
@@ -74,7 +76,7 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
   src_processor.use_module( "basicio", source_location );
   src_processor.process_source( *sf );
 
-  if ( report.error_count() == 0 )
+  if ( continue_on_error || report.error_count() == 0 )
     build_referenced_user_functions( workspace );
 
   return compiler_workspace;
@@ -83,8 +85,8 @@ std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build(
 std::unique_ptr<CompilerWorkspace> CompilerWorkspaceBuilder::build_module(
     const std::string& pathname )
 {
-  auto compiler_workspace =
-      std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache, profile );
+  auto compiler_workspace = std::make_unique<CompilerWorkspace>( report, em_cache, inc_cache,
+                                                                 continue_on_error, profile );
   auto& workspace = compiler_workspace->builder_workspace;
 
   auto ident = std::make_unique<SourceFileIdentifier>( 0, pathname );

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h
@@ -21,7 +21,7 @@ class CompilerWorkspaceBuilder
 {
 public:
   CompilerWorkspaceBuilder( SourceFileLoader& source_loader, SourceFileCache& em_cache,
-                            SourceFileCache& inc_cache, Profile&, Report& );
+                            SourceFileCache& inc_cache, bool continue_on_error, Profile&, Report& );
 
   std::unique_ptr<CompilerWorkspace> build( const std::string& pathname, UserFunctionInclusion );
   std::unique_ptr<CompilerWorkspace> build_module( const std::string& pathname );
@@ -32,6 +32,7 @@ private:
   SourceFileLoader& source_loader;
   SourceFileCache& em_cache;
   SourceFileCache& inc_cache;
+  const bool continue_on_error;
   Profile& profile;
   Report& report;
 };

--- a/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompoundStatementBuilder.cpp
@@ -41,7 +41,7 @@ namespace Pol::Bscript::Compiler
 {
 CompoundStatementBuilder::CompoundStatementBuilder(
     const SourceFileIdentifier& source_file_identifier, BuilderWorkspace& workspace )
-  : SimpleStatementBuilder( source_file_identifier, workspace )
+    : SimpleStatementBuilder( source_file_identifier, workspace )
 {
 }
 
@@ -121,7 +121,7 @@ void CompoundStatementBuilder::add_statements( EscriptParser::StatementContext* 
   {
     statements.push_back( std::make_unique<EmptyStatement>( location_for( *ctx ) ) );
   }
-  else
+  else if ( !workspace.continue_on_error )
   {
     location_for( *ctx ).internal_error( "unhandled statement" );
   }

--- a/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/SourceFileProcessor.cpp
@@ -28,13 +28,13 @@ std::string getpathof( const std::string& fname );
 SourceFileProcessor::SourceFileProcessor( const SourceFileIdentifier& source_file_identifier,
                                           BuilderWorkspace& workspace, bool is_src,
                                           UserFunctionInclusion user_function_inclusion )
-  : profile( workspace.profile ),
-    report( workspace.report ),
-    source_file_identifier( source_file_identifier ),
-    workspace( workspace ),
-    tree_builder( source_file_identifier, workspace ),
-    is_src( is_src ),
-    user_function_inclusion( user_function_inclusion )
+    : profile( workspace.profile ),
+      report( workspace.report ),
+      source_file_identifier( source_file_identifier ),
+      workspace( workspace ),
+      tree_builder( source_file_identifier, workspace ),
+      is_src( is_src ),
+      user_function_inclusion( user_function_inclusion )
 {
 }
 
@@ -96,7 +96,7 @@ void SourceFileProcessor::process_source( SourceFile& sf )
   profile.parse_src_micros.fetch_add( parse_us_counted );
   profile.parse_src_count++;
 
-  if ( report.error_count() == 0 )
+  if ( workspace.continue_on_error || report.error_count() == 0 )
   {
     Pol::Tools::HighPerfTimer ast_timer;
     compilation_unit->accept( this );
@@ -115,7 +115,7 @@ void SourceFileProcessor::process_include( SourceFile& sf, long long* micros_cou
   profile.parse_inc_micros.fetch_add( parse_micros_elapsed );
   *micros_counted += parse_micros_elapsed;
 
-  if ( report.error_count() == 0 )
+  if ( workspace.continue_on_error || report.error_count() == 0 )
   {
     Pol::Tools::HighPerfTimer ast_timer;
     compilation_unit->accept( this );

--- a/pol-core/bscript/compiler/file/SourceFile.cpp
+++ b/pol-core/bscript/compiler/file/SourceFile.cpp
@@ -104,15 +104,13 @@ std::shared_ptr<SourceFile> SourceFile::load( const SourceFileIdentifier& ident,
 
 void SourceFile::accept( EscriptParserVisitor& visitor )
 {
-  antlr4::ParserRuleContext* unit = nullptr;
-
-  if ( ( unit = compilation_unit ) )
+  if ( compilation_unit )
   {
-    visitor.visit( unit );
+    visitor.visit( compilation_unit );
   }
-  else if ( ( unit = module_unit ) )
+  else if ( module_unit )
   {
-    visitor.visit( unit );
+    visitor.visit( module_unit );
   }
 }
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.cpp
@@ -12,10 +12,11 @@
 namespace Pol::Bscript::Compiler
 {
 CompilerWorkspace::CompilerWorkspace( Report& report, SourceFileCache& em_cache,
-                                      SourceFileCache& inc_cache, Profile& profile )
+                                      SourceFileCache& inc_cache, bool continue_on_error,
+                                      Profile& profile )
     : constants( report ),
       scope_tree( *this ),
-      builder_workspace( *this, em_cache, inc_cache, profile, report )
+      builder_workspace( *this, em_cache, inc_cache, continue_on_error, profile, report )
 {
 }
 

--- a/pol-core/bscript/compiler/model/CompilerWorkspace.h
+++ b/pol-core/bscript/compiler/model/CompilerWorkspace.h
@@ -31,7 +31,7 @@ class CompilerWorkspace
 {
 public:
   explicit CompilerWorkspace( Report&, SourceFileCache& em_cache, SourceFileCache& inc_cache,
-                              Profile& profile );
+                              bool continue_on_error, Profile& profile );
   ~CompilerWorkspace();
 
   void accept( NodeVisitor& );


### PR DESCRIPTION
When a parsing error occurs, analysis would stop, therefore losing information on available symbols (variables, function declarations, ...), which would cause some features in extension to fail (eg. signature help, completion, ...). This change adds a `bool continue_on_error` parameter that alters this behavior.