### PR TITLE
Make polserver build on linux distributions that put their 64bit libs into a lib64 subdirectory.

### DIFF
--- a/cmake/Fmt.cmake
+++ b/cmake/Fmt.cmake
@@ -1,5 +1,7 @@
 # https://github.com/fmtlib/fmt
 
+include(GNUInstallDirs)
+
 message("* format")
 
 set(FMT_SOURCE_DIR "${POL_EXT_LIB_DIR}/fmt-10.2.0")
@@ -16,7 +18,7 @@ set(FMT_ARGS -DCMAKE_BUILD_TYPE=Release
    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
  )
 if (${linux})
-  set(FMT_LIB "${FMT_INSTALL_DIR}/lib/libfmt.a")
+  set(FMT_LIB "${FMT_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libfmt.a")
 else()
   set(FMT_LIB "${FMT_INSTALL_DIR}/lib/fmt.lib")
 endif()

--- a/cmake/Fmt.cmake
+++ b/cmake/Fmt.cmake
@@ -1,7 +1,5 @@
 # https://github.com/fmtlib/fmt
 
-include(GNUInstallDirs)
-
 message("* format")
 
 set(FMT_SOURCE_DIR "${POL_EXT_LIB_DIR}/fmt-10.2.0")
@@ -18,6 +16,7 @@ set(FMT_ARGS -DCMAKE_BUILD_TYPE=Release
    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
  )
 if (${linux})
+  include(GNUInstallDirs)
   set(FMT_LIB "${FMT_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libfmt.a")
 else()
   set(FMT_LIB "${FMT_INSTALL_DIR}/lib/fmt.lib")


### PR DESCRIPTION
If configuring the installation directory for 64bit libraries to be (/usr/)lib64 like common on Fedora and other distributions, the building fails because it cannot find libfmt.a as it looks for installdir/lib/libfmt.a while the library gets installed into installdir/lib64/libfmt.a due to a hardcoded path for linux in cmake/Fmt.cmake.

This patchset fixes the issue on linux and should not affect any other operating systems.

