### PR TITLE
Fix compiler crash on `error{}` members with no initializer

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-27-2024</datemodified>
+		<datemodified>02-04-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-04-2024</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Compiler crash on handling error member initializers with no expression initializer, eg. `error{ errortext }`.</change>
+		</entry>
 		<entry>
 			<date>01-27-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/ExpressionBuilder.cpp
@@ -279,8 +279,9 @@ std::unique_ptr<ErrorInitializer> ExpressionBuilder::error(
           expression_source_ctx.internal_error(
               "Unable to determine identifier for struct initializer" );
 
-        auto value = expression_ctx->expression() ? expression( expression_ctx->expression() )
-                                                  : std::unique_ptr<Expression>();
+        auto value = expression_ctx->expression()
+                         ? expression( expression_ctx->expression() )
+                         : std::make_unique<UninitializedValue>( expression_source_ctx );
 
         identifiers.push_back( std::move( identifier ) );
         expressions.push_back( std::move( value ) );

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+02-04-2024 Kevin:
+    Fixed: Compiler crash on handling error member initializers with no expression initializer, eg. `error{ errortext }`.
 01-27-2024 Kevin:
     Added: POL now exposes a Debug Adapter Protocol (DAP) server to provide debugging support. Any IDE or tooling that implements DAP, such as the vscode-escript extension (https://github.com/polserver/vscode-escript), can utilize this new debugging server. See pol.cfg setting DAPDebugPort.
 01-23-2024 Turley:

--- a/testsuite/escript/error/error001.out
+++ b/testsuite/escript/error/error001.out
@@ -1,0 +1,1 @@
+error{ errortext = <uninitialized object> }

--- a/testsuite/escript/error/error001.src
+++ b/testsuite/escript/error/error001.src
@@ -1,0 +1,1 @@
+print(error{ "errortext" });


### PR DESCRIPTION
TODO:
- [x] tests
- [x] implementation
- [x] docs