### PR TITLE
Add proxy protocol support

### DIFF
--- a/cmake/compile_defs.cmake
+++ b/cmake/compile_defs.cmake
@@ -42,7 +42,8 @@ function(set_compile_flags target is_executable)
       WIN32
       NOMINMAX
       WINDOWS
-      WINVER=0x0501
+      WINVER=0x0601
+      _WIN32_WINNT=0x0601
       _CONSOLE
     )
     if (${ARCH_BITS} EQUAL "64")

--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -109,7 +109,7 @@ Listener
     KeepClients      (integer 0/1 {default 0})
     Encryption       (string encryption type {default none})
     AOSResistances   (integer 0/1)
-    UseProxyProtocol (integer 0/1 {default 0})
+    [AllowProxy      (IPaddrr)[/(netmask)]]...
 }
 [Listener ...]
 
@@ -129,7 +129,7 @@ Listener
         This means you can listen for "1.26.4" clients on port 5003 and "ignition" clients on port 5555.</explain>
     <explain>KeepClients: if set to 1 clients keep this listener port even after different gameserver select; actually 1 is the old behaviour and 0 the old behaviour of pol.cfg ListenPort</explain>
     <explain>AOSResistances: This flag aids in deciding which version of Armor to send in the StatMsg packets. With this enabled, a client who uses an account with AOS Expansion enabled will see their Physical Resist instead of AR member.</explain>
-    <explain>UseProxyProtocol: expect incoming connection to use proxy protocol v2. Connections to this listener not using proxy protocol v2 will be rejected.</explain>
+    <explain>AllowProxy: Expect incoming connection from this network to use proxy protocol v2, connections not using valid proxy protocol v2 will be rejected. This element can be specified multiple times.</explain>
     <explain>MethodScript: General Methodscript for characters Deprecated!</explain>
     <related>attributes.cfg</related>
     <related>pol.cfg</related>
@@ -499,7 +499,7 @@ GameServer
     <explain>--lan-- attempts to find you non-routable LAN IP address, if any (i.e. '192.168.*.*' or '10.*.*.*').</explain>
     <explain>Port is the listening port of the Game Server, not the login server (though they may be the same). It's often the listener's Port in uoclients.cfg</explain>
     <explain>Example IPMatch value: 192.168.0.0/255.255.255.0 would prevent anyone with an IP address other than 192.168.0.* from seeing the gameserver.</explain>
-    <explain>ProxyMatch works same as IPMatch, except it matches against proxy address if there is one. If client is not conneting through proxy gameservers with this filter won't match.</explain>
+    <explain>ProxyMatch works similar to IPMatch, except it matches against proxy address if there is one. If client is not connecting through a proxy, gameservers with this filter won't match. If client is connecting through a proxy, gameservers without this filder won't match.</explain>
     <explain>AcctMatch lines have one account name per line, and are those accounts to show the given server to on login to the 'login server'.</explain>
     <related>movecost.cfg</related>
     <related>pol.cfg</related>

--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -105,10 +105,11 @@ Protocol
 }
 Listener
 {
-    Port           (int port number 1024..65535)
-    KeepClients    (integer 0/1 {default 0})
-    Encryption     (string encryption type {default none})
-    AOSResistances (integer 0/1)
+    Port             (int port number 1024..65535)
+    KeepClients      (integer 0/1 {default 0})
+    Encryption       (string encryption type {default none})
+    AOSResistances   (integer 0/1)
+    UseProxyProtocol (integer 0/1 {default 0})
 }
 [Listener ...]
 
@@ -128,6 +129,7 @@ Listener
         This means you can listen for "1.26.4" clients on port 5003 and "ignition" clients on port 5555.</explain>
     <explain>KeepClients: if set to 1 clients keep this listener port even after different gameserver select; actually 1 is the old behaviour and 0 the old behaviour of pol.cfg ListenPort</explain>
     <explain>AOSResistances: This flag aids in deciding which version of Armor to send in the StatMsg packets. With this enabled, a client who uses an account with AOS Expansion enabled will see their Physical Resist instead of AR member.</explain>
+    <explain>UseProxyProtocol: expect incoming connection to use proxy protocol v2. Connections to this listener not using proxy protocol v2 will be rejected.</explain>
     <explain>MethodScript: General Methodscript for characters Deprecated!</explain>
     <related>attributes.cfg</related>
     <related>pol.cfg</related>
@@ -483,11 +485,12 @@ Note: Token and nonToken Eventtype is still the same (SYSEVENT_SPEECH)</explain>
     <structure>
 GameServer
 {
-    Name       (string name of server)
-    IP         (string ip address, or --ip-- or --lan--, see below)
-    Port       (int TCP port number)
-    [IPMatch   (IPaddrr)/(netmask)]...
-    [AcctMatch (string account name)]...
+    Name        (string name of server)
+    IP          (string ip address, or --ip-- or --lan--, see below)
+    Port        (int TCP port number)
+    [IPMatch    (IPaddrr)/(netmask)]...
+    [ProxyMatch (IPaddrr)/(netmask)]...
+    [AcctMatch  (string account name)]...
 }
 [GameServer...]
 </structure>
@@ -496,6 +499,7 @@ GameServer
     <explain>--lan-- attempts to find you non-routable LAN IP address, if any (i.e. '192.168.*.*' or '10.*.*.*').</explain>
     <explain>Port is the listening port of the Game Server, not the login server (though they may be the same). It's often the listener's Port in uoclients.cfg</explain>
     <explain>Example IPMatch value: 192.168.0.0/255.255.255.0 would prevent anyone with an IP address other than 192.168.0.* from seeing the gameserver.</explain>
+    <explain>ProxyMatch works same as IPMatch, except it matches against proxy address if there is one. If client is not conneting through proxy gameservers with this filter won't match.</explain>
     <explain>AcctMatch lines have one account name per line, and are those accounts to show the given server to on login to the 'login server'.</explain>
     <related>movecost.cfg</related>
     <related>pol.cfg</related>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-06-2024</datemodified>
+		<datemodified>02-08-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-08-2024</date>
+			<author>Kukkino:</author>
+			<change type="Added">POL now accepts proxy protocol v2 if configured to in Listener in `uoclient.cfg` listener.</change>
+			<change type="Added">Gameservers in `servers.cfg` can now be filtered using `ProxyMatch` similar to `IPMatch` except for used proxy.</change>
+			<change type="Fixed">Gameservers `AcctMatch` and `IPMatch` can now be used at both at once (both conditions need to match).</change>
+		</entry>
 		<entry>
 			<date>02-06-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 -- POL100.2.0 --
+02-08-2024 Kukkino:
+    Added: POL now accepts proxy protocol v2 if configured to in Listener in `uoclient.cfg` listener.
+    Added: Gameservers in `servers.cfg` can now be filtered using `ProxyMatch` similar to `IPMatch` except for used proxy.
+    Fixed: Gameservers `AcctMatch` and `IPMatch` can now be used at both at once (both conditions need to match).
 02-06-2024 Kevin:
     Fixed: Compiler error with escaping `}` inside interpolated strings.
 02-04-2024 Kevin:

--- a/pol-core/pol/login.cpp
+++ b/pol-core/pol/login.cpp
@@ -106,8 +106,21 @@ bool ip_check( Network::Client* client, int i )
 
 bool proxy_check( Network::Client* client, int i )
 {
+  bool is_proxied = client->ipaddr_proxy.sa_family != AF_UNSPEC;
+
   if ( networkManager.servers[i]->proxy_match.empty() )
-    return true;
+  {
+    // If there is no ProxyMatch element but client is connecting through proxy
+    // do not present this server.
+    return !is_proxied;
+  }
+
+  if ( !is_proxied )
+  {
+    // This server has ProxyMatch element(s) but client is not connecting through proxy
+    // so do not present this server.
+    return false;
+  }
 
   for ( unsigned j = 0; j < networkManager.servers[i]->proxy_match.size(); ++j )
   {

--- a/pol-core/pol/login.cpp
+++ b/pol-core/pol/login.cpp
@@ -21,7 +21,6 @@
 
 #include <cstring>
 #include <string>
-#include <boost/asio/ip/address.hpp>
 
 #include "../clib/clib.h"
 #include "../clib/clib_MD5.h"

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -70,7 +70,8 @@ namespace Network
 {
 unsigned int Client::instance_counter_;
 
-ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, sockaddr& client_addr,
+ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
+                                sockaddr& client_addr,
                                 std::vector<boost::asio::ip::network_v4>& allowed_proxies )
     : myClient( myClient ),
       thread_pid( static_cast<size_t>( -1 ) ),

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -70,7 +70,7 @@ namespace Network
 {
 unsigned int Client::instance_counter_;
 
-ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient )
+ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, bool use_proxy_protocol )
     : myClient( myClient ),
       thread_pid( static_cast<size_t>( -1 ) ),
       csocket( INVALID_SOCKET ),
@@ -80,7 +80,7 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient 
       encrypt_server_stream( false ),
       last_activity_at( 0 ),
       last_packet_at( 0 ),
-      recv_state( RECV_STATE_CRYPTSEED_WAIT ),
+      recv_state( use_proxy_protocol ? RECV_STATE_PROXYPROTOCOLHEADER_WAIT : RECV_STATE_CRYPTSEED_WAIT ),
       bufcheck1_AA( 0xAA ),
       buffer(),  // zero-initializes the buffer
       bufcheck2_55( 0x55 ),
@@ -99,10 +99,11 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient 
 {
   memset( &counters, 0, sizeof counters );
   memset( &ipaddr, 0, sizeof( ipaddr ) );
+  memset( &ipaddr_proxy, 0, sizeof( ipaddr_proxy ) );
 };
 
-Client::Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption )
-    : ThreadedClient( encryption, *this ),
+Client::Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption, bool use_proxy_protocol )
+    : ThreadedClient( encryption, *this, use_proxy_protocol ),
       acct( nullptr ),
       chr( nullptr ),
       Interface( aInterface ),

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -70,7 +70,8 @@ namespace Network
 {
 unsigned int Client::instance_counter_;
 
-ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, bool use_proxy_protocol )
+ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
+                                bool use_proxy_protocol )
     : myClient( myClient ),
       thread_pid( static_cast<size_t>( -1 ) ),
       csocket( INVALID_SOCKET ),
@@ -80,7 +81,8 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
       encrypt_server_stream( false ),
       last_activity_at( 0 ),
       last_packet_at( 0 ),
-      recv_state( use_proxy_protocol ? RECV_STATE_PROXYPROTOCOLHEADER_WAIT : RECV_STATE_CRYPTSEED_WAIT ),
+      recv_state( use_proxy_protocol ? RECV_STATE_PROXYPROTOCOLHEADER_WAIT
+                                     : RECV_STATE_CRYPTSEED_WAIT ),
       bufcheck1_AA( 0xAA ),
       buffer(),  // zero-initializes the buffer
       bufcheck2_55( 0x55 ),
@@ -102,7 +104,8 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
   memset( &ipaddr_proxy, 0, sizeof( ipaddr_proxy ) );
 };
 
-Client::Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption, bool use_proxy_protocol )
+Client::Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption,
+                bool use_proxy_protocol )
     : ThreadedClient( encryption, *this, use_proxy_protocol ),
       acct( nullptr ),
       chr( nullptr ),

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -80,6 +80,7 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
       disconnect( false ),
       cryptengine( create_crypt_engine( encryption ) ),
       encrypt_server_stream( false ),
+      allowed_proxies( allowed_proxies ),
       last_activity_at( 0 ),
       last_packet_at( 0 ),
       recv_state( RECV_STATE_CRYPTSEED_WAIT ),
@@ -97,8 +98,7 @@ ThreadedClient::ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient,
       first_xmit_buffer( nullptr ),
       last_xmit_buffer( nullptr ),
       n_queued( 0 ),
-      queued_bytes_counter( 0 ),
-      allowed_proxies( allowed_proxies )
+      queued_bytes_counter( 0 )
 {
   memset( &counters, 0, sizeof counters );
   memcpy( &ipaddr, &client_addr, sizeof ipaddr );

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -148,6 +148,7 @@ public:
   void closeConnection();
 
   std::string ipaddrAsString() const;
+  std::string ipaddrProxyAsString() const;
 
   // methods below should be protected?
   bool have_queued_data() const;
@@ -163,7 +164,7 @@ public:
   PacketLog stop_log();
 
 protected:
-  ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient );
+  ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, bool use_proxy_protocol );
 
 public:
   // this reference is only needed because we have diagnostic messages that need the client
@@ -190,7 +191,9 @@ public:
     RECV_STATE_MSGTYPE_WAIT,
     RECV_STATE_MSGLEN_WAIT,
     RECV_STATE_MSGDATA_WAIT,
-    RECV_STATE_CLIENTVERSION_WAIT
+    RECV_STATE_CLIENTVERSION_WAIT,
+    RECV_STATE_PROXYPROTOCOLHEADER_WAIT,
+    RECV_STATE_PROXYPROTOCOLPAYLOAD_WAIT
   } recv_state;
 
   unsigned char bufcheck1_AA;
@@ -209,6 +212,7 @@ public:
   std::string fpLog;
 
   sockaddr ipaddr;
+  sockaddr ipaddr_proxy;
 
   bool disable_inactivity_timeout;
 
@@ -236,7 +240,7 @@ private:
 class Client : private ThreadedClient
 {
 public:
-  Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption );
+  Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption, bool use_proxy_protocol );
   Client( const Client& ) = delete;
   Client& operator=( const Client& ) = delete;
   ~Client();
@@ -246,9 +250,10 @@ public:
   ThreadedClient* session() { return static_cast<ThreadedClient*>( this ); }
   const ThreadedClient* session() const { return static_cast<const ThreadedClient*>( this ); }
 
-  // these remaining three members are ok to be public for now and will be wrapped later
+  // these remaining four members are ok to be public for now and will be wrapped later
   using ThreadedClient::csocket;
   using ThreadedClient::ipaddr;
+  using ThreadedClient::ipaddr_proxy;
   using ThreadedClient::msgtype_filter;
 
   // wrappers for ThreadedClient members

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <queue>
 #include <string>
+#include <boost/asio/ip/network_v4.hpp>
 
 #include "../../clib/network/sockets.h"
 #include "../../clib/rawtypes.h"
@@ -164,7 +165,8 @@ public:
   PacketLog stop_log();
 
 protected:
-  ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, bool use_proxy_protocol );
+  ThreadedClient( Crypt::TCryptInfo& encryption, Client& myClient, sockaddr& ipaddr,
+                  std::vector<boost::asio::ip::network_v4>& allowed_proxies );
 
 public:
   // this reference is only needed because we have diagnostic messages that need the client
@@ -178,6 +180,8 @@ public:
 
   Crypt::CCryptBase* cryptengine;
   bool encrypt_server_stream;  // encrypt the server stream (data sent to client)?
+
+  std::vector<boost::asio::ip::network_v4> allowed_proxies;
 
   // Will be set by clientthread
   std::atomic<Core::polclock_t> last_activity_at;
@@ -240,7 +244,8 @@ private:
 class Client : private ThreadedClient
 {
 public:
-  Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption, bool use_proxy_protocol );
+  Client( ClientInterface& aInterface, Crypt::TCryptInfo& encryption, sockaddr& ipaddr,
+          std::vector<boost::asio::ip::network_v4>& allowed_proxies );
   Client( const Client& ) = delete;
   Client& operator=( const Client& ) = delete;
   ~Client();

--- a/pol-core/pol/network/clientio.cpp
+++ b/pol-core/pol/network/clientio.cpp
@@ -93,6 +93,11 @@ std::string ThreadedClient::ipaddrAsString() const
   return AddressToString( &this->ipaddr );
 }
 
+std::string ThreadedClient::ipaddrProxyAsString() const
+{
+  return AddressToString( &this->ipaddr_proxy );
+}
+
 void ThreadedClient::recv_remaining( int total_expected )
 {
   int count;

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -466,16 +466,17 @@ bool process_data( Network::ThreadedClient* session )
   }
   else if ( session->recv_state == Network::ThreadedClient::RECV_STATE_PROXYPROTOCOLHEADER_WAIT )
   {
-    session->recv_remaining_nocrypt( sizeof(pp_header_v2) );
+    session->recv_remaining_nocrypt( sizeof( pp_header_v2 ) );
 
-    if ( session->bytes_received == sizeof(pp_header_v2) )
+    if ( session->bytes_received == sizeof( pp_header_v2 ) )
     {
-      pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>(&session->buffer);
+      pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>( &session->buffer );
 
       if ( !pp_header->is_valid() )
       {
-        POLLOGLN( "Client#{} ({}): disconnected due to invalid proxy header", session->myClient.instance_,
-          session->ipaddrAsString() );
+        POLLOGLN( "Client#{} ({}): disconnected due to invalid proxy header",
+                  session->myClient.instance_,
+                  session->ipaddrAsString() );
 
         // invalid header
         session->forceDisconnect();
@@ -484,7 +485,8 @@ bool process_data( Network::ThreadedClient* session )
 
       if ( pp_header->command() == PP_CMD_LOCAL && pp_header->payload_size() == 0 )
       {
-        // for local command with zero payload there is nothing else to read => continue with the stream
+        // for local command with zero payload there is nothing else to read => continue with the
+        // stream
         session->recv_state = Network::ThreadedClient::RECV_STATE_CRYPTSEED_WAIT;
         session->bytes_received = 0;
       }
@@ -499,12 +501,13 @@ bool process_data( Network::ThreadedClient* session )
 
   if ( session->recv_state == Network::ThreadedClient::RECV_STATE_PROXYPROTOCOLPAYLOAD_WAIT )
   {
-    pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>(&session->buffer);
-    session->recv_remaining_nocrypt( sizeof(pp_header_v2) + pp_header->payload_size() );
+    pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>( &session->buffer );
+    session->recv_remaining_nocrypt( sizeof( pp_header_v2 ) + pp_header->payload_size() );
 
-    if ( session->bytes_received == sizeof(pp_header_v2) + pp_header->payload_size() )
+    if ( session->bytes_received == sizeof( pp_header_v2 ) + pp_header->payload_size() )
     {
-      pp_payload_v2* pp_payload = reinterpret_cast<pp_payload_v2*>(&session->buffer[sizeof(pp_header_v2)]);
+      pp_payload_v2* pp_payload =
+          reinterpret_cast<pp_payload_v2*>( &session->buffer[sizeof( pp_header_v2 )] );
 
       if ( pp_header->command() == PP_CMD_LOCAL )
       {
@@ -517,35 +520,39 @@ bool process_data( Network::ThreadedClient* session )
       {
         bool was_proxied = false;
 
-        if ( pp_header->address_family() == PP_AF_INET && pp_header->payload_size() >= sizeof(pp_payload->ipv4_addr) )
+        if ( pp_header->address_family() == PP_AF_INET &&
+             pp_header->payload_size() >= sizeof( pp_payload->ipv4_addr ) )
         {
           memcpy( &session->ipaddr_proxy, &session->ipaddr, sizeof(session->ipaddr_proxy) );
-          memset( &session->ipaddr, 0, sizeof(session->ipaddr) );
+          memset( &session->ipaddr, 0, sizeof( session->ipaddr ) );
 
-          auto ipaddr_in = reinterpret_cast<sockaddr_in*>(&session->ipaddr);
+          auto ipaddr_in = reinterpret_cast<sockaddr_in*>( &session->ipaddr );
           ipaddr_in->sin_family = AF_INET;
           ipaddr_in->sin_port = pp_payload->ipv4_addr.src_port;
-          memcpy( &ipaddr_in->sin_addr, &pp_payload->ipv4_addr.src_addr, sizeof(ipaddr_in->sin_addr) );
+          memcpy( &ipaddr_in->sin_addr, &pp_payload->ipv4_addr.src_addr,
+                  sizeof(ipaddr_in->sin_addr) );
 
           was_proxied = true;
         }
 
         /* IPv6 isn't supported
-        if ( pp_header->address_family() == PP_AF_INET6 && pp_header->payload_size() >= sizeof(pp_payload->ipv6_addr) )
+        if ( pp_header->address_family() == PP_AF_INET6 &&
+             pp_header->payload_size() >= sizeof( pp_payload->ipv6_addr ) )
         {
-          memcpy( &session->ipaddr_proxy, &session->ipaddr, sizeof(session->ipaddr_proxy) );
-          memset( &session->ipaddr, 0, sizeof(session->ipaddr) );
+          memcpy( &session->ipaddr_proxy, &session->ipaddr, sizeof( session->ipaddr_proxy ) );
+          memset( &session->ipaddr, 0, sizeof( session->ipaddr ) );
 
-          auto ipaddr_in6 = reinterpret_cast<sockaddr_in6*>(&session->ipaddr);
+          auto ipaddr_in6 = reinterpret_cast<sockaddr_in6*>( &session->ipaddr );
           ipaddr_in6->sin6_family = AF_INET6;
           ipaddr_in6->sin6_port = pp_payload->ipv6_addr.src_port;
-          memcpy( &ipaddr_in6->sin6_addr, &pp_payload->ipv6_addr.src_addr, sizeof(ipaddr_in6->sin6_addr) );
+          memcpy( &ipaddr_in6->sin6_addr, &pp_payload->ipv6_addr.src_addr,
+                  sizeof(ipaddr_in6->sin6_addr) );
 
           was_proxied = true;
         }
         */
 
-        if (was_proxied)
+        if ( was_proxied )
         {
           POLLOGLN( "Client#{} ({}): connected through proxy {}", session->myClient.instance_,
             session->ipaddrAsString(),
@@ -558,8 +565,8 @@ bool process_data( Network::ThreadedClient* session )
       }
 
       // unsupported combination
-      POLLOGLN( "Client#{} ({}): disconnected due to unsupported proxy payload", session->myClient.instance_,
-        session->ipaddrAsString() );
+      POLLOGLN( "Client#{} ({}): disconnected due to unsupported proxy payload",
+        session->myClient.instance_, session->ipaddrAsString() );
 
       session->forceDisconnect();
       return false;

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -38,6 +38,7 @@
 #include "pktbothid.h"
 #include "pktdef.h"
 #include "pktinid.h"
+#include "proxyprotocol.h"
 
 
 #define CLIENT_CHECKPOINT( x ) client->session()->checkpoint = x
@@ -463,6 +464,109 @@ bool process_data( Network::ThreadedClient* session )
     }
     // Else keep waiting for IP address.
   }
+  else if ( session->recv_state == Network::ThreadedClient::RECV_STATE_PROXYPROTOCOLHEADER_WAIT )
+  {
+    session->recv_remaining_nocrypt( sizeof(pp_header_v2) );
+
+    if ( session->bytes_received == sizeof(pp_header_v2) )
+    {
+      pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>(&session->buffer);
+
+      if ( !pp_header->is_valid() )
+      {
+        POLLOGLN( "Client#{} ({}): disconnected due to invalid proxy header", session->myClient.instance_,
+          session->ipaddrAsString() );
+
+        // invalid header
+        session->forceDisconnect();
+        return false;
+      }
+
+      if ( pp_header->command() == PP_CMD_LOCAL && pp_header->payload_size() == 0 )
+      {
+        // for local command with zero payload there is nothing else to read => continue with the stream
+        session->recv_state = Network::ThreadedClient::RECV_STATE_CRYPTSEED_WAIT;
+        session->bytes_received = 0;
+      }
+      else
+      {
+        // other cases need to read payload first
+        session->recv_state = Network::ThreadedClient::RECV_STATE_PROXYPROTOCOLPAYLOAD_WAIT;
+      }
+    }
+    // Else keep waiting
+  }
+
+  if ( session->recv_state == Network::ThreadedClient::RECV_STATE_PROXYPROTOCOLPAYLOAD_WAIT )
+  {
+    pp_header_v2* pp_header = reinterpret_cast<pp_header_v2*>(&session->buffer);
+    session->recv_remaining_nocrypt( sizeof(pp_header_v2) + pp_header->payload_size() );
+
+    if ( session->bytes_received == sizeof(pp_header_v2) + pp_header->payload_size() )
+    {
+      pp_payload_v2* pp_payload = reinterpret_cast<pp_payload_v2*>(&session->buffer[sizeof(pp_header_v2)]);
+
+      if ( pp_header->command() == PP_CMD_LOCAL )
+      {
+        // local commands shouldn't have payload, but in case they do it should be skipped
+        session->recv_state = Network::ThreadedClient::RECV_STATE_CRYPTSEED_WAIT;
+        return true;
+      }
+
+      if ( pp_header->command() == PP_CMD_PROXY && pp_header->protocol() == PP_TP_STREAM )
+      {
+        bool was_proxied = false;
+
+        if ( pp_header->address_family() == PP_AF_INET && pp_header->payload_size() >= sizeof(pp_payload->ipv4_addr) )
+        {
+          memcpy( &session->ipaddr_proxy, &session->ipaddr, sizeof(session->ipaddr_proxy) );
+          memset( &session->ipaddr, 0, sizeof(session->ipaddr) );
+
+          auto ipaddr_in = reinterpret_cast<sockaddr_in*>(&session->ipaddr);
+          ipaddr_in->sin_family = AF_INET;
+          ipaddr_in->sin_port = pp_payload->ipv4_addr.src_port;
+          memcpy( &ipaddr_in->sin_addr, &pp_payload->ipv4_addr.src_addr, sizeof(ipaddr_in->sin_addr) );
+
+          was_proxied = true;
+        }
+
+        /* IPv6 isn't supported
+        if ( pp_header->address_family() == PP_AF_INET6 && pp_header->payload_size() >= sizeof(pp_payload->ipv6_addr) )
+        {
+          memcpy( &session->ipaddr_proxy, &session->ipaddr, sizeof(session->ipaddr_proxy) );
+          memset( &session->ipaddr, 0, sizeof(session->ipaddr) );
+
+          auto ipaddr_in6 = reinterpret_cast<sockaddr_in6*>(&session->ipaddr);
+          ipaddr_in6->sin6_family = AF_INET6;
+          ipaddr_in6->sin6_port = pp_payload->ipv6_addr.src_port;
+          memcpy( &ipaddr_in6->sin6_addr, &pp_payload->ipv6_addr.src_addr, sizeof(ipaddr_in6->sin6_addr) );
+
+          was_proxied = true;
+        }
+        */
+
+        if (was_proxied)
+        {
+          POLLOGLN( "Client#{} ({}): connected through proxy {}", session->myClient.instance_,
+            session->ipaddrAsString(),
+            session->ipaddrProxyAsString() );
+
+          session->recv_state = Network::ThreadedClient::RECV_STATE_CRYPTSEED_WAIT;
+          session->bytes_received = 0;
+          return true;
+        }
+      }
+
+      // unsupported combination
+      POLLOGLN( "Client#{} ({}): disconnected due to unsupported proxy payload", session->myClient.instance_,
+        session->ipaddrAsString() );
+
+      session->forceDisconnect();
+      return false;
+    }
+    // Else keep waiting
+  }
+
   if ( session->recv_state == Network::ThreadedClient::RECV_STATE_CLIENTVERSION_WAIT )
   {
     // receive and send to handler to get directly the version

--- a/pol-core/pol/network/proxyprotocol.h
+++ b/pol-core/pol/network/proxyprotocol.h
@@ -99,27 +99,20 @@ public:
 
   bool has_valid_signature() const
   {
-    return signaure[0] == 0x0D && signaure[1] == 0x0A &&
-           signaure[2] == 0x0D && signaure[3] == 0x0A &&
-           signaure[4] == 0x00 && signaure[5] == 0x0D &&
-           signaure[6] == 0x0A && signaure[7] == 0x51 &&
-           signaure[8] == 0x55 && signaure[9] == 0x49 &&
-           signaure[10] == 0x54 && signaure[11] == 0x0A;
+    return signaure[0] == 0x0D && signaure[1] == 0x0A && signaure[2] == 0x0D &&
+           signaure[3] == 0x0A && signaure[4] == 0x00 && signaure[5] == 0x0D &&
+           signaure[6] == 0x0A && signaure[7] == 0x51 && signaure[8] == 0x55 &&
+           signaure[9] == 0x49 && signaure[10] == 0x54 && signaure[11] == 0x0A;
   }
 
-  bool has_valid_version() const
-  {
-    return version() == 2;
-  }
+  bool has_valid_version() const { return version() == 2; }
 
-  bool has_valid_command() const
-  {
-    return command() == PP_CMD_LOCAL || command() == PP_CMD_PROXY;
-  }
+  bool has_valid_command() const { return command() == PP_CMD_LOCAL || command() == PP_CMD_PROXY; }
 
   bool has_valid_address_family() const
   {
-    return address_family() == PP_AF_UNSPEC || address_family() == PP_AF_INET || address_family() == PP_AF_INET6 || address_family() == PP_AF_UNIX;
+    return address_family() == PP_AF_UNSPEC || address_family() == PP_AF_INET ||
+           address_family() == PP_AF_INET6 || address_family() == PP_AF_UNIX;
   }
 
   bool has_valid_protocol() const

--- a/pol-core/pol/network/proxyprotocol.h
+++ b/pol-core/pol/network/proxyprotocol.h
@@ -1,0 +1,165 @@
+/** @file
+*
+ * @par History
+ * - 2024/02/07 Kukkino:  added proxy protocol v2 support
+ */
+
+#ifndef PROXYPROTOCOL_H
+#define PROXYPROTOCOL_H
+
+/*
+ * The connection was established on purpose by the proxy
+ * without being relayed. The connection endpoints are the sender and the
+ * receiver. Such connections exist when the proxy sends health-checks to the
+ * server. The receiver must accept this connection as valid and must use the
+ * real connection endpoints and discard the protocol block including the
+ * family which is ignored.
+ */
+#define PP_CMD_LOCAL 0x0
+
+/*
+ * The connection was established on behalf of another node,
+ * and reflects the original connection endpoints. The receiver must then use
+ * the information provided in the protocol block to get original the address.
+ */
+#define PP_CMD_PROXY 0x1
+
+/*
+ * The connection is forwarded for an unknown, unspecified
+ * or unsupported protocol. The sender should use this family when sending
+ * LOCAL commands or when dealing with unsupported protocol families. The
+ * receiver is free to accept the connection anyway and use the real endpoint
+ * addresses or to reject it. The receiver should ignore address information.
+ */
+#define PP_AF_UNSPEC 0x0
+/*
+ * The forwarded connection uses the AF_INET address family
+ * (IPv4). The addresses are exactly 4 bytes each in network byte order,
+ * followed by transport protocol information (typically ports).
+ */
+#define PP_AF_INET 0x1
+/*
+ * The forwarded connection uses the AF_INET6 address family
+ * (IPv6). The addresses are exactly 16 bytes each in network byte order,
+ * followed by transport protocol information (typically ports).
+ */
+#define PP_AF_INET6 0x2
+/*
+ * The forwarded connection uses the AF_UNIX address family
+ * (UNIX). The addresses are exactly 108 bytes each.
+ */
+#define PP_AF_UNIX 0x3
+
+/*
+ * the connection is forwarded for an unknown, unspecified
+ * or unsupported protocol. The sender should use this family when sending
+ * LOCAL commands or when dealing with unsupported protocol families. The
+ * receiver is free to accept the connection anyway and use the real endpoint
+ * addresses or to reject it. The receiver should ignore address information.
+ */
+#define PP_TP_UNSPEC 0x0
+
+/*
+ * the forwarded connection uses a SOCK_STREAM protocol (eg:
+ * TCP or UNIX_STREAM). When used with AF_INET/AF_INET6 (TCP), the addresses
+ * are followed by the source and destination ports represented on 2 bytes
+ * each in network byte order.
+ */
+#define PP_TP_STREAM 0x1
+
+/*
+ * The forwarded connection uses a SOCK_DGRAM protocol (eg:
+ * UDP or UNIX_DGRAM). When used with AF_INET/AF_INET6 (UDP), the addresses
+ * are followed by the source and destination ports represented on 2 bytes
+ * each in network byte order.
+ */
+#define PP_TP_DGRAM 0x2
+
+struct pp_header_v2
+{
+  /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */
+  uint8_t signaure[12];
+
+private:
+  /* protocol version and command */
+  uint8_t version_command_value;
+  /* protocol family and address */
+  uint8_t family_protocol_value;
+  /* number of following bytes part of the header */
+  uint16_t payload_size_value;
+
+public:
+  uint8_t version() const { return version_command_value >> 4; }
+  uint8_t command() const { return version_command_value & 0xf; }
+
+  uint8_t address_family() const { return family_protocol_value >> 4; }
+  uint8_t protocol() const { return family_protocol_value & 0xf; }
+
+  uint16_t payload_size() const { return ntohs(payload_size_value); }
+
+  bool has_valid_signature() const
+  {
+    return signaure[0] == 0x0D && signaure[1] == 0x0A &&
+      signaure[2] == 0x0D && signaure[3] == 0x0A &&
+      signaure[4] == 0x00 && signaure[5] == 0x0D &&
+      signaure[6] == 0x0A && signaure[7] == 0x51 &&
+      signaure[8] == 0x55 && signaure[9] == 0x49 &&
+      signaure[10] == 0x54 && signaure[11] == 0x0A;
+  }
+
+  bool has_valid_version() const
+  {
+    return version() == 2;
+  }
+
+  bool has_valid_command() const
+  {
+    return command() == PP_CMD_LOCAL || command() == PP_CMD_PROXY;
+  }
+
+  bool has_valid_address_family() const
+  {
+    return address_family() == PP_AF_UNSPEC || address_family() == PP_AF_INET || address_family() == PP_AF_INET6 || address_family() == PP_AF_UNIX;
+  }
+
+  bool has_valid_protocol() const
+  {
+    return protocol() == PP_TP_UNSPEC || protocol() == PP_TP_STREAM || protocol() == PP_TP_DGRAM;
+  }
+
+  bool is_valid() const
+  {
+    return has_valid_signature() && has_valid_version() && has_valid_command() && has_valid_address_family() && has_valid_protocol();
+  }
+
+};
+
+// sanity check
+static_assert(sizeof(pp_header_v2) == 16);
+
+union pp_payload_v2 {
+  /* for TCP/UDP over IPv4, len = 12 */
+  struct {
+    uint32_t src_addr;
+    uint32_t dst_addr;
+    uint16_t src_port;
+    uint16_t dst_port;
+  } ipv4_addr;
+  /* for TCP/UDP over IPv6, len = 36 */
+  struct {
+    uint8_t  src_addr[16];
+    uint8_t  dst_addr[16];
+    uint16_t src_port;
+    uint16_t dst_port;
+  } ipv6_addr;
+  /* for AF_UNIX sockets, len = 216 */
+  struct {
+    uint8_t src_addr[108];
+    uint8_t dst_addr[108];
+  } unix_addr;
+};
+
+// sanity check
+static_assert(sizeof(pp_payload_v2) == 216);
+
+#endif //PROXYPROTOCOL_H

--- a/pol-core/pol/network/proxyprotocol.h
+++ b/pol-core/pol/network/proxyprotocol.h
@@ -95,16 +95,16 @@ public:
   uint8_t address_family() const { return family_protocol_value >> 4; }
   uint8_t protocol() const { return family_protocol_value & 0xf; }
 
-  uint16_t payload_size() const { return ntohs(payload_size_value); }
+  uint16_t payload_size() const { return ntohs( payload_size_value ); }
 
   bool has_valid_signature() const
   {
     return signaure[0] == 0x0D && signaure[1] == 0x0A &&
-      signaure[2] == 0x0D && signaure[3] == 0x0A &&
-      signaure[4] == 0x00 && signaure[5] == 0x0D &&
-      signaure[6] == 0x0A && signaure[7] == 0x51 &&
-      signaure[8] == 0x55 && signaure[9] == 0x49 &&
-      signaure[10] == 0x54 && signaure[11] == 0x0A;
+           signaure[2] == 0x0D && signaure[3] == 0x0A &&
+           signaure[4] == 0x00 && signaure[5] == 0x0D &&
+           signaure[6] == 0x0A && signaure[7] == 0x51 &&
+           signaure[8] == 0x55 && signaure[9] == 0x49 &&
+           signaure[10] == 0x54 && signaure[11] == 0x0A;
   }
 
   bool has_valid_version() const
@@ -129,31 +129,35 @@ public:
 
   bool is_valid() const
   {
-    return has_valid_signature() && has_valid_version() && has_valid_command() && has_valid_address_family() && has_valid_protocol();
+    return has_valid_signature() && has_valid_version() && has_valid_command() &&
+           has_valid_address_family() && has_valid_protocol();
   }
 
 };
 
 // sanity check
-static_assert(sizeof(pp_header_v2) == 16);
+static_assert( sizeof( pp_header_v2 ) == 16 );
 
 union pp_payload_v2 {
   /* for TCP/UDP over IPv4, len = 12 */
-  struct {
+  struct
+  {
     uint32_t src_addr;
     uint32_t dst_addr;
     uint16_t src_port;
     uint16_t dst_port;
   } ipv4_addr;
   /* for TCP/UDP over IPv6, len = 36 */
-  struct {
+  struct
+  {
     uint8_t  src_addr[16];
     uint8_t  dst_addr[16];
     uint16_t src_port;
     uint16_t dst_port;
   } ipv6_addr;
   /* for AF_UNIX sockets, len = 216 */
-  struct {
+  struct
+  {
     uint8_t src_addr[108];
     uint8_t dst_addr[108];
   } unix_addr;

--- a/pol-core/pol/servdesc.h
+++ b/pol-core/pol/servdesc.h
@@ -24,6 +24,8 @@ public:
   unsigned short port;
   std::vector<unsigned int> ip_match;
   std::vector<unsigned int> ip_match_mask;
+  std::vector<unsigned int> proxy_match;
+  std::vector<unsigned int> proxy_match_mask;
   std::vector<std::string> acct_match;
   std::string hostname;
 };

--- a/pol-core/pol/uimport.cpp
+++ b/pol-core/pol/uimport.cpp
@@ -1456,6 +1456,26 @@ void read_gameservers()
       }
     }
 
+    while ( elem.remove_prop( "PROXYMATCH", &iptext ) )
+    {
+      auto delim = iptext.find_first_of( '/' );
+      if ( delim != std::string::npos )
+      {
+        std::string ipaddr_str = iptext.substr( 0, delim );
+        std::string ipmask_str = iptext.substr( delim + 1 );
+        unsigned int ipaddr = inet_addr( ipaddr_str.c_str() );
+        unsigned int ipmask = inet_addr( ipmask_str.c_str() );
+        svr->proxy_match.push_back( ipaddr );
+        svr->proxy_match_mask.push_back( ipmask );
+      }
+      else
+      {
+        unsigned int ipaddr = inet_addr( iptext.c_str() );
+        svr->proxy_match.push_back( ipaddr );
+        svr->proxy_match_mask.push_back( 0xFFffFFffLu );
+      }
+    }
+
     while ( elem.remove_prop( "ACCTMATCH", &accttext ) )
     {
       svr->acct_match.push_back( accttext );

--- a/pol-core/pol/uoclient.cpp
+++ b/pol-core/pol/uoclient.cpp
@@ -34,6 +34,7 @@ UoClientListener::UoClientListener( Clib::ConfigElem& elem )
     : port( elem.remove_ushort( "PORT" ) ),
       aosresist( elem.remove_bool( "AOSRESISTANCES", false ) ),
       sticky( elem.remove_bool( "KeepClients", false ) ),
+      use_proxy_protocol( elem.remove_bool( "UseProxyProtocol", false ) ),
       login_clients_size( 0 ),
       login_clients()
 

--- a/pol-core/pol/uoclient.cpp
+++ b/pol-core/pol/uoclient.cpp
@@ -34,12 +34,28 @@ UoClientListener::UoClientListener( Clib::ConfigElem& elem )
     : port( elem.remove_ushort( "PORT" ) ),
       aosresist( elem.remove_bool( "AOSRESISTANCES", false ) ),
       sticky( elem.remove_bool( "KeepClients", false ) ),
-      use_proxy_protocol( elem.remove_bool( "UseProxyProtocol", false ) ),
+      allowed_proxies(),
       login_clients_size( 0 ),
       login_clients()
 
 {
   CalculateCryptKeys( elem.remove_string( "ENCRYPTION", "none" ), encryption );
+
+  std::string iptext;
+  while ( elem.remove_prop( "AllowProxy", &iptext ) )
+  {
+    auto delim = iptext.find_first_of( '/' );
+    if ( delim != std::string::npos )
+    {
+      auto network = boost::asio::ip::make_network_v4( iptext );
+      allowed_proxies.push_back( network );
+    }
+    else
+    {
+      auto ip = boost::asio::ip::make_address_v4( iptext );
+      allowed_proxies.push_back( boost::asio::ip::network_v4( ip, 32 ) );
+    }
+  }
 }
 
 size_t UoClientListener::estimateSize() const

--- a/pol-core/pol/uoclient.h
+++ b/pol-core/pol/uoclient.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <boost/asio/ip/network_v4.hpp>
 
 #include "../clib/network/socketsvc.h"
 #include "crypt/cryptkey.h"
@@ -103,7 +104,7 @@ public:
     port = std::move( l.port );
     aosresist = std::move( l.aosresist );
     sticky = std::move( l.sticky );
-    use_proxy_protocol = std::move( l.use_proxy_protocol );
+    allowed_proxies = std::move( l.allowed_proxies );
     login_clients_size = l.login_clients_size.load();
     login_clients = std::move( l.login_clients );
   }
@@ -117,7 +118,7 @@ public:
   unsigned short port;
   bool aosresist;
   bool sticky;
-  bool use_proxy_protocol;
+  std::vector<boost::asio::ip::network_v4> allowed_proxies;
 
 private:
   std::atomic<size_t> login_clients_size;  // multiple threads want to know the login size

--- a/pol-core/pol/uoclient.h
+++ b/pol-core/pol/uoclient.h
@@ -103,6 +103,7 @@ public:
     port = std::move( l.port );
     aosresist = std::move( l.aosresist );
     sticky = std::move( l.sticky );
+    use_proxy_protocol = std::move( l.use_proxy_protocol );
     login_clients_size = l.login_clients_size.load();
     login_clients = std::move( l.login_clients );
   }
@@ -116,6 +117,7 @@ public:
   unsigned short port;
   bool aosresist;
   bool sticky;
+  bool use_proxy_protocol;
 
 private:
   std::atomic<size_t> login_clients_size;  // multiple threads want to know the login size

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -69,7 +69,7 @@ bool UoClientThread::create()
   socklen_t host_addrlen = sizeof host_addr;
 
   PolLock lck;
-  client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption );
+  client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption, _def->use_proxy_protocol );
 
   // TODO: move this into an initialization of ThreadedClient.
   client->csocket = _sck.release_handle();  // client cleans up its socket.

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -70,11 +70,11 @@ bool UoClientThread::create()
 
   PolLock lck;
   client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption,
-                                _def->use_proxy_protocol );
+                                client_addr,
+                                _def->allowed_proxies );
 
   // TODO: move this into an initialization of ThreadedClient.
   client->csocket = _sck.release_handle();  // client cleans up its socket.
-  memcpy( &client->ipaddr, &client_addr, sizeof client->ipaddr );
 
   if ( _def->sticky )
     client->listen_port = _def->port;

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -69,7 +69,8 @@ bool UoClientThread::create()
   socklen_t host_addrlen = sizeof host_addr;
 
   PolLock lck;
-  client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption, _def->use_proxy_protocol );
+  client = new Network::Client( *Core::networkManager.uo_client_interface.get(), _def->encryption,
+                                _def->use_proxy_protocol );
 
   // TODO: move this into an initialization of ThreadedClient.
   client->csocket = _sck.release_handle();  // client cleans up its socket.


### PR DESCRIPTION
This change adds option to create listeners with proxy protocol v2 support (<https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt>). This allows for preserving client ips while hiding your actual game server behind proxies (ex. <https://www.haproxy.org/>).

To accept proxy protocol `Listener` in `uoclient.cfg` needs to be configured with `AllowProxy x.x.x.x`. This will cause listener to expect proxy protocol v2 from these IPs.

For example:
```
Listener
{
    port 5000
    Encryption ignition
    AllowProxy 10.0.1.14
}
```
- if incoming connection from 10.0.1.14 is using proxy protocol, it is accepted and for all further processing the IP address presented by the protocol is used instead
- if incoming connection from 10.0.1.14 is not using proxy protocol, it is rejected
- if incoming connection from 10.0.1.55 is using proxy protocol, it is rejected (since pol expect uo protocol)
- if incoming connection from 10.0.1.55 is not using proxy protocol, it is accepted


This change also adds `ProxyMatch` property to `GameServer` in `servers.cfg`. When using proxy protocol this property should be present on at least one game server, otherwise clients connecting through proxy will receive empty server list. This may seem a little unintitive, however it provides a bit more options to directing users to correct listeners (can have open "secret" public ip as well as proxied one while not automatically exposing the former to proxy users).
```
GameServer
{
    Name        My server
    IP          89.100.100.65
    Port        5000
}

GameServer
{
    Name        My proxied server
    IP          89.100.100.65
    Port        5000
    ProxyMatch  10.0.1.14
}
```
- client connecting through proxy `10.0.1.14` will see only `My proxied server`
- client connecting through proxy `10.0.1.22` won't see any servers
- client connecting without proxy will see only `My server`


Proxy information is not exposed to scripting.

When client (172.17.0.1) is connecting through a proxy (127.0.0.1) log looks like this:
```
[02/14 16:36:05] Client#1 connected from 127.0.0.1 (1/0 connections) on interface 127.0.0.1
[02/14 16:36:05] Client#1 (172.17.0.1): connected through proxy 127.0.0.1
[02/14 16:36:05] Account admin logged in from 172.17.0.1
[02/14 16:36:09] Client#1 (172.17.0.1): disconnected (account admin)
[02/14 16:36:10] Client#2 connected from 127.0.0.1 (1/0 connections) on interface 127.0.0.1
[02/14 16:36:10] Client#2 (172.17.0.1): connected through proxy 127.0.0.1
[02/14 16:36:10] Account admin logged in from 172.17.0.1
[02/14 16:36:15] Account admin selecting character kukkino
[02/14 16:36:22] Client#2 (172.17.0.1): disconnected (account admin)
```

When client (127.0.0.1) is connecting without proxy when proxy protocol is expected, log looks like this:
```
[02/14 16:41:11] Client#4 connected from 127.0.0.1 (1/0 connections) on interface 127.0.0.1
[02/14 16:41:11] Client#4 (127.0.0.1): disconnected due to invalid proxy header
[02/14 16:41:11] Client#4 (127.0.0.1): disconnected (account unknown)
```