### PR TITLE
Set mmap_rnd_bits to 28

### DIFF
--- a/.github/workflows/buildsan.yml
+++ b/.github/workflows/buildsan.yml
@@ -99,6 +99,10 @@ jobs:
 
       - name: Register problem matcher
         run: echo "::add-matcher::.github/problem-matchers/${{ matrix.config.c-compiler }}.json"
+      - name: Set mmap_rnd_bits
+        run: |
+          sudo sysctl vm.mmap_rnd_bits
+          sudo sysctl vm.mmap_rnd_bits=28
       - name: Config
         run: |
           cd bin-build


### PR DESCRIPTION
Fix sanitizer builds by setting `vm.mmap_rnd_bits` to 28.

See https://github.com/google/sanitizers/issues/1716 for details.