### PR TITLE
Fix map crash on edges in Tokuno; Introduce Realm Descriptor versioning

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>03-16-2024</datemodified>
+		<datemodified>03-18-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>03-18-2024</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Crash when going to certain map edge locations in Tokuno.</change>
+			<change type="Note">This change requires recreating realms via uoconvert.</change>
+		</entry>
 		<entry>
 			<date>03-16-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -1,6 +1,9 @@
 # This is a short summary of breaking changes.
 # Please consult core-changes.txt for more information.
--- POL100.1.0 [work-in-progress] --
+-- POL100.2.0 [work-in-progress] --
+03-18-2024:
+    The file format for uoconvert's realm output has changed. Realms must be re-generated.
+-- POL100.1.0 --
     The ability to generate the Escript wordlist via the -W argument to ecompile.exe has been removed. Passing this argument will
     result in an unknown option error.
 2021-03-04:

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.2.0 --
+03-18-2024 Kevin:
+    Fixed: Crash when going to certain map edge locations in Tokuno.
+     Note: This change requires recreating realms via uoconvert.
 03-16-2024 Kevin:
     Added: item.weight_multiplier_mod to dynamically modify an item's weight.
            For example, on an item that weighs 100 stone, setting this property

--- a/pol-core/plib/mapblock.h
+++ b/pol-core/plib/mapblock.h
@@ -15,9 +15,9 @@ namespace Pol
 {
 namespace Plib
 {
-const unsigned MAPBLOCK_CHUNK = 64;
-const unsigned MAPBLOCK_SHIFT = 6;  // 6 bits
-const unsigned MAPBLOCK_CELLMASK = 0x3F;
+const unsigned MAPBLOCK_CHUNK = 8;
+const unsigned MAPBLOCK_SHIFT = 3;
+const unsigned MAPBLOCK_CELLMASK = 7;
 
 struct MAPBLOCK
 {

--- a/pol-core/plib/mapsolid.h
+++ b/pol-core/plib/mapsolid.h
@@ -10,13 +10,14 @@
 #ifndef PLIB_MAPBLOB_H
 #define PLIB_MAPBLOB_H
 
-#define SOLIDX_X_SIZE 16
-#define SOLIDX_X_SHIFT 4
-#define SOLIDX_X_CELLMASK 0xF
+#define SOLIDX_X_SIZE 8
+#define SOLIDX_X_SHIFT 3
+#define SOLIDX_X_CELLMASK 7
 
-#define SOLIDX_Y_SIZE 16
-#define SOLIDX_Y_SHIFT 4
-#define SOLIDX_Y_CELLMASK 0xF
+#define SOLIDX_Y_SIZE 8
+#define SOLIDX_Y_SHIFT 3
+#define SOLIDX_Y_CELLMASK 7
+
 namespace Pol
 {
 namespace Plib
@@ -33,7 +34,7 @@ struct SOLIDX2_ELEM
   unsigned int baseindex;
   unsigned short addindex[SOLIDX_X_SIZE][SOLIDX_Y_SIZE];
 };
-static_assert( sizeof( SOLIDX2_ELEM ) == 516, "size missmatch" );
+static_assert( sizeof( SOLIDX2_ELEM ) == 132, "size missmatch" );
 
 struct SOLIDS_ELEM
 {

--- a/pol-core/plib/mapwriter.cpp
+++ b/pol-core/plib/mapwriter.cpp
@@ -14,6 +14,7 @@
 #include "../clib/iohelp.h"
 #include "mapcell.h"
 #include "mapsolid.h"
+#include "realmdescriptor.h"
 #include "uofile.h"
 
 
@@ -63,6 +64,7 @@ void MapWriter::WriteConfigFile()
   ofs_cfg << "    num_static_patches " << num_static_patches << std::endl;
   ofs_cfg << "    num_map_patches " << num_map_patches << std::endl;
   ofs_cfg << "    season 1" << std::endl;
+  ofs_cfg << "    version " << RealmDescriptor::VERSION << std::endl;
   ofs_cfg << "}" << std::endl;
 }
 

--- a/pol-core/plib/realmdescriptor.cpp
+++ b/pol-core/plib/realmdescriptor.cpp
@@ -57,8 +57,16 @@ RealmDescriptor::RealmDescriptor( const std::string& realm_name, const std::stri
       season( elem.remove_unsigned( "season", 1 ) ),
       mapserver_type( Clib::strlowerASCII( elem.remove_string( "mapserver", "memory" ) ) ),
       grid_width( calc_grid_size( width ) ),
-      grid_height( calc_grid_size( height ) )
+      grid_height( calc_grid_size( height ) ),
+      version( elem.remove_ushort( "version", 0 ) )
 {
+  if ( version != RealmDescriptor::VERSION )
+  {
+    elem.throw_error(
+        fmt::format( "Invalid realm descriptor version: expecting version {}. "
+                     "Please regenerate realms using uoconvert.",
+                     RealmDescriptor::VERSION ) );
+  }
 }
 
 size_t RealmDescriptor::sizeEstimate() const

--- a/pol-core/plib/realmdescriptor.h
+++ b/pol-core/plib/realmdescriptor.h
@@ -25,6 +25,7 @@ class RealmDescriptor
 {
 public:
   static RealmDescriptor Load( const std::string& realm_name, const std::string& realm_path = "" );
+  static constexpr unsigned short VERSION = 1;
 
   std::string name;
   std::string file_path;
@@ -38,6 +39,7 @@ public:
   std::string mapserver_type;  // "memory" or "file"
   unsigned short grid_width;
   unsigned short grid_height;
+  unsigned short version;
 
   std::string path( const std::string& filename ) const;
   bool operator==( const RealmDescriptor& rdesc ) const


### PR DESCRIPTION
As this change modifies the structure of the realms data files, realms must be regenerated via uoconvert.