### PR TITLE
Add servspecopt NpcMinimumMovementDelay

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -393,6 +393,7 @@ Spell (int spellid)
 [UndoGetItemEnableRangeCheck    (0/1 {default 0})]
 [UndoGetItemDropHere            (0/1 {default 0})]
 [BoatSailsCollide               (0/1 {default 0})]
+[NpcMinimumMovementDelay        (int milliseconds {default 250})]
 </structure>
   <explain><i>RefreshDecayAfterBoatMoves</i> if enabled item's decayat will be refreshed after each move or turn of a boat. Note that item decay on boats is not yet handled by the core.</explain>
   <explain><i>TotalStatsAtCreation:</i> takes a comma-delimited lists of values and/or ranges (default = '65,80'). Example: TotalStatsAtCreation=65,80,90-95,100-110</explain>
@@ -473,6 +474,8 @@ Note: Token and nonToken Eventtype is still the same (SYSEVENT_SPEECH)</explain>
   and on fail to put item back to backpack drops item at character position (feet), except no_drop items. Attempt to return item in<br/>
   origin container will be skipped.</explain>
   <explain><i>BoatSailsCollide:</i> If enabled - boat sails will collide with objects in the world and cannot be passed through.</explain>
+  <explain><i>NpcMinimumMovementDelay:</i> Related to NPC's run_speed attribute. It is used to define minimum delay in between NPC's movement steps used by functions like WalkToward, RunAwayFrom and similar.<br/>
+   Lower the value to increase maximum speed of all NPCs. It is halved for running.</explain>
   <related>movecost.cfg</related>
   <related>repsys.cfg</related>
 </cfgfile>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -6,6 +6,12 @@
 	</header>
 	<version name="POL100.2.0">
 		<entry>
+			<date>04-24-2024</date>
+			<author>Reloecc:</author>
+			<change type="Added">`NpcMinimumMovementDelay` parameter to `servspecopt.cfg`.<br/>
+It controls maximum movement speed of NPCs.</change>
+		</entry>
+		<entry>
 			<date>04-14-2024</date>
 			<author>Kevin:</author>
 			<change type="Changed">Boat sails will now by default not collide with other objects in the<br/>

--- a/docs/docs.polserver.com/pol100/npcem.xml
+++ b/docs/docs.polserver.com/pol100/npcem.xml
@@ -74,11 +74,13 @@
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
     
 <function name="WalkAwayFrom">
@@ -89,11 +91,13 @@
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="RunToward">
@@ -104,11 +108,13 @@
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="RunAwayFrom">
@@ -119,11 +125,13 @@
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="TurnToward">
@@ -139,6 +147,7 @@ const FACE_FORCE := 0x1;</code></explain>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="TurnAwayFrom">
@@ -154,6 +163,7 @@ const FACE_FORCE := 0x1;</code></explain>
 	<error>"Mobile specified cannot be seen" if object is a character and invisible</error>
 	<related>NPC</related>
 	<related>UObject</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="WalkTowardLocation">
@@ -165,10 +175,12 @@ const FACE_FORCE := 0x1;</code></explain>
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Invalid Coordinates for Realm"</error>
 	<related>NPC</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="WalkAwayFromLocation">
@@ -180,10 +192,12 @@ const FACE_FORCE := 0x1;</code></explain>
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Invalid Coordinates for Realm"</error>
 	<related>NPC</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>	
 	
 <function name="RunTowardLocation">
@@ -195,10 +209,12 @@ const FACE_FORCE := 0x1;</code></explain>
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Invalid Coordinates for Realm"</error>
 	<related>NPC</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>
 
 <function name="RunAwayFromLocation">
@@ -210,10 +226,12 @@ const FACE_FORCE := 0x1;</code></explain>
 	<explain>See the NPC members run_speed and use_adjustments. If use_adjustments is 1 the NPC will adjust the direction of the move to attempt to avoid small obsticles. Also, this function will always return true as a result. If it is 0, the NPC will not attempt to adjust the move, and the function will return false.</explain>
 	<explain>The success of this function is affected by the NPC's anchor point. See SetAnchor().</explain>
 	<explain>In the future, this function will activate a pathfinding system.</explain>
+	<explain>servspecopt.cfg NpcMinimumMovementDelay setting controls the maximum speed of NPC.</explain>
 	<return>Boolean for move success</return>
 	<error>"Invalid parameter type"</error>
 	<error>"Invalid Coordinates for Realm"</error>
 	<related>NPC</related>
+	<relatedcfg>servspecopt.cfg</relatedcfg>
 </function>	
 
 <function name="TurnTowardLocation">

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+04-24-2024 Reloecc:
+    Added: `NpcMinimumMovementDelay` parameter to `servspecopt.cfg`. It controls maximum movement speed of NPCs.
 04-14-2024 Kevin:
   Changed: Boat sails will now by default not collide with other objects in the
            world. For example, large orc galleon ships "dock" properly at the coastline

--- a/pol-core/pol/module/npcmod.cpp
+++ b/pol-core/pol/module/npcmod.cpp
@@ -229,11 +229,12 @@ BObjectImp* NPCExecutorModule::move_self( Core::UFACING facing, bool run, bool a
     }
   }
 
-  // int base = 1000 - npc.dexterity() * 3;
-  int base = 1000 - npc.run_speed * 3;
-  if ( base < 250 )
-    base = 250;
-  u32 sleep = static_cast<u32>( base );
+  // int delay = 1000 - npc.dexterity() * 3;
+  int delay = std::max<int>(
+    1000 - npc.run_speed * 3,
+    Core::settingsManager.ssopt.npc_minimum_movement_delay
+  );
+  u32 sleep = static_cast<u32>( delay );
   os_module->SleepForMs( run ? ( sleep / 2 ) : sleep );
 
   // return new String( FacingStr(facing) );

--- a/pol-core/pol/ssopt.cpp
+++ b/pol-core/pol/ssopt.cpp
@@ -145,6 +145,8 @@ void ServSpecOpt::read_servspecopt()
   settingsManager.ssopt.undo_get_item_drop_here =
       elem.remove_ushort( "UndoGetItemDropHere", false );
   settingsManager.ssopt.boat_sails_collide = elem.remove_bool( "BoatSailsCollide", false );
+  settingsManager.ssopt.npc_minimum_movement_delay =
+      elem.remove_ushort( "NpcMinimumMovementDelay", 250 );
 
   ssopt_parse_totalstats( elem );
 

--- a/pol-core/pol/ssopt.h
+++ b/pol-core/pol/ssopt.h
@@ -105,6 +105,8 @@ struct ServSpecOpt
 
   bool boat_sails_collide;
 
+  unsigned short npc_minimum_movement_delay;
+
   static void read_servspecopt();
   static void ssopt_parse_totalstats( Clib::ConfigElem& elem );
 };

--- a/pol-core/poltool/baredistrofiles.cpp
+++ b/pol-core/poltool/baredistrofiles.cpp
@@ -615,7 +615,16 @@ void BareDistro::distro_files( std::map<fs::path, std::vector<std::string>>& dis
 "#",
 "# If enabled - boat sails will collide with objects in the world and cannot be passed through.",
 "#",
-"BoatSailsCollide=0"
+"BoatSailsCollide=0",
+"",
+"#",
+"# NpcMinimumMovementDelay - ms (default 250)",
+"#",
+"# Related to NPC's run_speed attribute. It is used to define minimum delay in between NPC's movement steps.",
+"# Used by functions like WalkToward, RunAwayFrom and similar.",
+"# Lower the value to increase maximum speed of all NPCs. It is halved for running.",
+"#",
+"NpcMinimumMovementDelay=250"
                   } ) );
 
   distro.emplace( "config/startloc.cfg",


### PR DESCRIPTION
Added config to control maximum movement speed of NPCs.

Useful to create NPCs that are at or above speed of mounted player, e.g. followers that won't lack behind or ncps that can't be outrunned.