### PR TITLE
dont use abort() when fail to open a socket.

### DIFF
--- a/pol-core/clib/network/socketsvc.cpp
+++ b/pol-core/clib/network/socketsvc.cpp
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 
 #include "logfacility.h"
+#include "passert.h"
 #include "socketsvc.h"
 #include "strutil.h"
 #include "threadhelp.h"
@@ -20,7 +21,7 @@ SocketListener::SocketListener( unsigned short port ) : _listen_sck()
   if ( !_listen_sck.listen( port ) )
   {
     POLLOG_ERRORLN( "Unable to open listen port {}", port );
-    abort();
+    passert_always( 0 );
   }
 }
 
@@ -31,7 +32,7 @@ SocketListener::SocketListener( unsigned short port, Socket::option opt ) : _lis
   if ( !_listen_sck.listen( port ) )
   {
     POLLOG_ERRORLN( "Unable to open listen port {}", port );
-    abort();
+    passert_always( 0 );
   }
 }
 

--- a/pol-core/clib/passert.cpp
+++ b/pol-core/clib/passert.cpp
@@ -107,6 +107,7 @@ void passert_failed( const char* expr, const std::string& reason, const char* fi
   if ( passert_abort )
   {
     POLLOG_ERRORLN( "Aborting due to assertion failure." );
+    Logging::global_logger->wait_for_empty_queue();
     abort();
   }
 


### PR DESCRIPTION
passert() before calling abort() waits now until the logger is done