### PR TITLE
Improve held weight computations

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>05-16-2024</datemodified>
+		<datemodified>06-14-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>06-14-2024</date>
+			<author>Kukkino:</author>
+			<change type="Fixed">Performance of containers held weight computations in deeply nested scenarios</change>
+		</entry>
 		<entry>
 			<date>05-16-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+06-14-2024 Kukkino:
+    Fixed: Performance of containers held weight computations in deeply nested scenarios
 05-16-2024 Kevin:
     Fixed: When removing a partial stack from a container, the `item` parameter in the container's
            OnRemoveScript will now be the partial stack itself (instead of the pre-split stack).

--- a/pol-core/pol/containr.cpp
+++ b/pol-core/pol/containr.cpp
@@ -228,18 +228,20 @@ void UContainer::remove_bulk( const Items::Item* item )
 
 void UContainer::add_bulk( int item_count_delta, int weight_delta )
 {
+  if ( item_count_delta == 0 && weight_delta == 0 )
+    return;
+
   held_item_count_ += item_count_delta;
 
   // passert( !stateManager.gflag_enforce_container_limits || (held_weight_ + weight_delta <=
   // MAX_WEIGHT) );
 
+  int oldweight = 0;
   if ( container != nullptr )
-    container->add_bulk( 0, -static_cast<int>( weight() ) );
-  int newweight = held_weight_;
-  newweight += weight_delta;
-  held_weight_ = Clib::clamp_convert<u16>( newweight );
+    oldweight = weight();
+  held_weight_ = Clib::clamp_convert<u16>( held_weight_ + weight_delta );
   if ( container != nullptr )
-    container->add_bulk( 0, weight() );
+    container->add_bulk( 0, weight() - oldweight );
 }
 
 

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -3835,9 +3835,9 @@ Bscript::BObjectImp* UContainer::set_script_member_id_double( const int id, doub
   {
     if ( container )
     {
-      container->add_bulk( 0, -static_cast<int>( weight() ) );
+      int oldweight = weight();
       held_weight_multiplier( value );
-      container->add_bulk( 0, weight() );
+      container->add_bulk( 0, weight() - oldweight );
     }
     else
     {


### PR DESCRIPTION
`held_weight_multiplier` introduced recursive call with exponential complexity which made working with deeply nested containers very slow, this PR optimizes the computations.

Before
```
Loading an item took load=0ms read=0ms store=11554ms (item=1884893733, container=1884936625, depth=28, callcount=268435455)
Loading an item took load=0ms read=0ms store=22974ms (item=1884893734, container=1884893733, depth=29, callcount=536870911)
Loading an item took load=0ms read=0ms store=46285ms (item=1884891786, container=1884893734, depth=30, callcount=1073741823)
Loading an item took load=0ms read=0ms store=92698ms (item=1884891787, container=1884891786, depth=31, callcount=2147483647)
Loading an item took load=0ms read=0ms store=185153ms (item=1884889478, container=1884891787, depth=32, callcount=4294967295)
Loading an item took load=0ms read=0ms store=368158ms (item=1884887796, container=1884889478, depth=33, callcount=8589934591)
Loading an item took load=0ms read=0ms store=722447ms (item=1884889479, container=1884887796, depth=34, callcount=17179869183)
```

After
```
Loading an item took load=0ms read=0ms store=0ms (item=1884893733, container=1884936625, depth=28, callcount=28)
Loading an item took load=0ms read=0ms store=0ms (item=1884893734, container=1884893733, depth=29, callcount=29)
Loading an item took load=0ms read=0ms store=0ms (item=1884891786, container=1884893734, depth=30, callcount=30)
Loading an item took load=0ms read=0ms store=0ms (item=1884891787, container=1884891786, depth=31, callcount=31)
Loading an item took load=0ms read=0ms store=0ms (item=1884889478, container=1884891787, depth=32, callcount=32)
Loading an item took load=0ms read=0ms store=0ms (item=1884887796, container=1884889478, depth=33, callcount=33)
Loading an item took load=0ms read=0ms store=0ms (item=1884889479, container=1884887796, depth=34, callcount=34)
```