### PR TITLE
Send `Print()` messages to attached debugger

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-14-2024</datemodified>
+		<datemodified>07-16-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>07-16-2024</date>
+			<author>Kevin:</author>
+			<change type="Added">When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.</change>
+		</entry>
 		<entry>
 			<date>07-14-2024</date>
 			<author>Turley:</author>

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -3462,6 +3462,16 @@ void Executor::detach_debugger()
   dbg_env_.reset();
   sethalt( false );
 }
+
+void Executor::print_to_debugger( const std::string& message )
+{
+  if ( dbg_env_ )
+  {
+    if ( std::shared_ptr<ExecutorDebugListener> listener = dbg_env_->listener.lock() )
+      listener->on_print( message );
+  }
+}
+
 void Executor::dbg_ins_trace()
 {
   if ( dbg_env_ )

--- a/pol-core/bscript/executor.h
+++ b/pol-core/bscript/executor.h
@@ -72,6 +72,7 @@ class ExecutorDebugListener
 public:
   virtual void on_halt(){};
   virtual void on_destroy(){};
+  virtual void on_print( const std::string& /*str*/ ){};
 };
 
 // FIXME: how to make this a nested struct in Executor?
@@ -417,6 +418,7 @@ public:
   bool attach_debugger( std::weak_ptr<ExecutorDebugListener> listener = {},
                         bool set_attaching = true );
   void detach_debugger();
+  void print_to_debugger( const std::string& message );
   std::string dbg_get_instruction( size_t atPC ) const;
   void dbg_get_instruction( size_t atPC, std::string& os ) const;
   void dbg_ins_trace();

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+07-16-2024 Kevin:
+    Added: When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.
 07-14-2024 Turley:
   Removed: pol.cfg SingleThreadDecay setting
   Changed: syshook CanDecay: returning 2 skips further core checks.

--- a/pol-core/pol/dap/clientthread.cpp
+++ b/pol-core/pol/dap/clientthread.cpp
@@ -64,6 +64,14 @@ void DebugClientThread::on_destroy()
   _exit_sent = true;
 }
 
+void DebugClientThread::on_print( const std::string& output )
+{
+  dap::OutputEvent event;
+  event.category = "stdout";
+  event.output = output + "\n";
+  _session->send( event );
+}
+
 dap::ConfigurationDoneResponse DebugClientThread::handle_configurationDone(
     const dap::ConfigurationDoneRequest& )
 {

--- a/pol-core/pol/dap/clientthread.h
+++ b/pol-core/pol/dap/clientthread.h
@@ -42,6 +42,8 @@ public:
 
   void on_destroy() override;
 
+  void on_print( const std::string& output ) override;
+
 private:
   // Handlers
   dap::ConfigurationDoneResponse handle_configurationDone( const dap::ConfigurationDoneRequest& );

--- a/pol-core/pol/module/basiciomod.cpp
+++ b/pol-core/pol/module/basiciomod.cpp
@@ -24,15 +24,20 @@ Bscript::BObjectImp* BasicIoExecutorModule::mf_Print()
   const Bscript::String* color;
   if ( !exec.getStringParam( 1, color ) )
     return new Bscript::BError( "Invalid parameter type" );
+
+  auto message = exec.getParamImp( 0 )->getStringRep();
+
   if ( Plib::systemstate.config.enable_colored_output && color->length() )
   {
-    INFO_PRINTLN( "{}{}{}", color->value(), exec.getParamImp( 0 )->getStringRep(),
-                 Clib::Logging::CONSOLE_RESET_COLOR );
+    INFO_PRINTLN( "{}{}{}", color->value(), message, Clib::Logging::CONSOLE_RESET_COLOR );
   }
   else
   {
-    INFO_PRINTLN( exec.getParamImp( 0 )->getStringRep() );
+    INFO_PRINTLN( message );
   }
+
+  exec.print_to_debugger( message );
+
   return new Bscript::UninitObject;
 }
 }  // namespace Pol::Module

--- a/pol-core/pol/module/basiciomod.cpp
+++ b/pol-core/pol/module/basiciomod.cpp
@@ -25,7 +25,7 @@ Bscript::BObjectImp* BasicIoExecutorModule::mf_Print()
   if ( !exec.getStringParam( 1, color ) )
     return new Bscript::BError( "Invalid parameter type" );
 
-  auto message = exec.getParamImp( 0 )->getStringRep();
+  const auto& message = exec.getParamImp( 0 )->getStringRep();
 
   if ( Plib::systemstate.config.enable_colored_output && color->length() )
   {

--- a/testsuite/pol/testpkgs/debugger/debuggee.src
+++ b/testsuite/pol/testpkgs/debugger/debuggee.src
@@ -18,6 +18,13 @@ program main(running)
         var shadowed_result := funcShadowed("funcShadowed:param1");
         Sleepms(1);
     dowhile (running && running != "stop");
+
+    // This only prints in the "launch" test, as the "attach" test never finishes the loop.
+    //
+    // [NB: The "launch" test kills this script once the test finishes, whereas the "launch"
+    // script waits for this script to exit.]
+
+    print( "Loop finished!" );
 endprogram
 
 function func1( func1_param1, func1_param2, func1_param3 )

--- a/testsuite/pol/testpkgs/debugger/debugger_client.src
+++ b/testsuite/pol/testpkgs/debugger/debugger_client.src
@@ -103,6 +103,17 @@ function run_launch_test()
         return err;
     endif
 
+    // Wait for event: output
+    var output;
+    if ( !( output := event_received( err, "output" ) ) )
+        return err;
+    endif
+
+    if ( output.category != "stdout" || output.output != "Loop finished!\n" )
+        return ret_error( $"Incorrect output event. Expected category='stdout', output='Loop finished!\\n', got category='{output.category}', output='{output.output}'" );
+    endif
+
+
     // Wait for event: exited
     if (!event_received(err, "exited"))
         return err;


### PR DESCRIPTION
When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.