### PR TITLE
Add source location to `Print()` messages sent to debugger

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,7 +8,8 @@
 		<entry>
 			<date>07-16-2024</date>
 			<author>Kevin:</author>
-			<change type="Added">When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.</change>
+			<change type="Added">When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.<br/>
+The log message includes the source location of the `Print()` call.</change>
 		</entry>
 		<entry>
 			<date>07-14-2024</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,7 @@
 -- POL100.2.0 --
 07-16-2024 Kevin:
     Added: When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.
+           The log message includes the source location of the `Print()` call.
 07-14-2024 Turley:
   Removed: pol.cfg SingleThreadDecay setting
   Changed: syshook CanDecay: returning 2 skips further core checks.

--- a/testsuite/pol/testpkgs/debugger/debuggee.src
+++ b/testsuite/pol/testpkgs/debugger/debuggee.src
@@ -24,7 +24,7 @@ program main(running)
     // [NB: The "launch" test kills this script once the test finishes, whereas the "launch"
     // script waits for this script to exit.]
 
-    print( "Loop finished!" );
+    print( "Loop finished!" ); /*print*/
 endprogram
 
 function func1( func1_param1, func1_param2, func1_param3 )

--- a/testsuite/pol/testpkgs/debugger/debugger_client.src
+++ b/testsuite/pol/testpkgs/debugger/debugger_client.src
@@ -46,6 +46,19 @@ program auxservice(conn, params)
 endprogram
 
 function run_launch_test()
+    // Get script source
+    var source := ReadFile( "debuggee.src" );
+    if (!source)
+        return ret_error(source);
+    endif
+
+    var print_linenum;
+    foreach line in source
+        if (line.find("/*print*/"))
+            print_linenum := _line_iter;
+        endif
+    endforeach
+
     var err;
 
     // Send request: initialize
@@ -109,10 +122,21 @@ function run_launch_test()
         return err;
     endif
 
-    if ( output.category != "stdout" || output.output != "Loop finished!\n" )
-        return ret_error( $"Incorrect output event. Expected category='stdout', output='Loop finished!\\n', got category='{output.category}', output='{output.output}'" );
-    endif
+    var expected := struct{
+        category := "stdout",
+        output := "Loop finished!\n",
+        line := print_linenum,
+        source := struct{
+            path := stackTrace.stackFrames[1].source.path
+        }
+    };
 
+    if ( output.category != expected.category ||
+        output.output != expected.output ||
+        output.line != expected.line ||
+        output.source.path != expected.source.path )
+            return ret_error( $"Incorrect output event. Expected: {expected}, actual {output}" );
+    endif
 
     // Wait for event: exited
     if (!event_received(err, "exited"))


### PR DESCRIPTION
The log message includes the source location of the `Print()` call.