### PR TITLE
Update Github Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,17 +201,17 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download artefacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Nightly-Linux-g++
           path: Nightly-Linux-g++
       - name: Download artefacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Nightly-Linux-clang++
           path: Nightly-Linux-clang++
       - name: Download artefacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Nightly-Windows-cl
           path: Nightly-Windows-cl


### PR DESCRIPTION
Update missing download-artifact action which I believe was the cause of the release failure as we have the artifacts uploaded but was on a different version
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/36e95f25-cd0a-45c5-8586-071021d7cf53">
