### PR TITLE
Fix status hp values upon realm change

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-16-2024</datemodified>
+		<datemodified>07-21-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>07-21-2024</date>
+			<author>Kukkino:</author>
+			<change type="Fixed">Changing realm will now send full status to player to prevent showing scaled hp/maxhp.</change>
+		</entry>
 		<entry>
 			<date>07-16-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+07-21-2024 Kukkino:
+    Fixed: Changing realm will now send full status to player to prevent showing scaled hp/maxhp.
 07-16-2024 Kevin:
     Added: When using the debugger, an attached script's `Print()` calls will now show in the Debug Console.
            The log message includes the source location of the `Print()` call.

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -4009,7 +4009,7 @@ void Character::realm_changed()
     Core::send_map_difs( client );
     if ( Core::settingsManager.ssopt.core_sends_season )
       Core::send_season_info( client );
-    Core::send_short_statmsg( client, this );
+    Core::send_full_statmsg( client, this );
     Core::send_feature_enable( client );
   }
 }


### PR DESCRIPTION
When changing realms player gets sent status update packet with values scaled to 1000 instead of actual values. This PR changes behavior so that full status update is sent, which is consistent with all other usages - `Core::send_short_statmsg` is otherwise used only when sending status of other entities that aren't current player.