### PR TITLE
improved escript formatter when formatting if's/function parameters

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-29-2024</datemodified>
+		<datemodified>07-31-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>07-31-2024</date>
+			<author>Turley:</author>
+			<change type="Improved">EScript ECompile Formatter: formatting of if statements and function parameters</change>
+		</entry>
 		<entry>
 			<date>07-29-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
@@ -427,7 +427,7 @@ antlrcpp::Any PrettifyFileProcessor::visitExpressionList(
   {
     visitExpression( args[i] );
     if ( i < args.size() - 1 )
-      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() );
+      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
   return {};
 }
@@ -457,7 +457,7 @@ antlrcpp::Any PrettifyFileProcessor::visitExpression( EscriptParser::ExpressionC
     case EscriptLexer::OR_B:
     case EscriptLexer::AND_A:
     case EscriptLexer::AND_B:
-      style = FmtToken::SPACE | FmtToken::BREAKPOINT;
+      style = FmtToken::SPACE | FmtToken::BREAKPOINT | FmtToken::PREFERRED_BREAK;
       break;
     case EscriptLexer::ADDMEMBER:
     case EscriptLexer::DELMEMBER:
@@ -693,7 +693,7 @@ antlrcpp::Any PrettifyFileProcessor::visitFunctionParameterList(
   {
     visitFunctionParameter( params[i] );
     if ( i < params.size() - 1 )
-      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() );
+      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
   return {};
 }
@@ -1047,7 +1047,7 @@ antlrcpp::Any PrettifyFileProcessor::visitModuleFunctionParameterList(
   {
     visitModuleFunctionParameter( params[i] );
     if ( i < params.size() - 1 )
-      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() );
+      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
   return {};
 }
@@ -1118,7 +1118,7 @@ antlrcpp::Any PrettifyFileProcessor::visitProgramParameterList(
     visitProgramParameter( params[i] );
     // comma is optional here
     if ( i < params.size() - 1 && ctx->COMMA( i ) )
-      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() );
+      addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
   return {};
 }

--- a/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
@@ -457,7 +457,7 @@ antlrcpp::Any PrettifyFileProcessor::visitExpression( EscriptParser::ExpressionC
     case EscriptLexer::OR_B:
     case EscriptLexer::AND_A:
     case EscriptLexer::AND_B:
-      style = FmtToken::SPACE | FmtToken::BREAKPOINT | FmtToken::PREFERRED_BREAK;
+      style = FmtToken::SPACE | FmtToken::BREAKPOINT | FmtToken::PREFERRED_BREAK_LOGICAL;
       break;
     case EscriptLexer::ADDMEMBER:
     case EscriptLexer::DELMEMBER:

--- a/pol-core/bscript/compiler/file/PrettifyLineBuilder.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyLineBuilder.cpp
@@ -141,8 +141,8 @@ void PrettifyLineBuilder::buildLine( size_t current_ident )
   mergeComments();
 
   // fill lines with final strings splitted at breakpoints
-  // <splitted string, forcenewline, groupid>
-  std::vector<std::tuple<std::string, bool, size_t, size_t>> lines;
+  // <splitted string, groupid, firstgroup, style>
+  std::vector<std::tuple<std::string, size_t, size_t, int>> lines;
   {
     std::string line;
     size_t firstgroup = 0;
@@ -164,8 +164,8 @@ void PrettifyLineBuilder::buildLine( size_t current_ident )
       }
       if ( _line_parts[i].style & FmtToken::FORCED_BREAK )
       {
-        lines.emplace_back(
-            std::make_tuple( std::move( line ), true, _line_parts[i].group, firstgroup ) );
+        lines.emplace_back( std::make_tuple( std::move( line ), _line_parts[i].group, firstgroup,
+                                             _line_parts[i].style ) );
         line.clear();
       }
       // start a new line if breakpoint
@@ -196,34 +196,37 @@ void PrettifyLineBuilder::buildLine( size_t current_ident )
         }
         if ( skip )
           continue;
-        lines.emplace_back(
-            std::make_tuple( std::move( line ), false, _line_parts[i].group, firstgroup ) );
+        lines.emplace_back( std::make_tuple( std::move( line ), _line_parts[i].group, firstgroup,
+                                             _line_parts[i].style ) );
         line.clear();
       }
     }
     // add remainings
     if ( !line.empty() )
     {
-      lines.emplace_back( std::make_tuple( std::move( line ), false, _line_parts.back().group,
-                                           _line_parts.back().group ) );
+      lines.emplace_back( std::make_tuple( std::move( line ), _line_parts.back().group,
+                                           _line_parts.back().group, _line_parts.back().style ) );
       line.clear();
     }
   }
 #ifdef DEBUG_FORMAT_BREAK
   INFO_PRINTLN( "BREAK " );
-  for ( auto& [l, forced, group, firstgroup] : lines )
-    INFO_PRINTLN( "\"{}\" {}-{}", l, group, firstgroup );
+  for ( auto& [l, group, firstgroup, style] : lines )
+    INFO_PRINTLN( "\"{}\" {}-{} ->{}", l, group, firstgroup, style );
 #endif
   // add newline from original sourcecode
   addEmptyLines( _line_parts.front().pos.line_number );
 
-  // sum up linelength, are groups inside
+  // sum up linelength, are groups inside or preferred breaks
   bool groups = false;
+  bool has_preferred = false;
   size_t linelength = 0;
-  for ( auto& [l, forced, group, firstgroup] : lines )
+  for ( auto& [l, group, firstgroup, style] : lines )
   {
     if ( group != 0 )
       groups = true;
+    if ( style & FmtToken::PREFERRED_BREAK )
+      has_preferred = true;
     linelength += l.size();
   }
 
@@ -238,9 +241,9 @@ void PrettifyLineBuilder::buildLine( size_t current_ident )
     auto ident = identSpacing();
     line = ident;
     bool groupdiffered = false;
-    for ( auto& [l, forced, group, firstgroup] : lines )
+    for ( auto& [l, group, firstgroup, style] : lines )
     {
-      if ( forced )
+      if ( style & FmtToken::FORCED_BREAK )
       {
         line += l;
         stripline( line );
@@ -336,27 +339,83 @@ void PrettifyLineBuilder::buildLine( size_t current_ident )
   }
   else  // split based on parts
   {
-    // build final lines
-    size_t alignmentspace = 0;
-    for ( auto& [l, forced, group, firstgroup] : lines )
+    // with preferred breaks
+    if ( has_preferred )
     {
-      // following lines need to be aligned
-      if ( line.empty() && alignmentspace )
-        line = alignmentSpacing( alignmentspace );
-      // first breakpoint defines the alignment and add initial ident level
-      if ( !alignmentspace )
+      // first join parts until a forced/preferred break
+      size_t alignmentspace = 0;
+      std::vector<std::pair<std::string, int>> parts;
+      std::string tmp;
+      for ( auto& [l, group, firstgroup, style] : lines )
       {
-        auto ident = identSpacing();
-        alignmentspace = l.size() + ident.size();
-        line += ident;
+        if ( !alignmentspace )
+        {
+          auto ident = identSpacing();
+          alignmentspace = l.size() + ident.size();
+          line += ident;
+          parts.push_back( { l, FmtToken::NONE } );
+          continue;
+        }
+        tmp += l;
+        if ( style & FmtToken::FORCED_BREAK || style & FmtToken::PREFERRED_BREAK )
+        {
+          parts.push_back( { std::move( tmp ), style } );
+          tmp.clear();
+        }
       }
-      line += l;
-      // linewidth reached add current line, start a new one
-      if ( line.size() > compilercfg.FormatterLineWidth || forced )
+      if ( !tmp.empty() )
+        parts.push_back( { tmp, FmtToken::NONE } );
+      // now build the actual line(s)
+      bool alignpart = false;
+      for ( auto& [l, style] : parts )
       {
-        stripline( line );
-        _lines.emplace_back( std::move( line ) );
-        line.clear();
+#ifdef DEBUG_FORMAT_BREAK
+        INFO_PRINTLN( "'{}'{} -{} FILTERED", l, l.size(), style );
+#endif
+        if ( line.empty() && alignmentspace && alignpart )
+          line = alignmentSpacing( alignmentspace );
+        alignpart = true;  // otherwise first part would get spacing
+        // with a margin of 50% start a new line before
+        if ( ( line.size() + ( l.size() / 2 ) ) > compilercfg.FormatterLineWidth )
+        {
+          stripline( line );
+          _lines.emplace_back( std::move( line ) );
+          line = alignmentSpacing( alignmentspace );
+        }
+        line += l;
+        // linewidth reached add current line, start a new one
+        if ( line.size() > compilercfg.FormatterLineWidth || style & FmtToken::FORCED_BREAK )
+        {
+          stripline( line );
+          _lines.emplace_back( std::move( line ) );
+          line.clear();
+        }
+      }
+    }
+    else  // simple splitting
+    {
+      // build final lines
+      size_t alignmentspace = 0;
+      for ( auto& [l, group, firstgroup, style] : lines )
+      {
+        // following lines need to be aligned
+        if ( line.empty() && alignmentspace )
+          line = alignmentSpacing( alignmentspace );
+        // first breakpoint defines the alignment and add initial ident level
+        if ( !alignmentspace )
+        {
+          auto ident = identSpacing();
+          alignmentspace = l.size() + ident.size();
+          line += ident;
+        }
+        line += l;
+        // linewidth reached add current line, start a new one
+        if ( line.size() > compilercfg.FormatterLineWidth || style & FmtToken::FORCED_BREAK )
+        {
+          stripline( line );
+          _lines.emplace_back( std::move( line ) );
+          line.clear();
+        }
       }
     }
   }

--- a/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
+++ b/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
@@ -55,12 +55,13 @@ struct FmtToken
 {
   enum Style
   {
-    NONE = 0,              // do nothing
-    ATTACHED = 1,          // override SPACE of preceding token
-    SPACE = 2,             // add a whitespace char after this token
-    BREAKPOINT = 4,        // potential linebreak
-    FORCED_BREAK = 8,      // force linebreak
-    PREFERRED_BREAK = 16,  // preferred linebreak eg && or , in params
+    NONE = 0,                      // do nothing
+    ATTACHED = 1,                  // override SPACE of preceding token
+    SPACE = 2,                     // add a whitespace char after this token
+    BREAKPOINT = 4,                // potential linebreak
+    FORCED_BREAK = 8,              // force linebreak
+    PREFERRED_BREAK = 16,          // preferred linebreak , in params
+    PREFERRED_BREAK_LOGICAL = 32,  // preferred linebreak eg &&
   };
   std::string text = {};
   Position pos = {};

--- a/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
+++ b/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
@@ -55,11 +55,12 @@ struct FmtToken
 {
   enum Style
   {
-    NONE = 0,          // do nothing
-    ATTACHED = 1,      // override SPACE of preceding token
-    SPACE = 2,         // add a whitespace char after this token
-    BREAKPOINT = 4,    // potential linebreak
-    FORCED_BREAK = 8,  // force linebreak
+    NONE = 0,              // do nothing
+    ATTACHED = 1,          // override SPACE of preceding token
+    SPACE = 2,             // add a whitespace char after this token
+    BREAKPOINT = 4,        // potential linebreak
+    FORCED_BREAK = 8,      // force linebreak
+    PREFERRED_BREAK = 16,  // preferred linebreak eg && or , in params
   };
   std::string text = {};
   Position pos = {};

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+07-31-2024 Turley:
+ Improved: EScript ECompile Formatter: formatting of if statements and function parameters
 07-29-2024 Kevin:
     Added: Compiler support for function expressions via syntax `@(param1, param2, ..., paramN) { ... }`.
            For example, to get all hidden online players:


### PR DESCRIPTION
logical operators get now a preferred break style same for commas in function/program parameters. split based on this flag the line