### PR TITLE
Delayed AST building of class variable statements

### DIFF
--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -897,7 +897,8 @@ bool SemanticAnalyzer::report_function_name_conflict( const SourceLocation& refe
                                                       const std::string& function_name,
                                                       const std::string& element_description )
 {
-  return report_function_name_conflict( workspace, report, referencing_loc, function_name,
+  return report_function_name_conflict( workspace, report, referencing_loc,
+                                        ScopableName( current_scope_name, function_name ).string(),
                                         element_description );
 }
 

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.h
@@ -59,7 +59,7 @@ private:
                                       const std::string& element_description );
   static bool report_function_name_conflict( const CompilerWorkspace&, Report&,
                                              const SourceLocation&,
-                                             const std::string& function_name,
+                                             const std::string& scoped_function_name,
                                              const std::string& element_description );
 
   CompilerWorkspace& workspace;

--- a/pol-core/bscript/compiler/ast/ClassBody.cpp
+++ b/pol-core/bscript/compiler/ast/ClassBody.cpp
@@ -4,14 +4,9 @@
 
 namespace Pol::Bscript::Compiler
 {
-ClassBody::ClassBody( const SourceLocation& source_location, NodeVector statements )
+ClassBody::ClassBody( const SourceLocation& source_location )
     : Statement( source_location )
 {
-  children.reserve( statements.size() );
-  for ( auto& statement : statements )
-  {
-    children.push_back( std::move( statement ) );
-  }
 }
 
 void ClassBody::accept( NodeVisitor& visitor )

--- a/pol-core/bscript/compiler/ast/ClassBody.h
+++ b/pol-core/bscript/compiler/ast/ClassBody.h
@@ -5,12 +5,12 @@
 namespace Pol::Bscript::Compiler
 {
 class NodeVisitor;
-// Only contains user functions as children, as variable statements are added in
-// `top_level_statements` by SourceFileProcessor.
+// Contains no children when initially constructed in SourceFileProcessor.
+// UserFunctionVisitor will add children once referenced.
 class ClassBody : public Statement
 {
 public:
-  ClassBody( const SourceLocation&, NodeVector statements );
+  ClassBody( const SourceLocation& );
 
   void accept( NodeVisitor& visitor ) override;
   void describe_to( std::string& ) const override;

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
@@ -1,6 +1,6 @@
 #include "ClassDeclaration.h"
 
-#include "bscript/compiler/ast/ClassBody.h"
+
 #include "bscript/compiler/ast/ClassParameterList.h"
 #include "bscript/compiler/ast/DefaultConstructorFunction.h"
 #include "bscript/compiler/ast/Identifier.h"
@@ -13,10 +13,11 @@ namespace Pol::Bscript::Compiler
 ClassDeclaration::ClassDeclaration(
     const SourceLocation& source_location, std::string name,
     std::unique_ptr<ClassParameterList> parameters, std::vector<std::string> function_names,
-    std::unique_ptr<DefaultConstructorFunction> default_constructor )
+    Node* class_body, std::unique_ptr<DefaultConstructorFunction> default_constructor )
     : Node( source_location ),
       name( std::move( name ) ),
-      function_names( std::move( function_names ) )
+      function_names( std::move( function_names ) ),
+      class_body( class_body )
 {
   children.reserve( 2 );
   children.push_back( std::move( parameters ) );

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -17,7 +17,7 @@ class ClassDeclaration : public Node
 public:
   ClassDeclaration( const SourceLocation& source_location, std::string name,
                     std::unique_ptr<ClassParameterList> parameters,
-                    std::vector<std::string> function_names,
+                    std::vector<std::string> function_names, Node* body,
                     std::unique_ptr<DefaultConstructorFunction> default_constructor );
 
   void accept( NodeVisitor& visitor ) override;
@@ -26,6 +26,9 @@ public:
 
   const std::string name;
   std::vector<std::string> function_names;
+
+  // Owned by top_level_statements
+  Node *class_body;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
+++ b/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
@@ -12,10 +12,15 @@ class ParserRuleContext;
 
 namespace Pol::Bscript::Compiler
 {
+class Node;
+
 struct AvailableParseTree
 {
   SourceLocation source_location;
   antlr4::ParserRuleContext* const parse_rule_context;
   std::string scope;
+  // Used by UserFunctionVisitor/Builder to add var statemnts to the ClassBody
+  // inside TopLevelStatements.
+  Node* top_level_statements_child_node;
 };
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -83,7 +83,8 @@ void CompilerWorkspaceBuilder::build_referenced_user_functions( BuilderWorkspace
     for ( auto& apt : to_build )
     {
       UserFunctionVisitor user_function_visitor( *apt.source_location.source_file_identifier,
-                                                 workspace, apt.scope );
+                                                 workspace, apt.scope,
+                                                 apt.top_level_statements_child_node );
 
       apt.parse_rule_context->accept( &user_function_visitor );
     }

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.h
@@ -29,7 +29,11 @@ public:
   explicit FunctionResolver( Report& );
   ~FunctionResolver();
 
+  // Force reference to a function
   void force_reference( const ScopableName& name, const SourceLocation& );
+
+  // Force reference to a class
+  void force_reference( const ScopeName& name );
 
   void register_available_user_function( const SourceLocation&,
                                          EscriptGrammar::EscriptParser::FunctionDeclarationContext*,
@@ -41,7 +45,8 @@ public:
 
   void register_available_class_declaration(
       const SourceLocation& class_loc, const ScopeName& class_name,
-      EscriptGrammar::EscriptParser::ClassDeclarationContext* class_ctx );
+      EscriptGrammar::EscriptParser::ClassDeclarationContext* class_ctx,
+      Node* top_level_statements_child_node );
 
   void register_function_link( const ScopableName& name,
                                std::shared_ptr<FunctionLink> function_link );
@@ -49,6 +54,7 @@ public:
       const SourceLocation&, EscriptGrammar::EscriptParser::FunctionExpressionContext* );
   void register_module_function( ModuleFunctionDeclaration* );
   void register_user_function( const std::string& scope, UserFunction* );
+  void register_class_declaration( ClassDeclaration* );
 
   bool resolve( std::vector<AvailableParseTree>& user_functions_to_build );
 
@@ -60,18 +66,25 @@ private:
                                                     const ScopableName& name,
                                                     bool force_reference );
   void register_available_class_decl_parse_tree( const SourceLocation&, antlr4::ParserRuleContext*,
-                                                 const ScopeName& scope );
+                                                 const ScopeName& scope,
+                                                 Node* top_level_statements_child_node );
 
   Report& report;
 
   using FunctionMap = std::map<ScopableName, Function*>;
+  using ClassDeclarationMap = std::map<ScopeName, ClassDeclaration*>;
+
   using FunctionReferenceMap = std::map<ScopableName, std::vector<std::shared_ptr<FunctionLink>>>;
+  using ClassReferenceMap = std::set<ScopeName>;
+
   using AvailableParseTreeMap = std::map<std::string, AvailableParseTree, Clib::ci_cmp_pred>;
 
   AvailableParseTreeMap available_user_function_parse_trees;
   AvailableParseTreeMap available_class_decl_parse_trees;
   FunctionMap resolved_functions;
+  ClassDeclarationMap resolved_classes;
   FunctionReferenceMap unresolved_function_links;
+  ClassReferenceMap unresolved_classes;
 
   // Returns Function if the key's `{call_scope, name}` exists in
   // `resolved_functions_by_name`, otherwise nullptr.

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.h
@@ -9,6 +9,7 @@ class UserFunction;
 class ClassDeclaration;
 class ClassVariableList;
 class ClassMethodList;
+class Node;
 
 // TODO rename this as it also builds classes
 class UserFunctionBuilder : public CompoundStatementBuilder
@@ -22,7 +23,7 @@ public:
   std::unique_ptr<UserFunction> function_expression(
       EscriptGrammar::EscriptParser::FunctionExpressionContext* );
   std::unique_ptr<ClassDeclaration> class_declaration(
-      EscriptGrammar::EscriptParser::ClassDeclarationContext* );
+      EscriptGrammar::EscriptParser::ClassDeclarationContext*, Node* class_body );
 
 private:
   template <typename ParserContext>

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
@@ -9,8 +9,12 @@
 namespace Pol::Bscript::Compiler
 {
 UserFunctionVisitor::UserFunctionVisitor( const SourceFileIdentifier& sfi, BuilderWorkspace& ws,
-                                          const std::string& scope )
-    : workspace( ws ), tree_builder( sfi, ws ), scope( scope )
+                                          const std::string& scope,
+                                          Node* top_level_statements_child_node )
+    : workspace( ws ),
+      tree_builder( sfi, ws ),
+      scope( scope ),
+      top_level_statements_child_node( top_level_statements_child_node )
 {
 }
 
@@ -49,7 +53,8 @@ antlrcpp::Any UserFunctionVisitor::visitFunctionExpression(
 antlrcpp::Any UserFunctionVisitor::visitClassDeclaration(
     EscriptGrammar::EscriptParser::ClassDeclarationContext* ctx )
 {
-  auto cd = tree_builder.class_declaration( ctx );
+  auto cd = tree_builder.class_declaration( ctx, top_level_statements_child_node );
+  workspace.function_resolver.register_class_declaration( cd.get() );
   workspace.compiler_workspace.class_declarations.push_back( std::move( cd ) );
   return antlrcpp::Any();
 }

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.h
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.h
@@ -11,11 +11,13 @@ class Profile;
 class Report;
 class SourceFileIdentifier;
 class BuilderWorkspace;
+class Node;
 
 class UserFunctionVisitor : public EscriptGrammar::EscriptParserBaseVisitor
 {
 public:
-  UserFunctionVisitor( const SourceFileIdentifier&, BuilderWorkspace&, const std::string& scope );
+  UserFunctionVisitor( const SourceFileIdentifier&, BuilderWorkspace&, const std::string& scope,
+                       Node* top_level_statements_child_node );
 
   antlrcpp::Any visitFunctionDeclaration(
       EscriptGrammar::EscriptParser::FunctionDeclarationContext* ) override;
@@ -31,6 +33,7 @@ private:
 
   UserFunctionBuilder tree_builder;
   const std::string scope;
+  Node* top_level_statements_child_node;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/ScopeName.cpp
+++ b/pol-core/bscript/compiler/model/ScopeName.cpp
@@ -25,4 +25,20 @@ std::string ScopeName::string() const
 {
   return value_or( "" );
 }
+bool ScopeName::operator<( const ScopeName& other ) const
+{
+  if ( !has_value() && !other.has_value() )
+  {
+    return false;
+  }
+  if ( !has_value() && other.has_value() )
+  {
+    return true;
+  }
+  if ( has_value() && !other.has_value() )
+  {
+    return false;
+  }
+  return stricmp( value().c_str(), other.value().c_str() ) < 0;
+}
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/model/ScopeName.h
+++ b/pol-core/bscript/compiler/model/ScopeName.h
@@ -23,5 +23,7 @@ public:
 
   static ScopeName Global;
   static ScopeName None;
+
+  bool operator<( const ScopeName& other ) const;
 };
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/clib/clib.h
+++ b/pol-core/clib/clib.h
@@ -11,6 +11,14 @@
 #include <algorithm>
 #include <limits>
 
+#ifdef __GNUC__
+#include <strings.h>
+#endif
+
+#ifdef _MSC_VER
+#include <string.h>
+#endif
+
 #ifndef __STDDEF_H
 #include "stddef.h"
 #endif

--- a/testsuite/escript/classes/fail-scopes-const-shadowing.src
+++ b/testsuite/escript/classes/fail-scopes-const-shadowing.src
@@ -7,4 +7,9 @@
 const constant := 1;
 class Animal()
     var constant := 2;
+
+    var foo;
 endclass
+
+// Must reference the class to get the parse tree visited.
+Animal::foo;

--- a/testsuite/escript/classes/fail-scopes-var-and-func.err
+++ b/testsuite/escript/classes/fail-scopes-var-and-func.err
@@ -1,0 +1,1 @@
+fail-scopes-var-and-func.src:4:9: error: Cannot define a variable with the same name as function 'Animal::foo'.

--- a/testsuite/escript/classes/fail-scopes-var-and-func.src
+++ b/testsuite/escript/classes/fail-scopes-var-and-func.src
@@ -1,0 +1,11 @@
+// A class cannot have a variable and function with the same name.
+
+class Animal()
+    var foo := "foo";
+
+    function foo()
+    endfunction
+endclass
+
+// Reference the class
+Animal::foo();

--- a/testsuite/escript/classes/scopes-userfunc-shadowing-modfunc.out
+++ b/testsuite/escript/classes/scopes-userfunc-shadowing-modfunc.out
@@ -1,0 +1,4 @@
+BasicioExt::Print what=root i=3
+BasicioExt::Print what=no-scope i=2
+BasicioExt::Print what=with-scope i=1
+BasicioExt::Print what=funcref i=0

--- a/testsuite/escript/classes/scopes-userfunc-shadowing-modfunc.src
+++ b/testsuite/escript/classes/scopes-userfunc-shadowing-modfunc.src
@@ -1,0 +1,17 @@
+// Class defines method `Print`, shadowing `basicio::Print`. Class calls both methods
+
+class BasicioExt()
+    function Print( what, i )
+        ::Print( $"BasicioExt::Print what={what} i={i}" );
+        if ( i == 3 )
+            Print( "no-scope", i - 1 );
+        elseif ( i == 2 )
+            BasicioExt::Print( "with-scope", i - 1 );
+        elseif ( i == 1 )
+            @BasicioExt::Print( "funcref", i - 1 );
+        endif
+    endfunction
+
+endclass
+
+BasicioExt::Print( "root", 3 );

--- a/testsuite/escript/classes/scopes-var-shadowing-modfunc.src
+++ b/testsuite/escript/classes/scopes-var-shadowing-modfunc.src
@@ -1,0 +1,15 @@
+// Variables can shadow user functions
+
+class Animal()
+    var print := "foo";
+
+    function Test()
+        ::print( Print + "bar" );
+    endfunction
+endclass
+
+// Global scope can access the var
+print( Animal::Print );
+
+// Test that a function inside class can access
+Animal::test();

--- a/testsuite/escript/classes/scopes-vars-not-visited.src
+++ b/testsuite/escript/classes/scopes-vars-not-visited.src
@@ -1,0 +1,10 @@
+// Variables are not visited (and therefore not emitted) if the class is never referenced.
+
+const constant := 1;
+class Animal()
+    var constant := 1;
+    var foo;
+endclass
+
+// Uncomment for an error:
+// Animal::foo;


### PR DESCRIPTION
### Split variable statements into two passes

1. When the `SourceFileProcessor` (first-pass AST visitor) visits a class declaration, it will add an (empty) `ClassBody` node to top-level statements. This node is stored in the `AvailableParseTree` (which the `FunctionResolver` keeps as a list of ASTs to visit in second-pass)
2. When the `UserFunctionVisitor` (second-pass AST visitor) visits a class declaration, it adds the var-statement children to the (previously-empty) `ClassBody` node corresponding to its declaration.

Since the var statements are still in proper tree traversal order inside top-level statements (as children of `ClassBody` vs direct children of `TopLevelStatements`), all node visitors (semantic analysis, optimizer, instruction generation, ...) will continue to work. Additionally, any node visitor could decide _not_ to visit class var statements, but currently not the case.

----

### Add class references for scoped identifiers

A class that only provides variables has no functions, so we need to track their availability. The `FunctionResolver` now has new members `resolved_classes` and `unresolved_classes` for tracking classes. When visiting a scoped identifier, we force a reference to the class via `force_reference( ScopeName )`, and resolving the reference via `register_class_declaration( ClassDeclaration* )`


These are the "class equivalent" for the function-based `resolved_functions`, `unresolved_function_links`, `force_reference`, and `register_user_function` respectively.