### PR TITLE
Support linking functions in super scope; explicit `super::` scope calls

### DIFF
--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -226,12 +226,13 @@ bool FunctionResolver::resolve( std::vector<AvailableParseTree>& to_build_ast )
         if ( !calling_scope.empty() )
         {
           std::set<std::string> visited;
-          std::list<std::string> to_link( { calling_scope } );
+          std::list<std::string> to_check( { calling_scope } );
           bool handled = false;
 
-          for ( auto itr = to_link.begin(); !handled && itr != to_link.end(); itr++ )
+          for ( auto to_check_itr = to_check.begin(); !handled && to_check_itr != to_check.end();
+                ++to_check_itr )
           {
-            auto cd_itr = resolved_classes.find( *itr );
+            auto cd_itr = resolved_classes.find( *to_check_itr );
             if ( cd_itr == resolved_classes.end() )
               continue;
 
@@ -251,7 +252,7 @@ bool FunctionResolver::resolve( std::vector<AvailableParseTree>& to_build_ast )
             {
               if ( auto base_cd = base_cd_link->class_declaration() )
               {
-                to_link.push_back( base_cd->name );
+                to_check.push_back( base_cd->name );
               }
             }
           }
@@ -533,11 +534,11 @@ bool FunctionResolver::build_if_available( std::vector<AvailableParseTree>& to_b
     };
 
     std::set<std::string> visited;
-    std::list<std::string> to_link( { calling_scope } );
+    std::list<std::string> to_check( { calling_scope } );
 
-    for ( auto itr = to_link.begin(); itr != to_link.end(); itr++ )
+    for ( auto to_check_itr = to_check.begin(); to_check_itr != to_check.end(); ++to_check_itr )
     {
-      auto cd_itr = resolved_classes.find( *itr );
+      auto cd_itr = resolved_classes.find( *to_check_itr );
       if ( cd_itr == resolved_classes.end() )
         continue;
 
@@ -549,7 +550,7 @@ bool FunctionResolver::build_if_available( std::vector<AvailableParseTree>& to_b
 
       if ( handled_by_scope( cd->name ) )
       {
-        itr = to_link.end();
+        to_check_itr = to_check.end();
         break;
       }
 
@@ -557,7 +558,7 @@ bool FunctionResolver::build_if_available( std::vector<AvailableParseTree>& to_b
       {
         if ( auto base_cd = base_cd_link->class_declaration() )
         {
-          to_link.push_back( base_cd->name );
+          to_check.push_back( base_cd->name );
         }
       }
     }

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -550,7 +550,6 @@ bool FunctionResolver::build_if_available( std::vector<AvailableParseTree>& to_b
 
       if ( handled_by_scope( cd->name ) )
       {
-        to_check_itr = to_check.end();
         break;
       }
 

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -50,6 +50,14 @@ std::unique_ptr<ClassDeclaration> UserFunctionBuilder::class_declaration(
     EscriptGrammar::EscriptParser::ClassDeclarationContext* ctx, Node* class_body )
 {
   std::string class_name = text( ctx->IDENTIFIER() );
+
+  if ( Clib::caseInsensitiveEqual( class_name, "super" ) )
+  {
+    workspace.report.error( location_for( *ctx->IDENTIFIER() ),
+                            "The class name 'super' is reserved." );
+    return nullptr;
+  }
+
   std::vector<std::unique_ptr<ClassParameterDeclaration>> parameters;
   std::vector<std::shared_ptr<ClassLink>> base_classes;
   std::vector<std::string> function_names;

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionVisitor.cpp
@@ -51,8 +51,11 @@ antlrcpp::Any UserFunctionVisitor::visitClassDeclaration(
     EscriptGrammar::EscriptParser::ClassDeclarationContext* ctx )
 {
   auto cd = tree_builder.class_declaration( ctx, top_level_statements_child_node );
-  workspace.function_resolver.register_class_declaration( cd.get() );
-  workspace.compiler_workspace.class_declarations.push_back( std::move( cd ) );
+  if ( cd )
+  {
+    workspace.function_resolver.register_class_declaration( cd.get() );
+    workspace.compiler_workspace.class_declarations.push_back( std::move( cd ) );
+  }
   return antlrcpp::Any();
 }
 

--- a/pol-core/bscript/compiler/model/ScopeName.cpp
+++ b/pol-core/bscript/compiler/model/ScopeName.cpp
@@ -1,11 +1,13 @@
 #include "ScopeName.h"
 
 #include "clib/clib.h"
+#include "clib/strutil.h"
 
 namespace Pol::Bscript::Compiler
 {
 ScopeName ScopeName::Global = ScopeName( "" );
 ScopeName ScopeName::None = ScopeName();
+ScopeName ScopeName::Super = ScopeName( "super" );
 
 ScopeName::ScopeName( const std::string& name ) : std::optional<std::string>( name ) {}
 
@@ -14,6 +16,11 @@ ScopeName::ScopeName() : std::optional<std::string>( std::nullopt ) {}
 bool ScopeName::global() const
 {
   return empty() || value().empty();
+}
+
+bool ScopeName::super() const
+{
+  return has_value() && Clib::caseInsensitiveEqual( value(), ScopeName::Super.value() );
 }
 
 bool ScopeName::empty() const

--- a/pol-core/bscript/compiler/model/ScopeName.h
+++ b/pol-core/bscript/compiler/model/ScopeName.h
@@ -15,6 +15,9 @@ public:
   // True if scope is global scope
   bool global() const;
 
+  // True if scope is super scope
+  bool super() const;
+
   // True if scope was not specified
   bool empty() const;
 
@@ -23,6 +26,7 @@ public:
 
   static ScopeName Global;
   static ScopeName None;
+  static ScopeName Super;
 
   bool operator<( const ScopeName& other ) const;
 };

--- a/testsuite/escript/classes/fail-class-named-super.err
+++ b/testsuite/escript/classes/fail-class-named-super.err
@@ -1,0 +1,1 @@
+fail-class-named-super.src:1:7: error: The class name 'super' is reserved.

--- a/testsuite/escript/classes/fail-class-named-super.src
+++ b/testsuite/escript/classes/fail-class-named-super.src
@@ -1,0 +1,4 @@
+class SUPER()
+endclass
+
+SUPER();

--- a/testsuite/escript/classes/fail-super-scope.err
+++ b/testsuite/escript/classes/fail-super-scope.err
@@ -1,0 +1,1 @@
+fail-super-scope.src:10:12: error: Unknown identifier 'super::Method'.

--- a/testsuite/escript/classes/fail-super-scope.src
+++ b/testsuite/escript/classes/fail-super-scope.src
@@ -1,0 +1,17 @@
+// Various tests with calling a super-class's method in an unscoped manner
+
+class BaseClass()
+  function BaseClass( this )
+  endfunction
+endclass
+
+class Foo( BaseClass  )
+  function Foo( this )
+    super::Method( this );
+  endfunction
+
+  function Method( this )
+  endfunction
+endclass
+
+Foo();

--- a/testsuite/escript/classes/super-scope.out
+++ b/testsuite/escript/classes/super-scope.out
@@ -3,5 +3,11 @@ BaseClass0::Method0 this=struct{  }
 BaseClass1::Method1 this=struct{  }
 BaseClass2::Method2 this=struct{  }
 Foo::Method3 this=struct{  }
+-
+BaseClass1::Common this=struct{  }
+BaseClass0::Method0 this=struct{  }
+BaseClass1::Method1 this=struct{  }
+BaseClass2::Method2 this=struct{  }
+BaseClass1::Method3 this=struct{  }
 ----
 BaseClass2::Common this=struct{  }

--- a/testsuite/escript/classes/super-scope.out
+++ b/testsuite/escript/classes/super-scope.out
@@ -1,0 +1,7 @@
+BaseClass1::Common this=struct{  }
+BaseClass0::Method0 this=struct{  }
+BaseClass1::Method1 this=struct{  }
+BaseClass2::Method2 this=struct{  }
+Foo::Method3 this=struct{  }
+----
+BaseClass2::Common this=struct{  }

--- a/testsuite/escript/classes/super-scope.src
+++ b/testsuite/escript/classes/super-scope.src
@@ -45,6 +45,12 @@ class Foo( BaseClass1, BaseClass2  )
     Method1( this ); // In base1
     Method2( this ); // In base2
     Method3( this ); // In Foo and base1
+    print("-");
+    super::Common( this ); // In base1 and base2
+    super::Method0( this ); // In base0
+    super::Method1( this ); // In base1
+    super::Method2( this ); // In base2
+    super::Method3( this ); // In Foo and base1
   endfunction
 
   function Method3( this )

--- a/testsuite/escript/classes/super-scope.src
+++ b/testsuite/escript/classes/super-scope.src
@@ -1,0 +1,66 @@
+// Various tests with calling a super-class's method in an unscoped manner
+
+class BaseClass0()
+  function BaseClass0( this )
+  endfunction
+  function Method0( this )
+    print( $"BaseClass0::Method0 this={this}" );
+  endfunction
+endclass
+
+class BaseClass1(BaseClass0)
+  function BaseClass1( this )
+  endfunction
+
+  function Method1( this )
+    print( $"BaseClass1::Method1 this={this}" );
+  endfunction
+
+  function Common( this )
+    print( $"BaseClass1::Common this={this}" );
+  endfunction
+
+  function Method3( this )
+    print( $"BaseClass1::Method3 this={this}" );
+  endfunction
+endclass
+
+class BaseClass2()
+  function BaseClass2( this )
+  endfunction
+
+  function Method2( this )
+    print( $"BaseClass2::Method2 this={this}" );
+  endfunction
+
+  function Common( this )
+    print( $"BaseClass2::Common this={this}" );
+  endfunction
+endclass
+
+class Foo( BaseClass1, BaseClass2  )
+  function Foo( this )
+    Common( this ); // In base1 and base2
+    Method0( this ); // In base0
+    Method1( this ); // In base1
+    Method2( this ); // In base2
+    Method3( this ); // In Foo and base1
+  endfunction
+
+  function Method3( this )
+    print( $"Foo::Method3 this={this}" );
+  endfunction
+endclass
+
+Foo();
+
+print( "----" );
+
+// Order of base classes matters: Since BaseClass2 is first, `Common()` links to `BaseClass2::Common`.
+class Bar( BaseClass2, BaseClass1 )
+  function Bar( this )
+    Common( this ); // In base1 and base2
+  endfunction
+endclass
+
+Bar();


### PR DESCRIPTION
### Function resolver changes
- In the areas where we were checking "if calling_scope is not empty": instead of checking _only_ the calling scope, check the calling scope + ancestors
- In the case of a `super::` call, we do _not_ check current calling scope, but only ancestors.