### PR TITLE
Add reading, writing of function table to ecl program

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -316,6 +316,8 @@ set (bscript_sources    # sorted !
   compiler/representation/ExportedFunction.h
   compiler/representation/FunctionReferenceDescriptor.cpp
   compiler/representation/FunctionReferenceDescriptor.h
+  compiler/representation/MethodDescriptor.cpp
+  compiler/representation/MethodDescriptor.h
   compiler/representation/ModuleDescriptor.cpp
   compiler/representation/ModuleDescriptor.h
   compiler/representation/ModuleFunctionDescriptor.cpp

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -218,6 +218,8 @@ set (bscript_sources    # sorted !
   compiler/astbuilder/ValueBuilder.h
   compiler/codegen/CaseDispatchGroupVisitor.cpp
   compiler/codegen/CaseDispatchGroupVisitor.h
+  compiler/codegen/ClassDeclarationRegistrar.cpp
+  compiler/codegen/ClassDeclarationRegistrar.h
   compiler/codegen/CaseJumpDataBlock.cpp
   compiler/codegen/CaseJumpDataBlock.h
   compiler/codegen/CodeEmitter.cpp
@@ -302,6 +304,8 @@ set (bscript_sources    # sorted !
   compiler/optimizer/UnaryOperatorOptimizer.h
   compiler/optimizer/ValueConsumerOptimizer.cpp
   compiler/optimizer/ValueConsumerOptimizer.h
+  compiler/representation/ClassDescriptor.cpp
+  compiler/representation/ClassDescriptor.h
   compiler/representation/CompiledScript.cpp
   compiler/representation/CompiledScript.h
   compiler/representation/DebugBlock.cpp

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -126,7 +126,7 @@ void Compiler::compile_file_steps( const std::string& pathname, Report& report )
   if ( report.error_count() )
     return;
 
-  output = generate( std::move( workspace ) );
+  output = generate( std::move( workspace ), report );
 }
 
 bool Compiler::format_file( const std::string& filename, bool is_module, bool inplace )
@@ -189,10 +189,11 @@ void Compiler::analyze( CompilerWorkspace& workspace, Report& report )
   profile.analyze_micros += timer.ellapsed().count();
 }
 
-std::unique_ptr<CompiledScript> Compiler::generate( std::unique_ptr<CompilerWorkspace> workspace )
+std::unique_ptr<CompiledScript> Compiler::generate( std::unique_ptr<CompilerWorkspace> workspace,
+                                                    Report& report )
 {
   Pol::Tools::HighPerfTimer codegen_timer;
-  auto compiled_script = CodeGenerator::generate( std::move( workspace ) );
+  auto compiled_script = CodeGenerator::generate( std::move( workspace ), report );
   profile.codegen_micros += codegen_timer.ellapsed().count();
   return compiled_script;
 }

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -38,7 +38,7 @@ private:
   void optimize( CompilerWorkspace&, Report& );
   void disambiguate( CompilerWorkspace&, Report& );
   void analyze( CompilerWorkspace&, Report& );
-  std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace> );
+  std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace>, Report& );
 
   void display_outcome( const std::string& filename, Report& );
 

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
@@ -11,16 +11,19 @@ namespace Pol::Bscript::Compiler
 {
 ClassDeclaration::ClassDeclaration( const SourceLocation& source_location, std::string name,
                                     std::unique_ptr<ClassParameterList> parameters,
-                                    std::vector<std::string> method_names, Node* class_body,
+                                    const std::vector<std::string>& method_names, Node* class_body,
                                     std::vector<std::shared_ptr<ClassLink>> base_class_links )
     : Node( source_location, std::move( parameters ) ),
       name( std::move( name ) ),
-      method_names( std::move( method_names ) ),
       class_body( class_body ),
       constructor_link(
           std::make_unique<FunctionLink>( source_location, name, true /* requires_ctor */ ) ),
       base_class_links( std::move( base_class_links ) )
 {
+  for ( const auto& method_name : method_names )
+  {
+    methods[method_name] = std::make_unique<FunctionLink>( source_location, method_name );
+  }
 }
 
 void ClassDeclaration::accept( NodeVisitor& visitor )

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
@@ -11,11 +11,11 @@ namespace Pol::Bscript::Compiler
 {
 ClassDeclaration::ClassDeclaration( const SourceLocation& source_location, std::string name,
                                     std::unique_ptr<ClassParameterList> parameters,
-                                    std::vector<std::string> function_names, Node* class_body,
+                                    std::vector<std::string> method_names, Node* class_body,
                                     std::vector<std::shared_ptr<ClassLink>> base_class_links )
     : Node( source_location, std::move( parameters ) ),
       name( std::move( name ) ),
-      function_names( std::move( function_names ) ),
+      method_names( std::move( method_names ) ),
       class_body( class_body ),
       constructor_link(
           std::make_unique<FunctionLink>( source_location, name, true /* requires_ctor */ ) ),

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -18,7 +18,7 @@ class ClassDeclaration : public Node
 public:
   ClassDeclaration( const SourceLocation& source_location, std::string name,
                     std::unique_ptr<ClassParameterList> parameters,
-                    std::vector<std::string> function_names, Node* body,
+                    std::vector<std::string> method_names, Node* body,
                     std::vector<std::shared_ptr<ClassLink>> base_classes );
 
   void accept( NodeVisitor& visitor ) override;
@@ -26,7 +26,10 @@ public:
   std::vector<std::reference_wrapper<ClassParameterDeclaration>> parameters();
 
   const std::string name;
-  std::vector<std::string> function_names;
+
+  // Only contains functions that are `UserFunctionType::Method`, ie. a first
+  // `this` parameter and not a constructor.
+  std::vector<std::string> method_names;
 
   // Owned by top_level_statements
   Node* class_body;

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <map>
+
 #include "bscript/compiler/ast/Node.h"
 #include "bscript/compiler/astbuilder/AvailableParseTree.h"
 namespace Pol::Bscript::Compiler
@@ -18,7 +20,7 @@ class ClassDeclaration : public Node
 public:
   ClassDeclaration( const SourceLocation& source_location, std::string name,
                     std::unique_ptr<ClassParameterList> parameters,
-                    std::vector<std::string> method_names, Node* body,
+                    const std::vector<std::string>& method_names, Node* body,
                     std::vector<std::shared_ptr<ClassLink>> base_classes );
 
   void accept( NodeVisitor& visitor ) override;
@@ -29,7 +31,7 @@ public:
 
   // Only contains functions that are `UserFunctionType::Method`, ie. a first
   // `this` parameter and not a constructor.
-  std::vector<std::string> method_names;
+  std::map<std::string, std::shared_ptr<FunctionLink>, Clib::ci_cmp_pred> methods;
 
   // Owned by top_level_statements
   Node* class_body;

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -129,11 +129,6 @@ std::unique_ptr<ClassDeclaration> UserFunctionBuilder::class_declaration(
               // 2. The first parameter is named `this`.
               if ( Clib::caseInsensitiveEqual( parameter_name, "this" ) )
               {
-                // Force a reference to the method so it'll be included in instruction generation +
-                // function table.
-                workspace.function_resolver.force_reference( ScopableName( class_name, func_name ),
-                                                             func_loc );
-
                 // 3. The function name is the same as the class name: constructor
                 if ( func_name == class_name )
                 {
@@ -269,6 +264,17 @@ std::unique_ptr<UserFunction> UserFunctionBuilder::make_user_function(
   {
     class_link = std::make_shared<ClassLink>( location_for( *ctx ), class_name );
     workspace.function_resolver.register_class_link( ScopeName( class_name ), class_link );
+    auto cd = class_link->class_declaration();
+
+    // Should never happen, since the only reason this user function can be
+    // visited is because the class has been registered.
+    if ( !cd )
+      class_link->source_location.internal_error( "ClassLink has no ClassDeclaration" );
+
+    // The `methods` object only contains methods, as the constructor is in the `constructor_link`.
+    if ( type == UserFunctionType::Method )
+      workspace.function_resolver.register_function_link( ScopableName( class_name, name ),
+                                                          cd->methods[name] );
   }
 
   return std::make_unique<UserFunction>( location_for( *ctx ), exported, expression, type,

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -129,7 +129,12 @@ std::unique_ptr<ClassDeclaration> UserFunctionBuilder::class_declaration(
               // 2. The first parameter is named `this`.
               if ( Clib::caseInsensitiveEqual( parameter_name, "this" ) )
               {
-                // 3a. The function name is the same as the class name: constructor
+                // Force a reference to the method so it'll be included in instruction generation +
+                // function table.
+                workspace.function_resolver.force_reference( ScopableName( class_name, func_name ),
+                                                             func_loc );
+
+                // 3. The function name is the same as the class name: constructor
                 if ( func_name == class_name )
                 {
                   has_ctor = true;

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
@@ -1,15 +1,25 @@
 #include "ClassDeclarationRegistrar.h"
 
 #include "bscript/compiler/representation/ClassDescriptor.h"
+#include "bscript/compiler/representation/MethodDescriptor.h"
 
 namespace Pol::Bscript::Compiler
 {
+class MethodDescriptor;
+
 ClassDeclarationRegistrar::ClassDeclarationRegistrar() = default;
+
+
+void ClassDeclarationRegistrar::register_class(
+    unsigned class_name_offset, const std::vector<unsigned>& constructor_addresses,
+    const std::vector<MethodDescriptor>& method_descriptors )
+{
+  descriptors.emplace_back( class_name_offset, constructor_addresses, method_descriptors );
+}
 
 std::vector<ClassDescriptor> ClassDeclarationRegistrar::take_descriptors()
 {
-  std::vector<ClassDescriptor> class_descriptors;
-  return class_descriptors;
+  return std::move( descriptors );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
@@ -1,0 +1,15 @@
+#include "ClassDeclarationRegistrar.h"
+
+#include "bscript/compiler/representation/ClassDescriptor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ClassDeclarationRegistrar::ClassDeclarationRegistrar() = default;
+
+std::vector<ClassDescriptor> ClassDeclarationRegistrar::take_descriptors()
+{
+  std::vector<ClassDescriptor> class_descriptors;
+  return class_descriptors;
+}
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
@@ -5,13 +5,20 @@
 namespace Pol::Bscript::Compiler
 {
 class ClassDescriptor;
+class MethodDescriptor;
 
 class ClassDeclarationRegistrar
 {
 public:
   ClassDeclarationRegistrar();
 
+  void register_class( unsigned class_name_offset,
+                       const std::vector<unsigned>& constructor_addresses,
+                       const std::vector<MethodDescriptor>& method_descriptors );
 
   std::vector<ClassDescriptor> take_descriptors();
+
+private:
+  std::vector<ClassDescriptor> descriptors;
 };
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+
+namespace Pol::Bscript::Compiler
+{
+class ClassDescriptor;
+
+class ClassDeclarationRegistrar
+{
+public:
+  ClassDeclarationRegistrar();
+
+
+  std::vector<ClassDescriptor> take_descriptors();
+};
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -21,6 +21,7 @@
 #include "bscript/compiler/representation/CompiledScript.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
+#include "bscript/compiler/representation/MethodDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
 #include "bscript/compiler/representation/ModuleFunctionDescriptor.h"
 
@@ -56,8 +57,7 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
   InstructionEmitter instruction_emitter(
       code, data, debug, exported_functions, module_declaration_registrar,
       function_reference_registrar, class_declaration_registrar );
-  CodeGenerator generator( instruction_emitter, module_declaration_registrar,
-                           class_declaration_registrar );
+  CodeGenerator generator( instruction_emitter, module_declaration_registrar );
 
   generator.register_module_functions_alphabetically( *workspace );
 
@@ -81,10 +81,8 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
 }
 
 CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
-                              ModuleDeclarationRegistrar& module_declaration_registrar,
-                              ClassDeclarationRegistrar& class_declaration_registrar )
+                              ModuleDeclarationRegistrar& module_declaration_registrar )
     : module_declaration_registrar( module_declaration_registrar ),
-      class_declaration_registrar( class_declaration_registrar ),
       emitter( emitter ),
       emit( emitter )
 {

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -9,6 +9,7 @@
 #include "bscript/compiler/ast/ProgramParameterList.h"
 #include "bscript/compiler/ast/TopLevelStatements.h"
 #include "bscript/compiler/ast/UserFunction.h"
+#include "bscript/compiler/codegen/ClassDeclarationRegistrar.h"
 #include "bscript/compiler/codegen/FunctionReferenceRegistrar.h"
 #include "bscript/compiler/codegen/InstructionEmitter.h"
 #include "bscript/compiler/codegen/InstructionGenerator.h"
@@ -16,6 +17,7 @@
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/FlowControlLabel.h"
+#include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/CompiledScript.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
@@ -49,11 +51,13 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
 
   ModuleDeclarationRegistrar module_declaration_registrar;
   FunctionReferenceRegistrar function_reference_registrar;
+  ClassDeclarationRegistrar class_declaration_registrar;
 
-  InstructionEmitter instruction_emitter( code, data, debug, exported_functions,
-                                          module_declaration_registrar,
-                                          function_reference_registrar );
-  CodeGenerator generator( instruction_emitter, module_declaration_registrar );
+  InstructionEmitter instruction_emitter(
+      code, data, debug, exported_functions, module_declaration_registrar,
+      function_reference_registrar, class_declaration_registrar );
+  CodeGenerator generator( instruction_emitter, module_declaration_registrar,
+                           class_declaration_registrar );
 
   generator.register_module_functions_alphabetically( *workspace );
 
@@ -67,16 +71,20 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
   std::vector<FunctionReferenceDescriptor> function_references =
       function_reference_registrar.take_descriptors();
 
+  std::vector<ClassDescriptor> class_descriptors = class_declaration_registrar.take_descriptors();
+
   return std::make_unique<CompiledScript>(
       std::move( code ), std::move( data ), std::move( debug ), std::move( exported_functions ),
       std::move( workspace->global_variable_names ), std::move( module_descriptors ),
-      std::move( function_references ), std::move( program_info ),
+      std::move( function_references ), std::move( class_descriptors ), std::move( program_info ),
       std::move( workspace->referenced_source_file_identifiers ) );
 }
 
 CodeGenerator::CodeGenerator( InstructionEmitter& emitter,
-                              ModuleDeclarationRegistrar& module_declaration_registrar )
+                              ModuleDeclarationRegistrar& module_declaration_registrar,
+                              ClassDeclarationRegistrar& class_declaration_registrar )
     : module_declaration_registrar( module_declaration_registrar ),
+      class_declaration_registrar( class_declaration_registrar ),
       emitter( emitter ),
       emit( emitter )
 {

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -28,7 +28,7 @@
 namespace Pol::Bscript::Compiler
 {
 std::unique_ptr<CompiledScript> CodeGenerator::generate(
-    std::unique_ptr<CompilerWorkspace> workspace )
+    std::unique_ptr<CompilerWorkspace> workspace, Report& report )
 {
   auto program_info =
       workspace->program
@@ -56,7 +56,7 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
 
   InstructionEmitter instruction_emitter(
       code, data, debug, exported_functions, module_declaration_registrar,
-      function_reference_registrar, class_declaration_registrar );
+      function_reference_registrar, class_declaration_registrar, report );
   CodeGenerator generator( instruction_emitter, module_declaration_registrar );
 
   generator.register_module_functions_alphabetically( *workspace );

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -10,11 +10,13 @@ class CompilerWorkspace;
 class FunctionReferenceRegistrar;
 class InstructionEmitter;
 class ModuleDeclarationRegistrar;
+class Report;
 
 class CodeGenerator
 {
 public:
-  static std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace> );
+  static std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace>,
+                                                   Report& report );
 
 private:
   CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar& );

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -10,6 +10,7 @@ class CompilerWorkspace;
 class FunctionReferenceRegistrar;
 class InstructionEmitter;
 class ModuleDeclarationRegistrar;
+class ClassDeclarationRegistrar;
 
 class CodeGenerator
 {
@@ -17,7 +18,7 @@ public:
   static std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace> );
 
 private:
-  CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar& );
+  CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar&, ClassDeclarationRegistrar& );
 
   void generate_instructions( CompilerWorkspace& );
 
@@ -30,6 +31,7 @@ private:
 
 private:
   ModuleDeclarationRegistrar& module_declaration_registrar;
+  ClassDeclarationRegistrar& class_declaration_registrar;
 
   // Verb vs noun - see InstructionGenerator for reasoning
   InstructionEmitter& emitter;

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -10,7 +10,6 @@ class CompilerWorkspace;
 class FunctionReferenceRegistrar;
 class InstructionEmitter;
 class ModuleDeclarationRegistrar;
-class ClassDeclarationRegistrar;
 
 class CodeGenerator
 {
@@ -18,7 +17,7 @@ public:
   static std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace> );
 
 private:
-  CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar&, ClassDeclarationRegistrar& );
+  CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar& );
 
   void generate_instructions( CompilerWorkspace& );
 
@@ -31,7 +30,6 @@ private:
 
 private:
   ModuleDeclarationRegistrar& module_declaration_registrar;
-  ClassDeclarationRegistrar& class_declaration_registrar;
 
   // Verb vs noun - see InstructionGenerator for reasoning
   InstructionEmitter& emitter;

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -84,21 +84,17 @@ void InstructionEmitter::register_class_declaration(
 
     if ( cd->constructor_link )
     {
-      auto uf = cd->constructor_link->user_function();
-      // Should never happen
-      if ( !uf )
+      if ( auto uf = cd->constructor_link->user_function() )
       {
-        cd->internal_error( fmt::format( "constructor {} no function linked", cd->name ) );
+        auto ctor_itr = user_function_labels.find( ScopableName( cd->name, cd->name ).string() );
+        if ( ctor_itr == user_function_labels.end() )
+        {
+          report.debug( *cd, " - Constructor: {} PC=???", cd->name );
+          cd->internal_error(
+              fmt::format( "Constructor {} not found in user_function_labels", cd->name ) );
+        }
+        constructor_addresses.push_back( ctor_itr->second.address() );
       }
-
-      auto ctor_itr = user_function_labels.find( ScopableName( cd->name, cd->name ).string() );
-      if ( ctor_itr == user_function_labels.end() )
-      {
-        report.debug( *cd, " - Constructor: {} PC=???", cd->name );
-        cd->internal_error(
-            fmt::format( "Constructor {} not found in user_function_labels", cd->name ) );
-      }
-      constructor_addresses.push_back( ctor_itr->second.address() );
     }
 
     for ( const auto& [method, uf_link] : cd->methods )

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -86,7 +86,7 @@ void InstructionEmitter::register_class_declaration(
     {
       if ( auto uf = cd->constructor_link->user_function() )
       {
-        auto ctor_itr = user_function_labels.find( ScopableName( cd->name, cd->name ).string() );
+        auto ctor_itr = user_function_labels.find( uf->scoped_name() );
         if ( ctor_itr == user_function_labels.end() )
         {
           report.debug( *cd, " - Constructor: {} PC=???", cd->name );

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -129,6 +129,7 @@ void InstructionEmitter::register_class_declaration(
         method_descriptors.emplace_back( name_offset, address, funcref_index );
         report.debug( *cd, " - Method: {} PC={} funcref_index={}", method,
                       method_itr->second.address(), funcref_index );
+        method_names.insert( method );
       }
       else
       {

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -1,6 +1,7 @@
 #ifndef POLSERVER_INSTRUCTIONEMITTER_H
 #define POLSERVER_INSTRUCTIONEMITTER_H
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,6 +33,8 @@ class CompiledScript;
 class FlowControlLabel;
 class LocalVariableScopeInfo;
 class ModuleDeclarationRegistrar;
+class ClassDeclaration;
+class ClassDeclarationRegistrar;
 class ModuleFunctionDeclaration;
 class FunctionReferenceRegistrar;
 class UserFunction;
@@ -44,12 +47,13 @@ class InstructionEmitter
 public:
   InstructionEmitter( CodeSection& code, DataSection& data, DebugStore& debug,
                       ExportedFunctions& exported_functions, ModuleDeclarationRegistrar&,
-                      FunctionReferenceRegistrar& );
+                      FunctionReferenceRegistrar&, ClassDeclarationRegistrar& );
 
   void initialize_data();
 
   void register_exported_function( FlowControlLabel& label, const std::string& name,
                                    unsigned arguments );
+  void register_class_declaration( ClassDeclaration&, std::map<std::string, FlowControlLabel>& );
 
   unsigned enter_debug_block( const LocalVariableScopeInfo& );
   void set_debug_block( unsigned );
@@ -143,6 +147,7 @@ private:
   ExportedFunctions& exported_functions;
   ModuleDeclarationRegistrar& module_declaration_registrar;
   FunctionReferenceRegistrar& function_reference_registrar;
+  ClassDeclarationRegistrar& class_declaration_registrar;
 
   DebugStore::InstructionInfo debug_instruction_info{};
 };

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.h
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.h
@@ -41,13 +41,14 @@ class UserFunction;
 class Node;
 class Variable;
 class SourceLocation;
+class Report;
 
 class InstructionEmitter
 {
 public:
   InstructionEmitter( CodeSection& code, DataSection& data, DebugStore& debug,
                       ExportedFunctions& exported_functions, ModuleDeclarationRegistrar&,
-                      FunctionReferenceRegistrar&, ClassDeclarationRegistrar& );
+                      FunctionReferenceRegistrar&, ClassDeclarationRegistrar&, Report& );
 
   void initialize_data();
 
@@ -150,6 +151,7 @@ private:
   ClassDeclarationRegistrar& class_declaration_registrar;
 
   DebugStore::InstructionInfo debug_instruction_info{};
+  Report& report;
 };
 }  // namespace Pol::Bscript::Compiler
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -246,9 +246,9 @@ void InstructionGenerator::visit_branch_selector( BranchSelector& node )
   }
 }
 
-void InstructionGenerator::visit_class_parameter_list( ClassParameterList& /*node*/ )
+void InstructionGenerator::visit_class_declaration( ClassDeclaration& node )
 {
-  // Identifiers for class parameters are not used in the generated code.
+  emitter.register_class_declaration( node, user_function_labels );
 }
 
 void InstructionGenerator::visit_class_instance( ClassInstance& node )

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.h
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.h
@@ -33,7 +33,7 @@ public:
   void visit_block( Block& ) override;
   void visit_boolean_value( BooleanValue& ) override;
   void visit_branch_selector( BranchSelector& ) override;
-  void visit_class_parameter_list( ClassParameterList& ) override;
+  void visit_class_declaration( ClassDeclaration& ) override;
   void visit_class_instance( ClassInstance& ) override;
   void visit_debug_statement_marker( DebugStatementMarker& ) override;
   void visit_dictionary_entry( DictionaryEntry& ) override;

--- a/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
+++ b/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
@@ -132,8 +132,8 @@ void CompiledScriptSerializer::write( const std::string& pathname ) const
       // Handle class entry
       BSCRIPT_CLASS_TABLE_ENTRY bcte{};
       bcte.name_offset = elem.name_offset;
-      bcte.constructor_count = elem.constructor_addresses.size();
-      bcte.method_count = elem.methods.size();
+      bcte.constructor_count = static_cast<unsigned>( elem.constructor_addresses.size() );
+      bcte.method_count = static_cast<unsigned>( elem.methods.size() );
       ofs.write( reinterpret_cast<const char*>( &bcte ), sizeof bcte );
 
       // Handle constructors

--- a/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
+++ b/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
@@ -4,9 +4,11 @@
 #include <fstream>
 
 #include "StoredToken.h"
+#include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/CompiledScript.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
+#include "bscript/compiler/representation/MethodDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
 #include "bscript/compiler/representation/ModuleFunctionDescriptor.h"
 #include "clib/clib.h"
@@ -111,6 +113,46 @@ void CompiledScriptSerializer::write( const std::string& pathname ) const
       bfr.capture_count = elem.capture_count();
       bfr.is_variadic = elem.is_variadic();
       ofs.write( reinterpret_cast<const char*>( &bfr ), sizeof bfr );
+    }
+  }
+
+  if ( !compiled_script.class_descriptors.empty() )
+  {
+    BSCRIPT_CLASS_TABLE bct{};
+    sechdr.type = BSCRIPT_SECTION_CLASS_TABLE;
+    sechdr.length = static_cast<unsigned int>( sizeof bct );
+    ofs.write( reinterpret_cast<const char*>( &sechdr ), sizeof sechdr );
+
+    bct.class_count = static_cast<unsigned int>( compiled_script.class_descriptors.size() );
+    ofs.write( reinterpret_cast<const char*>( &bct ), sizeof bct );
+
+    // For each class...
+    for ( const auto& elem : compiled_script.class_descriptors )
+    {
+      // Handle class entry
+      BSCRIPT_CLASS_TABLE_ENTRY bcte{};
+      bcte.name_offset = elem.name_offset;
+      bcte.constructor_count = elem.constructor_addresses.size();
+      bcte.method_count = elem.methods.size();
+      ofs.write( reinterpret_cast<const char*>( &bcte ), sizeof bcte );
+
+      // Handle constructors
+      for ( const auto& constructor_address : elem.constructor_addresses )
+      {
+        BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY bctce{};
+        bctce.address = constructor_address;
+        ofs.write( reinterpret_cast<const char*>( &bctce ), sizeof bctce );
+      }
+
+      // Handle methods
+      for ( const auto& method : elem.methods )
+      {
+        BSCRIPT_CLASS_TABLE_METHOD_ENTRY bctme{};
+        bctme.name_offset = method.name_offset;
+        bctme.address = method.address;
+        bctme.function_reference_index = method.function_reference_index;
+        ofs.write( reinterpret_cast<const char*>( &bctme ), sizeof bctme );
+      }
     }
   }
 }

--- a/pol-core/bscript/compiler/optimizer/Optimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/Optimizer.cpp
@@ -41,9 +41,11 @@ void Optimizer::optimize( CompilerWorkspace& workspace,
   workspace.accept( *this );
 
   std::vector<UserFunction*> all_user_functions;
-  if ( user_function_inclusion == UserFunctionInclusion::All )
+  for ( auto& user_function : workspace.user_functions )
   {
-    for ( auto& user_function : workspace.user_functions )
+    if ( user_function_inclusion == UserFunctionInclusion::All ||
+         user_function->type == UserFunctionType::Method ||
+         user_function->type == UserFunctionType::Constructor )
     {
       all_user_functions.push_back( user_function.get() );
     }
@@ -66,9 +68,10 @@ void Optimizer::optimize( CompilerWorkspace& workspace,
   {
     gatherer.reference( uf );
   }
-  if ( user_function_inclusion == UserFunctionInclusion::All )
+  for ( auto& uf : all_user_functions )
   {
-    for ( auto& uf : all_user_functions )
+    if ( user_function_inclusion == UserFunctionInclusion::All ||
+         uf->type == UserFunctionType::Method || uf->type == UserFunctionType::Constructor )
     {
       gatherer.reference( uf );
     }

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
@@ -1,0 +1,6 @@
+#include "ClassDescriptor.h"
+
+namespace Pol::Bscript::Compiler
+{
+ClassDescriptor::ClassDescriptor( std::string name ) : name( std::move( name ) ) {}
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
@@ -1,6 +1,14 @@
 #include "ClassDescriptor.h"
 
+#include "bscript/compiler/representation/MethodDescriptor.h"
+
 namespace Pol::Bscript::Compiler
 {
-ClassDescriptor::ClassDescriptor( std::string name ) : name( std::move( name ) ) {}
+ClassDescriptor::ClassDescriptor( unsigned name_offset, std::vector<unsigned> constructor_addresses,
+                                  std::vector<MethodDescriptor> methods )
+    : name_offset( name_offset ),
+      constructor_addresses( std::move( constructor_addresses ) ),
+      methods( std::move( methods ) )
+{
+}
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.h
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.h
@@ -1,15 +1,20 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace Pol::Bscript::Compiler
 {
+class MethodDescriptor;
 class ClassDescriptor
 {
 public:
-  ClassDescriptor( std::string );
+  ClassDescriptor( unsigned name_offset, std::vector<unsigned> constructor_addresses,
+                   std::vector<MethodDescriptor> methods );
 
-  const std::string name;
+  const unsigned name_offset;
+  const std::vector<unsigned> constructor_addresses;
+  const std::vector<MethodDescriptor> methods;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.h
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class ClassDescriptor
+{
+public:
+  ClassDescriptor( std::string );
+
+  const std::string name;
+};
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/CompiledScript.cpp
+++ b/pol-core/bscript/compiler/representation/CompiledScript.cpp
@@ -7,6 +7,7 @@
 #include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
+#include "bscript/compiler/representation/MethodDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
 #include "bscript/compiler/representation/ModuleFunctionDescriptor.h"
 

--- a/pol-core/bscript/compiler/representation/CompiledScript.cpp
+++ b/pol-core/bscript/compiler/representation/CompiledScript.cpp
@@ -4,6 +4,7 @@
 
 #include "StoredToken.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
+#include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
@@ -11,13 +12,11 @@
 
 namespace Pol::Bscript::Compiler
 {
-CompiledScript::CompiledScript( CodeSection code, DataSection data, DebugStore debug,
-                                ExportedFunctions exported_functions,
-                                std::vector<std::string> global_variable_names,
-                                ModuleDescriptors module_descriptors,
-                                FunctionReferences function_references,
-                                std::unique_ptr<ProgramInfo> program_info,
-                                SourceFileIdentifiers source_file_identifiers )
+CompiledScript::CompiledScript(
+    CodeSection code, DataSection data, DebugStore debug, ExportedFunctions exported_functions,
+    std::vector<std::string> global_variable_names, ModuleDescriptors module_descriptors,
+    FunctionReferences function_references, ClassDescriptors class_descriptors,
+    std::unique_ptr<ProgramInfo> program_info, SourceFileIdentifiers source_file_identifiers )
     : code( std::move( code ) ),
       data( std::move( data ) ),
       debug( std::move( debug ) ),
@@ -25,6 +24,7 @@ CompiledScript::CompiledScript( CodeSection code, DataSection data, DebugStore d
       global_variable_names( std::move( global_variable_names ) ),
       module_descriptors( std::move( module_descriptors ) ),
       function_references( std::move( function_references ) ),
+      class_descriptors( std::move( class_descriptors ) ),
       program_info( std::move( program_info ) ),
       source_file_identifiers( std::move( source_file_identifiers ) )
 {

--- a/pol-core/bscript/compiler/representation/CompiledScript.h
+++ b/pol-core/bscript/compiler/representation/CompiledScript.h
@@ -19,12 +19,14 @@ class ExportedFunction;
 class FunctionReferenceDescriptor;
 class SourceFileIdentifier;
 class ModuleDescriptor;
+class ClassDescriptor;
 
 using CodeSection = std::vector<StoredToken>;
 using DataSection = std::vector<std::byte>;
 using ExportedFunctions = std::vector<ExportedFunction>;
 using FunctionReferences = std::vector<FunctionReferenceDescriptor>;
 using ModuleDescriptors = std::vector<ModuleDescriptor>;
+using ClassDescriptors = std::vector<ClassDescriptor>;
 using SourceFileIdentifiers = std::vector<std::unique_ptr<SourceFileIdentifier>>;
 
 class CompiledScript
@@ -38,8 +40,8 @@ public:
   CompiledScript( CodeSection code_section, DataSection data_section, DebugStore debug,
                   ExportedFunctions exported_functions,
                   std::vector<std::string> global_variable_names, ModuleDescriptors modules,
-                  FunctionReferences function_references, std::unique_ptr<ProgramInfo>,
-                  SourceFileIdentifiers );
+                  FunctionReferences function_references, ClassDescriptors class_descriptors,
+                  std::unique_ptr<ProgramInfo>, SourceFileIdentifiers );
   ~CompiledScript();
   CompiledScript( const CompiledScript& ) = delete;
   CompiledScript& operator=( const CompiledScript& ) = delete;
@@ -51,6 +53,7 @@ public:
   const std::vector<std::string> global_variable_names;
   const ModuleDescriptors module_descriptors;
   const FunctionReferences function_references;
+  const ClassDescriptors class_descriptors;
   const std::unique_ptr<ProgramInfo> program_info;
   const SourceFileIdentifiers source_file_identifiers;
 };

--- a/pol-core/bscript/compiler/representation/MethodDescriptor.cpp
+++ b/pol-core/bscript/compiler/representation/MethodDescriptor.cpp
@@ -1,0 +1,12 @@
+#include "MethodDescriptor.h"
+
+namespace Pol::Bscript::Compiler
+{
+MethodDescriptor::MethodDescriptor( unsigned name_offset, unsigned address,
+                                    unsigned function_reference_index )
+    : name_offset( name_offset ),
+      address( address ),
+      function_reference_index( function_reference_index )
+{
+}
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/MethodDescriptor.h
+++ b/pol-core/bscript/compiler/representation/MethodDescriptor.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Pol::Bscript::Compiler
+{
+class MethodDescriptor
+{
+public:
+  MethodDescriptor( unsigned name_offset, unsigned address, unsigned function_reference_index);
+
+  const unsigned name_offset;
+  const unsigned address;
+  const unsigned function_reference_index;
+};
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/eprog.h
+++ b/pol-core/bscript/eprog.h
@@ -9,11 +9,13 @@
 #define BSCRIPT_EPROG_H
 
 #include <iosfwd>
+#include <map>
 #include <stdio.h>
 #include <string>
 #include <vector>
 
 #include "../clib/boostutils.h"
+#include "../clib/maputil.h"
 #include "../clib/rawtypes.h"
 #include "../clib/refptr.h"
 #include "executortype.h"
@@ -89,6 +91,23 @@ struct EPFunctionReference
   }
 };
 
+struct EPMethodDescriptor
+{
+  unsigned address;
+  unsigned function_reference_index;
+};
+
+using EPConstructorList = std::vector<unsigned>;
+
+using EPMethodMap = std::map<unsigned /* name_offset */, EPMethodDescriptor>;
+
+struct EPClassDescriptor
+{
+  unsigned name_offset;
+  EPConstructorList constructor_addresses;
+  EPMethodMap methods;
+};
+
 struct EPDbgFunction
 {
   std::string name;
@@ -132,6 +151,7 @@ public:
   int read_globalvarnames( FILE* fp );
   int read_exported_functions( FILE* fp, BSCRIPT_SECTION_HDR* hdr );
   int read_function_references( FILE* fp, BSCRIPT_SECTION_HDR* hdr );
+  int read_class_table( FILE* fp );
   int _readToken( Token& token, unsigned position ) const;
   int create_instructions();
 
@@ -146,6 +166,7 @@ public:
 
   std::vector<EPExportedFunction> exported_functions;
   std::vector<EPFunctionReference> function_references;
+  std::vector<EPClassDescriptor> class_descriptors;
 
   // executor only:
   unsigned short version;

--- a/pol-core/bscript/filefmt.h
+++ b/pol-core/bscript/filefmt.h
@@ -71,6 +71,7 @@ enum BSCRIPT_SECTION
   BSCRIPT_SECTION_GLOBALVARNAMES = 5,
   BSCRIPT_SECTION_EXPORTED_FUNCTIONS = 6,
   BSCRIPT_SECTION_FUNCTION_REFERENCES = 7,
+  BSCRIPT_SECTION_CLASS_TABLE = 8,
 };
 
 
@@ -132,6 +133,35 @@ struct BSCRIPT_FUNCTION_REFERENCE
   bool is_variadic;
 };
 static_assert( sizeof( BSCRIPT_FUNCTION_REFERENCE ) == 9, "size missmatch" );
+
+struct BSCRIPT_CLASS_TABLE
+{
+  unsigned class_count;
+};
+
+static_assert( sizeof( BSCRIPT_CLASS_TABLE ) == 4, "size missmatch" );
+
+struct BSCRIPT_CLASS_TABLE_ENTRY
+{
+  unsigned name_offset;
+  unsigned constructor_count;
+  unsigned method_count;
+};
+
+struct BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY
+{
+  unsigned address;
+};
+static_assert( sizeof( BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY ) == 4, "size missmatch" );
+
+struct BSCRIPT_CLASS_TABLE_METHOD_ENTRY
+{
+  unsigned name_offset;
+  unsigned address;
+  unsigned function_reference_index;
+};
+
+static_assert( sizeof( BSCRIPT_CLASS_TABLE_METHOD_ENTRY ) == 12, "size missmatch" );
 
 #pragma pack( pop )
 }  // namespace Bscript


### PR DESCRIPTION
### Misc. Code Generator changes
- Pass `Report` as a parameter to allow printing debug statements 

### Class Descriptors
- Introduce `ClassDescriptor`, `MethodDescriptor` and its registrar `ClassDescriptorRegistrar`.
- It behaves similar to the FunctionReferenceRegistrar:
  - The instruction emitter uses this new registrar to register class descriptors.
  - When creating the `CompiledScript`, we take the descriptors from the registrar.

### EProgram changes
- Added structs to support the class table and it's corresponding nested entries

### Optimizer changes
- Keep methods and constructors in the `workspace.user_functions` list, regardless of their reference as a compile-time function call (eg. `Animal::bark( this )`). Methods must be kept because they can also be accessed via `this.bark()`

### AST Changes
- `ClassDeclaration` used to have a vector of all function names as strings. This has been refactored to be a map of method name -> function link, only having _methods_ (ie. user function with `this` parameter that is _not_ a constructor). This allows us to get the `UserFunction` from the link when accessing the class declaration, eg. code generation. (NB: the constructor link has already existed as `ClassDeclaration::constructor_link`)
  - We need the `UserFunction` because we have to create an entry in the function reference table. 
  - The function reference entry is needed because of a method call of `this.foo(arg0, arg1)` -> the executor must know how many params are for `foo`. This information is held in the function reference table.