### PR TITLE
ssopt.MobilesBlockNpcMovement allows followers to stack on a tile

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -387,7 +387,7 @@ Spell (int spellid)
 [SpeedHack_FootWalkDelay        (int milliseconds {default 380})]
 [SeperateSpeechTokens           (0/1 {default 0})]
 [CoreGuildMessages              (0/1 {default 1})]
-[MobilesBlockNpcMovement        (0/1 {default 1})]
+[MobilesBlockNpcMovement        (0/1/2 {default 1})]
 [DefaultCharacterHeight         (1-32 {default 15})]
 [EnableWorldMapPackets          (0/1 (default 0))]
 [UndoGetItemEnableRangeCheck    (0/1 {default 0})]
@@ -456,7 +456,10 @@ for RegisterForSpeechEvents() you get speech with and without Tokens when settin
 and no speech without Tokens setting LISTENPT_NO_SPEECH<br/>
 Note: Token and nonToken Eventtype is still the same (SYSEVENT_SPEECH)</explain>
   <explain><i>CoreGuildMessages:</i> used to determine if core should handle guild and alliance messages</explain>
-  <explain><i>MobilesBlockNpcMovement:</i> use to determine if mobiles block the movement of npcs</explain>
+  <explain><i>MobilesBlockNpcMovement:</i> use to determine if mobiles block the movement of npcs.<br/>
+0 - Npcs are not blocked by other mobiles, but followers of the same master do not walk/run on each other.<br/>
+1 - All mobiles block movement of other npcs. PushThrough hook is not called in such case at all.<br/>
+2 - Mobiles do not block movement. You can still hook the PushThrough to stop movement if needed.</explain>
   <explain><i>DefaultCharacterHeight:</i> This is the default (and never changed so far) height for Characters and NPCs.<br/>
   Default value is 15. Back in the POL095 days is was 9, so consider 9-15 as your "safe" play range.<br/>
   Anything outside that range could cause weird movement behavior.<br/>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-24-2024</datemodified>
+		<datemodified>08-27-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>08-27-2024</date>
+			<author>Reloecc:</author>
+			<change type="Changed">ssopt.MobilesBlockNpcMovement now accepts values 0/1/2. Earlier 0 = false, 1 = true.<br/>
+			2 = new behavior, where npcs of the same master are allowed to walk on top of each other. Backward compatible.</change>
+		</entry>
 		<entry>
 			<date>08-24-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.2.0 --
+08-27-2024 Reloecc:
+  Changed: ssopt.MobilesBlockNpcMovement now accepts values 0/1/2. Earlier 0 = false, 1 = true.
+           2 = new behavior, where npcs of the same master are allowed to walk on top of each other. Backward compatible.
 08-24-2024 Kevin:
     Fixed: Resolved an issue where the Z coordinate of objects on a boat was incorrectly
            calculated during turns (introduced in the 07-08-2024 nightly build).

--- a/pol-core/pol/mobile/npc.cpp
+++ b/pol-core/pol/mobile/npc.cpp
@@ -198,16 +198,19 @@ bool NPC::npc_path_blocked( Core::UFACING fdir ) const
 {
   if ( can_freemove() )
     return false;
-  if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 2 )
+
+  Core::MOVEBLOCKMODE moveBlockMode = Core::settingsManager.ssopt.mobiles_block_npc_movement;
+
+  if ( moveBlockMode == Core::MOVEBLOCKMODE_NONE )
     return false;
-  if ( !this->master() && Core::settingsManager.ssopt.mobiles_block_npc_movement == 0 )
+  if ( !this->master() && moveBlockMode == Core::MOVEBLOCKMODE_SAME_MASTER )
     return false;
 
   auto new_pos = pos().move( fdir );
 
   Core::Pos2d gridp = Core::zone_convert( new_pos );
 
-  if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 1 )
+  if ( moveBlockMode == Core::MOVEBLOCKMODE_ALL )
   {
     for ( const auto& chr : realm()->getzone_grid( gridp ).characters )
     {
@@ -226,7 +229,7 @@ bool NPC::npc_path_blocked( Core::UFACING fdir ) const
     if ( chr->pos2d() == new_pos.xy() && chr->z() >= z() - 10 && chr->z() <= z() + 10 )
     {
       // Do not allow npcs of same master running on top of each other
-      if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 0 )
+      if ( moveBlockMode == Core::MOVEBLOCKMODE_SAME_MASTER )
       {
         NPC* npc = static_cast<NPC*>( chr );
         if ( npc->master() && this->master() == npc->master() && !npc->dead() &&

--- a/pol-core/pol/mobile/npc.cpp
+++ b/pol-core/pol/mobile/npc.cpp
@@ -196,15 +196,18 @@ bool NPC::could_move( Core::UFACING fdir ) const
 
 bool NPC::npc_path_blocked( Core::UFACING fdir ) const
 {
-  if ( can_freemove() ||
-       ( !this->master() && !Core::settingsManager.ssopt.mobiles_block_npc_movement ) )
+  if ( can_freemove() )
+    return false;
+  if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 2 )
+    return false;
+  if ( !this->master() && Core::settingsManager.ssopt.mobiles_block_npc_movement == 0 )
     return false;
 
   auto new_pos = pos().move( fdir );
 
   Core::Pos2d gridp = Core::zone_convert( new_pos );
 
-  if ( Core::settingsManager.ssopt.mobiles_block_npc_movement )
+  if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 1 )
   {
     for ( const auto& chr : realm()->getzone_grid( gridp ).characters )
     {
@@ -216,14 +219,14 @@ bool NPC::npc_path_blocked( Core::UFACING fdir ) const
       }
     }
   }
+
   for ( const auto& chr : realm()->getzone_grid( gridp ).npcs )
   {
     // First check if there really is a character blocking
     if ( chr->pos2d() == new_pos.xy() && chr->z() >= z() - 10 && chr->z() <= z() + 10 )
     {
-      // Check first with the ssopt false to now allow npcs of same master running on top of
-      // each other
-      if ( !Core::settingsManager.ssopt.mobiles_block_npc_movement )
+      // Do not allow npcs of same master running on top of each other
+      if ( Core::settingsManager.ssopt.mobiles_block_npc_movement == 0 )
       {
         NPC* npc = static_cast<NPC*>( chr );
         if ( npc->master() && this->master() == npc->master() && !npc->dead() &&

--- a/pol-core/pol/ssopt.cpp
+++ b/pol-core/pol/ssopt.cpp
@@ -127,7 +127,7 @@ void ServSpecOpt::read_servspecopt()
   settingsManager.ssopt.seperate_speechtoken = elem.remove_bool( "SeperateSpeechTokens", false );
   settingsManager.ssopt.core_sends_guildmsgs = elem.remove_bool( "CoreGuildMessages", true );
   settingsManager.ssopt.mobiles_block_npc_movement =
-      elem.remove_bool( "MobilesBlockNpcMovement", true );
+      elem.remove_ushort( "MobilesBlockNpcMovement", 1 );
 
   unsigned char default_character_height =
       static_cast<unsigned char>( elem.remove_ushort( "DefaultCharacterHeight", 15 ) );

--- a/pol-core/pol/ssopt.cpp
+++ b/pol-core/pol/ssopt.cpp
@@ -127,7 +127,7 @@ void ServSpecOpt::read_servspecopt()
   settingsManager.ssopt.seperate_speechtoken = elem.remove_bool( "SeperateSpeechTokens", false );
   settingsManager.ssopt.core_sends_guildmsgs = elem.remove_bool( "CoreGuildMessages", true );
   settingsManager.ssopt.mobiles_block_npc_movement =
-      elem.remove_ushort( "MobilesBlockNpcMovement", 1 );
+      static_cast<MOVEBLOCKMODE>( elem.remove_ushort( "MobilesBlockNpcMovement", 1 ) );
 
   unsigned char default_character_height =
       static_cast<unsigned char>( elem.remove_ushort( "DefaultCharacterHeight", 15 ) );

--- a/pol-core/pol/ssopt.h
+++ b/pol-core/pol/ssopt.h
@@ -29,6 +29,8 @@
 #include <string>
 #include <vector>
 
+#include "../clib/rawtypes.h"
+
 namespace Pol
 {
 namespace Clib
@@ -38,6 +40,14 @@ class ConfigElem;
 
 namespace Core
 {
+
+enum MOVEBLOCKMODE : u8
+{
+  MOVEBLOCKMODE_SAME_MASTER = 0,
+  MOVEBLOCKMODE_ALL = 1,
+  MOVEBLOCKMODE_NONE = 2
+};
+
 struct ServSpecOpt
 {
   bool allow_secure_trading_in_warmode;
@@ -95,7 +105,7 @@ struct ServSpecOpt
   std::vector<std::string> total_stats_at_creation;
   bool seperate_speechtoken;
   bool core_sends_guildmsgs;
-  unsigned short mobiles_block_npc_movement;
+  MOVEBLOCKMODE mobiles_block_npc_movement;
 
   unsigned char default_character_height;
   bool enable_worldmap_packets;

--- a/pol-core/pol/ssopt.h
+++ b/pol-core/pol/ssopt.h
@@ -95,7 +95,7 @@ struct ServSpecOpt
   std::vector<std::string> total_stats_at_creation;
   bool seperate_speechtoken;
   bool core_sends_guildmsgs;
-  bool mobiles_block_npc_movement;
+  unsigned short mobiles_block_npc_movement;
 
   unsigned char default_character_height;
   bool enable_worldmap_packets;

--- a/pol-core/poltool/baredistrofiles.cpp
+++ b/pol-core/poltool/baredistrofiles.cpp
@@ -560,7 +560,10 @@ void BareDistro::distro_files( std::map<fs::path, std::vector<std::string>>& dis
 "",
 "#",
 "# MobilesBlockNpcMovement",
-"# If enabled mobiles will block the movement of npcs.",
+"# Mobiles will block the movement of npcs.",
+"# 0 = Npcs are not blocked by other mobiles, but followers of the same master do not walk/run on each other."
+"# 1 = All mobiles block movement of other npcs. PushThrough hook is not called for such movement."
+"# 2 = Mobiles do not block movement. You can hook the PushThrough to stop movement if needed.",
 "# Default is 1",
 "#",
 "MobilesBlockNpcMovement=1",


### PR DESCRIPTION
ssopt.MobilesBlockNpcMovement now accepts values 0/1/2.
Earlier 0 = false, 1 = true.
Now 2 = npcs of the same master are allowed to walk on top of each other.
Backward compatible.