### PR TITLE
Generate constructors for child classes

### DIFF
--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -162,8 +162,8 @@ set (bscript_sources    # sorted !
   compiler/ast/StructInitializer.h
   compiler/ast/StructMemberInitializer.cpp
   compiler/ast/StructMemberInitializer.h
-  compiler/ast/SuperFunction.cpp
-  compiler/ast/SuperFunction.h
+  compiler/ast/GeneratedFunction.cpp
+  compiler/ast/GeneratedFunction.h
   compiler/ast/TopLevelStatements.cpp
   compiler/ast/TopLevelStatements.h
   compiler/ast/UnaryOperator.cpp

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -498,6 +498,14 @@ void SemanticAnalyzer::visit_function_call( FunctionCall& fc )
       }
       else
       {
+        if ( dynamic_cast<GeneratedFunction*>( uf ) != nullptr )
+        {
+          if ( uf->body().children.empty() )
+          {
+            report.error( fc, "In call to '{}': No base class defines a constructor.", uf->name );
+            return;
+          }
+        }
         // Find the class declaration for the function.
         auto class_itr =
             std::find_if( workspace.class_declarations.begin(), workspace.class_declarations.end(),

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
@@ -11,13 +11,13 @@ namespace Pol::Bscript::Compiler
 {
 ClassDeclaration::ClassDeclaration( const SourceLocation& source_location, std::string name,
                                     std::unique_ptr<ClassParameterList> parameters,
+                                    std::shared_ptr<FunctionLink> constructor_link,
                                     const std::vector<std::string>& method_names, Node* class_body,
                                     std::vector<std::shared_ptr<ClassLink>> base_class_links )
     : Node( source_location, std::move( parameters ) ),
       name( std::move( name ) ),
       class_body( class_body ),
-      constructor_link(
-          std::make_unique<FunctionLink>( source_location, name, true /* requires_ctor */ ) ),
+      constructor_link( std::move( constructor_link ) ),
       base_class_links( std::move( base_class_links ) )
 {
   for ( const auto& method_name : method_names )

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -38,7 +38,7 @@ public:
   Node* class_body;
 
   // `nullptr` if class has no constructor defined.
-  const std::shared_ptr<FunctionLink> constructor_link;
+  std::shared_ptr<FunctionLink> constructor_link;
 
   // Passed as ctor parameter by UserFunctionBuilder when generating this AST
   // node. The class links are immediately registered (inside

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -20,6 +20,7 @@ class ClassDeclaration : public Node
 public:
   ClassDeclaration( const SourceLocation& source_location, std::string name,
                     std::unique_ptr<ClassParameterList> parameters,
+                    std::shared_ptr<FunctionLink> constructor_link,
                     const std::vector<std::string>& method_names, Node* body,
                     std::vector<std::shared_ptr<ClassLink>> base_classes );
 
@@ -36,7 +37,7 @@ public:
   // Owned by top_level_statements
   Node* class_body;
 
-  // Will have no function linked if class has no constructor defined.
+  // `nullptr` if class has no constructor defined.
   const std::shared_ptr<FunctionLink> constructor_link;
 
   // Passed as ctor parameter by UserFunctionBuilder when generating this AST

--- a/pol-core/bscript/compiler/ast/Function.h
+++ b/pol-core/bscript/compiler/ast/Function.h
@@ -19,6 +19,7 @@ public:
 
   unsigned parameter_count() const;
   bool is_variadic() const;
+  // TODO implement ScopableName and update GeneratedFunctionBuilder
   std::string scoped_name() const;
   std::vector<std::reference_wrapper<FunctionParameterDeclaration>> parameters();
 

--- a/pol-core/bscript/compiler/ast/FunctionCall.cpp
+++ b/pol-core/bscript/compiler/ast/FunctionCall.cpp
@@ -42,7 +42,14 @@ void FunctionCall::accept( NodeVisitor& visitor )
 
 void FunctionCall::describe_to( std::string& w ) const
 {
-  fmt::format_to( std::back_inserter( w ), "function-call({})", scoped_name->string() );
+  if ( scoped_name )
+  {
+    fmt::format_to( std::back_inserter( w ), "function-call({})", scoped_name->string() );
+  }
+  else
+  {
+    fmt::format_to( std::back_inserter( w ), "expression-as-callee function-call" );
+  }
 }
 
 std::vector<std::unique_ptr<Argument>> FunctionCall::take_arguments()

--- a/pol-core/bscript/compiler/ast/GeneratedFunction.cpp
+++ b/pol-core/bscript/compiler/ast/GeneratedFunction.cpp
@@ -1,6 +1,4 @@
-#include "SuperFunction.h"
-
-#include <set>
+#include "GeneratedFunction.h"
 
 #include "bscript/compiler/ast/Argument.h"
 #include "bscript/compiler/ast/ClassDeclaration.h"
@@ -9,23 +7,29 @@
 #include "bscript/compiler/ast/FunctionParameterList.h"
 #include "bscript/compiler/ast/Statement.h"
 #include "bscript/compiler/ast/UserFunction.h"
+#include "bscript/compiler/model/ClassLink.h"
 
 namespace Pol::Bscript::Compiler
 {
-SuperFunction::SuperFunction( const SourceLocation& loc, ClassDeclaration* cd )
+GeneratedFunction::GeneratedFunction( const SourceLocation& loc, ClassDeclaration* cd,
+                                      UserFunctionType type, const std::string& name )
     : UserFunction(
-          loc, false, false, UserFunctionType::Super, cd->name /* scope */,
-          "super" /* function name */,
+          loc, false /* exported */, false /* expression */, type, cd->name /* scope */, name,
           std::make_unique<FunctionParameterList>(
               loc, std::vector<std::unique_ptr<FunctionParameterDeclaration>>() ),
           std::make_unique<FunctionBody>( loc, std::vector<std::unique_ptr<Statement>>() ), loc,
-          nullptr ),
-      class_declaration( cd )
+          std::make_shared<ClassLink>( loc, cd->name ) )
 {
+  class_link->link_to( cd );
 }
 
-void SuperFunction::describe_to( std::string& w ) const
+void GeneratedFunction::describe_to( std::string& w ) const
 {
-  fmt::format_to( std::back_inserter( w ), "super-function({})", name );
+  fmt::format_to( std::back_inserter( w ), "generated-function({})", name );
+}
+
+ClassDeclaration* GeneratedFunction::class_declaration() const
+{
+  return class_link->class_declaration();
 }
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/GeneratedFunction.h
+++ b/pol-core/bscript/compiler/ast/GeneratedFunction.h
@@ -6,14 +6,15 @@ namespace Pol::Bscript::Compiler
 {
 class ClassDeclaration;
 
-class SuperFunction : public UserFunction
+class GeneratedFunction : public UserFunction
 {
 public:
-  SuperFunction( const SourceLocation&, ClassDeclaration* );
+  GeneratedFunction( const SourceLocation&, ClassDeclaration*, UserFunctionType,
+                     const std::string& name );
 
   // Do not override accept, so that the UserFunction accept is used.
   void describe_to( std::string& ) const override;
 
-  ClassDeclaration* class_declaration;
+  ClassDeclaration* class_declaration() const;
 };
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/NodeVisitor.cpp
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.cpp
@@ -40,6 +40,7 @@
 #include "bscript/compiler/ast/FunctionExpression.h"
 #include "bscript/compiler/ast/FunctionParameterDeclaration.h"
 #include "bscript/compiler/ast/FunctionParameterList.h"
+#include "bscript/compiler/ast/GeneratedFunction.h"
 #include "bscript/compiler/ast/IfThenElseStatement.h"
 #include "bscript/compiler/ast/InterpolateString.h"
 #include "bscript/compiler/ast/JumpStatement.h"
@@ -59,7 +60,6 @@
 #include "bscript/compiler/ast/StringValue.h"
 #include "bscript/compiler/ast/StructInitializer.h"
 #include "bscript/compiler/ast/StructMemberInitializer.h"
-#include "bscript/compiler/ast/SuperFunction.h"
 #include "bscript/compiler/ast/TopLevelStatements.h"
 #include "bscript/compiler/ast/UnaryOperator.h"
 #include "bscript/compiler/ast/UserFunction.h"
@@ -351,7 +351,7 @@ void NodeVisitor::visit_struct_member_initializer( StructMemberInitializer& node
   visit_children( node );
 }
 
-void NodeVisitor::visit_super_function( SuperFunction& node )
+void NodeVisitor::visit_generated_function( GeneratedFunction& node )
 {
   visit_children( node );
 }

--- a/pol-core/bscript/compiler/ast/NodeVisitor.h
+++ b/pol-core/bscript/compiler/ast/NodeVisitor.h
@@ -66,7 +66,7 @@ class MemberAssignmentByOperator;
 class StringValue;
 class StructInitializer;
 class StructMemberInitializer;
-class SuperFunction;
+class GeneratedFunction;
 class TopLevelStatements;
 class UnaryOperator;
 class UninitializedValue;
@@ -119,6 +119,7 @@ public:
   virtual void visit_function_parameter_list( FunctionParameterList& );
   virtual void visit_function_expression( FunctionExpression& );
   virtual void visit_function_reference( FunctionReference& );
+  virtual void visit_generated_function( GeneratedFunction& );
   virtual void visit_identifier( Identifier& );
   virtual void visit_if_then_else_statement( IfThenElseStatement& );
   virtual void visit_integer_value( IntegerValue& );
@@ -140,7 +141,6 @@ public:
   virtual void visit_format_expression( FormatExpression& );
   virtual void visit_struct_initializer( StructInitializer& );
   virtual void visit_struct_member_initializer( StructMemberInitializer& );
-  virtual void visit_super_function( SuperFunction& );
   virtual void visit_top_level_statements( TopLevelStatements& );
   virtual void visit_unary_operator( UnaryOperator& );
   virtual void visit_uninitialized_value( UninitializedValue& );

--- a/pol-core/bscript/compiler/astbuilder/AvailableParseTree.cpp
+++ b/pol-core/bscript/compiler/astbuilder/AvailableParseTree.cpp
@@ -2,11 +2,53 @@
 
 #include <fmt/format.h>
 
-fmt::format_context::iterator fmt::formatter<Pol::Bscript::Compiler::AvailableParseTree>::format(
-    const Pol::Bscript::Compiler::AvailableParseTree& apt, fmt::format_context& ctx ) const
+namespace Pol::Bscript::Compiler
 {
-  std::string tmp =
-      fmt::format( "apt({}, ctx={})", (void*)( &apt ), (void*)( apt.parse_rule_context ) );
+AvailableSecondPassTarget::AvailableSecondPassTarget( const SourceLocation& loc, Type type,
+                                                      Node* context )
+    : source_location( loc ), type( type ), context( context )
+{
+}
 
-  return fmt::formatter<std::string>::format( std::move( tmp ), ctx );
+AvailableGeneratedFunction::AvailableGeneratedFunction( const SourceLocation& loc, Node* context,
+                                                        const ScopableName& name,
+                                                        UserFunctionType type )
+    : AvailableSecondPassTarget( loc, Type::GeneratedFunction, context ), name( name ), type( type )
+{
+}
+AvailableParseTree::AvailableParseTree( const SourceLocation& loc,
+                                        antlr4::ParserRuleContext* parse_rule_context,
+                                        const ScopeName& scope, Node* context )
+    : AvailableSecondPassTarget( loc, Type::ParseTree, context ),
+      parse_rule_context( parse_rule_context ),
+      scope( scope )
+{
+}
+}  // namespace Pol::Bscript::Compiler
+
+fmt::format_context::iterator
+fmt::formatter<Pol::Bscript::Compiler::AvailableSecondPassTarget>::format(
+    const Pol::Bscript::Compiler::AvailableSecondPassTarget& aspt, fmt::format_context& ctx ) const
+{
+  if ( aspt.type == Pol::Bscript::Compiler::AvailableSecondPassTarget::Type::ParseTree )
+  {
+    const Pol::Bscript::Compiler::AvailableParseTree& apt =
+        static_cast<const Pol::Bscript::Compiler::AvailableParseTree&>( aspt );
+
+    std::string tmp = fmt::format( "apt({}, scope={}, ctx={})", (void*)( &apt ), apt.scope.string(),
+                                   (void*)( apt.parse_rule_context ) );
+
+    return fmt::formatter<std::string>::format( std::move( tmp ), ctx );
+  }
+  else if ( aspt.type ==
+            Pol::Bscript::Compiler::AvailableSecondPassTarget::Type::GeneratedFunction )
+  {
+    const Pol::Bscript::Compiler::AvailableGeneratedFunction& agf =
+        static_cast<const Pol::Bscript::Compiler::AvailableGeneratedFunction&>( aspt );
+    std::string tmp = fmt::format( "agf({}, name={})", (void*)( &agf ), agf.name );
+
+    return fmt::formatter<std::string>::format( std::move( tmp ), ctx );
+  }
+
+  return fmt::formatter<std::string>::format( "", ctx );
 }

--- a/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
+++ b/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "bscript/compiler/file/SourceLocation.h"
+#include "bscript/compiler/model/ScopableName.h"
+#include "bscript/compiler/model/UserFunctionType.h"
 
 #include <clib/maputil.h>
 #include <map>
@@ -14,20 +16,53 @@ namespace Pol::Bscript::Compiler
 {
 class Node;
 
-struct AvailableParseTree
+class AvailableSecondPassTarget
 {
+public:
+  enum class Type;
+
+  AvailableSecondPassTarget( const SourceLocation& loc, Type type, Node* context );
+
   SourceLocation source_location;
+  Type type;
+  // Used by UserFunctionVisitor/Builder to add var statements to the ClassBody
+  // inside (context=) TopLevelStatements; and GeneratedFunctionBuilder to
+  // create a SuperFunction for a (context=) ClassDeclaration.
+  Node* context;
+
+  enum class Type
+  {
+    ParseTree,
+    GeneratedFunction
+  };
+};
+
+class AvailableGeneratedFunction : public AvailableSecondPassTarget
+{
+public:
+  AvailableGeneratedFunction( const SourceLocation& loc, Node* context, const ScopableName& name,
+                              UserFunctionType type );
+
+  ScopableName name;
+  UserFunctionType type;
+};
+
+class AvailableParseTree : public AvailableSecondPassTarget
+{
+public:
+  AvailableParseTree( const SourceLocation& loc, antlr4::ParserRuleContext* parse_rule_context,
+                      const ScopeName& scope, Node* context );
   antlr4::ParserRuleContext* const parse_rule_context;
-  std::string scope;
-  // Used by UserFunctionVisitor/Builder to add var statemnts to the ClassBody
-  // inside TopLevelStatements.
-  Node* top_level_statements_child_node;
+
+  ScopeName scope;
 };
 }  // namespace Pol::Bscript::Compiler
 
 template <>
-struct fmt::formatter<Pol::Bscript::Compiler::AvailableParseTree> : fmt::formatter<std::string>
+struct fmt::formatter<Pol::Bscript::Compiler::AvailableSecondPassTarget>
+    : fmt::formatter<std::string>
 {
-  fmt::format_context::iterator format( const Pol::Bscript::Compiler::AvailableParseTree& apt,
-                                        fmt::format_context& ctx ) const;
+  fmt::format_context::iterator format(
+      const Pol::Bscript::Compiler::AvailableSecondPassTarget& apt,
+      fmt::format_context& ctx ) const;
 };

--- a/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
+++ b/pol-core/bscript/compiler/astbuilder/AvailableParseTree.h
@@ -22,6 +22,7 @@ public:
   enum class Type;
 
   AvailableSecondPassTarget( const SourceLocation& loc, Type type, Node* context );
+  virtual ~AvailableSecondPassTarget() = default;
 
   SourceLocation source_location;
   Type type;
@@ -42,6 +43,7 @@ class AvailableGeneratedFunction : public AvailableSecondPassTarget
 public:
   AvailableGeneratedFunction( const SourceLocation& loc, Node* context, const ScopableName& name,
                               UserFunctionType type );
+  virtual ~AvailableGeneratedFunction() = default;
 
   ScopableName name;
   UserFunctionType type;
@@ -53,6 +55,7 @@ public:
   AvailableParseTree( const SourceLocation& loc, antlr4::ParserRuleContext* parse_rule_context,
                       const ScopeName& scope, Node* context );
   antlr4::ParserRuleContext* const parse_rule_context;
+  virtual ~AvailableParseTree() = default;
 
   ScopeName scope;
 };

--- a/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/CompilerWorkspaceBuilder.cpp
@@ -3,10 +3,10 @@
 #include "bscript/compiler/Profile.h"
 #include "bscript/compiler/Report.h"
 #include "bscript/compiler/ast/ClassDeclaration.h"
+#include "bscript/compiler/ast/GeneratedFunction.h"
 #include "bscript/compiler/ast/ModuleFunctionDeclaration.h"
 #include "bscript/compiler/ast/Program.h"
 #include "bscript/compiler/ast/Statement.h"
-#include "bscript/compiler/ast/SuperFunction.h"
 #include "bscript/compiler/ast/TopLevelStatements.h"
 #include "bscript/compiler/ast/UserFunction.h"
 #include "bscript/compiler/astbuilder/AvailableParseTree.h"
@@ -76,8 +76,8 @@ void CompilerWorkspaceBuilder::build_referenced_user_functions( BuilderWorkspace
 {
   Pol::Tools::HighPerfTimer timer;
 
-  std::vector<AvailableParseTree> to_build;
-  std::vector<std::unique_ptr<SuperFunction>> super_functions;
+  std::vector<std::unique_ptr<AvailableSecondPassTarget>> to_build;
+  std::vector<std::unique_ptr<GeneratedFunction>> generated_functions;
 
   int resolves_done = 0;
   while ( workspace.function_resolver.resolve( to_build ) )
@@ -87,24 +87,27 @@ void CompilerWorkspaceBuilder::build_referenced_user_functions( BuilderWorkspace
     report.debug( *workspace.compiler_workspace.top_level_statements, "Resolution {} starting.",
                   resolves_done );
 
-    for ( auto& apt : to_build )
+    for ( auto& target : to_build )
     {
-      if ( apt.parse_rule_context )
+      report.debug( *workspace.compiler_workspace.top_level_statements, "Resolving {}", *target );
+      if ( target->type == AvailableSecondPassTarget::Type::ParseTree )
       {
-        report.debug( *workspace.compiler_workspace.top_level_statements, "Resolving {}", apt );
-        UserFunctionVisitor user_function_visitor( *apt.source_location.source_file_identifier,
-                                                   workspace, apt.scope,
-                                                   apt.top_level_statements_child_node );
-        apt.parse_rule_context->accept( &user_function_visitor );
+        auto apt = static_cast<AvailableParseTree*>( target.get() );
+        UserFunctionVisitor user_function_visitor( *apt->source_location.source_file_identifier,
+                                                   workspace, apt->scope.string(), apt->context );
+
+        apt->parse_rule_context->accept( &user_function_visitor );
       }
-      else
+      else if ( target->type == AvailableSecondPassTarget::Type::GeneratedFunction )
       {
-        if ( auto cd = dynamic_cast<ClassDeclaration*>( apt.top_level_statements_child_node ) )
-        {
-          auto super = std::make_unique<SuperFunction>( cd->source_location, cd );
-          workspace.function_resolver.register_user_function( cd->name, super.get() );
-          super_functions.push_back( std::move( super ) );
-        }
+        auto agf = static_cast<AvailableGeneratedFunction*>( target.get() );
+        auto cd = static_cast<ClassDeclaration*>( agf->context );
+        auto name = agf->type == UserFunctionType::Super ? "super" : cd->name;
+
+        auto super =
+            std::make_unique<GeneratedFunction>( cd->source_location, cd, agf->type, name );
+        workspace.function_resolver.register_user_function( cd->name, super.get() );
+        generated_functions.push_back( std::move( super ) );
       }
     }
     report.debug( *workspace.compiler_workspace.top_level_statements,
@@ -113,19 +116,25 @@ void CompilerWorkspaceBuilder::build_referenced_user_functions( BuilderWorkspace
     to_build.clear();
   };
 
-  // We must build the super functions _after_ the AST resolution: super
+  // We must build the generated functions _after_ the AST resolution: generated
   // functions reference class links.
-  for ( auto& super : super_functions )
+  for ( auto& function : generated_functions )
   {
-    GeneratedFunctionBuilder tree_builder( *super->source_location.source_file_identifier,
+    GeneratedFunctionBuilder tree_builder( *function->source_location.source_file_identifier,
                                            workspace );
 
-    tree_builder.super_function( super );
+    if ( function->type == UserFunctionType::Super )
+      tree_builder.super_function( function );
+    else if ( function->type == UserFunctionType::Constructor )
+      tree_builder.constructor_function( function );
+    else
+      function->internal_error( "unknown UserFunctionType" );
 
     report.debug( *workspace.compiler_workspace.top_level_statements,
-                  "Super function {} takes {} params", super->name, super->parameter_count() );
+                  "Generated function {} takes {} params", function->name,
+                  function->parameter_count() );
 
-    workspace.compiler_workspace.user_functions.push_back( std::move( super ) );
+    workspace.compiler_workspace.user_functions.push_back( std::move( function ) );
   }
 
   workspace.profile.ast_resolve_functions_micros += timer.ellapsed().count();

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -399,7 +399,6 @@ void FunctionResolver::register_available_function_parse_tree(
                   scoped_name, previous->source_location );
   }
 
-  // available_user_function_parse_trees.insert( { scoped_name, apt } );
   available_user_function_parse_trees[scoped_name] = std::move( apt );
 }
 
@@ -409,7 +408,7 @@ void FunctionResolver::register_available_user_function_parse_tree(
 {
   register_available_function_parse_tree(
       source_location, name,
-      std::make_unique<AvailableParseTree>( source_location, ctx, name.scope.string(), nullptr ) );
+      std::make_unique<AvailableParseTree>( source_location, ctx, name.scope, nullptr ) );
 
   if ( force_reference )
   {
@@ -461,7 +460,7 @@ void FunctionResolver::register_available_class_decl_parse_tree(
                   name, what, what, previous->source_location );
   }
 
-  auto apt = std::make_unique<AvailableParseTree>( source_location, ctx, name,
+  auto apt = std::make_unique<AvailableParseTree>( source_location, ctx, scope_name,
                                                    top_level_statements_child_node );
   available_class_decl_parse_trees[name] = std::move( apt );
 }

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
@@ -93,7 +93,6 @@ void GeneratedFunctionBuilder::constructor_function(
   to_visit.insert( to_visit.end(), class_declaration->base_class_links.begin(),
                    class_declaration->base_class_links.end() );
 
-  // while ( !to_visit.empty() )
   for ( auto to_link_itr = to_visit.begin(); to_link_itr != to_visit.end();
         to_link_itr = to_visit.erase( to_link_itr ) )
   {

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/adaptor/sliced.hpp>
+#include <set>
 
 #include "bscript/compiler/Report.h"
 #include "bscript/compiler/ast/Argument.h"
@@ -62,8 +63,6 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
           base_class_ctors.push_back( base_class_ctor );
         }
       }
-      to_link.insert( to_link.end(), base_cd->base_class_links.begin(),
-                      base_cd->base_class_links.end() );
     }
   }
 
@@ -94,6 +93,8 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
       }
     }
 
+    std::set<ScopableName> visited_arg_names;
+
     for ( auto base_class_ctor : boost::adaptors::reverse( base_class_ctors ) )
     {
       auto params = base_class_ctor->parameters();
@@ -105,9 +106,15 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
       for ( auto& param_ref : params )
       {
         auto& param = param_ref.get();
+        auto param_scope = first                      ? ScopeName::None
+                           : param.name.scope.empty() ? ScopeName( base_class_ctor->name )
+                                                      : param.name.scope;
+
+        auto param_name = ScopableName( param_scope, param.name.name );
+
 
         // Skip the first `this` parameter of the function declaration, as we've already added it.
-        if ( !first )
+        if ( !first && visited_arg_names.find( param_name ) == visited_arg_names.end() )
         {
           // If the base ctor parameter is a rest param, our super() function parameter
           // will _not_ be a rest, but a regular variable with a default [empty]
@@ -115,8 +122,7 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
           if ( param.rest && !can_use_rest )
           {
             function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                loc, ScopableName( base_class_ctor->name, param.name.name ), param.byref,
-                param.unused, false,
+                loc, param_name, param.byref, param.unused, false,
                 std::make_unique<ArrayInitializer>(
                     param.source_location, std::vector<std::unique_ptr<Expression>>() ) ) );
           }
@@ -130,8 +136,8 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
             if ( auto final_argument = cloner.clone( *default_value ) )
             {
               function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                  loc, ScopableName( base_class_ctor->name, param.name.name ), param.byref,
-                  param.unused, false, std::move( final_argument ) ) );
+                  loc, param_name, param.byref, param.unused, false,
+                  std::move( final_argument ) ) );
             }
             else
             {
@@ -150,17 +156,14 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
             auto is_rest_param = param.rest && can_use_rest;
 
             function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                loc, ScopableName( base_class_ctor->name, param.name.name ), param.byref,
-                param.unused, is_rest_param ) );
+                loc, param_name, param.byref, param.unused, is_rest_param ) );
           }
         }
 
         // By default, the function call argument inside this super()'s function
         // declaration will just be the super() alias'ed parameter.
-        std::unique_ptr<Expression> call_argument = std::make_unique<Identifier>(
-            param.source_location,
-            ScopableName( first ? ScopeName::None : ScopeName( base_class_ctor->name ),
-                          param.name.name ) );
+        std::unique_ptr<Expression> call_argument =
+            std::make_unique<Identifier>( param.source_location, param_name );
 
         // If the base ctor parameter is a rest param, the base_ctor() function
         // call will spread the super() function parameter -- an array -- into
@@ -176,7 +179,7 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
         call_arguments.insert( call_arguments.end(), std::make_unique<Argument>(
                                                          param.source_location, param.name,
                                                          std::move( call_argument ), param.rest ) );
-
+        visited_arg_names.insert( param_name );
         first = false;
       }
 
@@ -199,15 +202,28 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
   workspace.report.debug( loc, "Super function: {}", desc );
 }
 
-void GeneratedFunctionBuilder::constructor_function( std::unique_ptr<GeneratedFunction>& super )
+void GeneratedFunctionBuilder::constructor_function(
+    std::unique_ptr<GeneratedFunction>& constructor )
 {
   std::set<ClassDeclaration*> visited;
   std::vector<std::shared_ptr<ClassLink>> to_visit;
-  auto class_declaration = super->class_declaration();
+  auto class_declaration = constructor->class_declaration();
   const auto& loc = class_declaration->source_location;
   UserFunction* base_class_ctor = nullptr;
-  auto& function_parameters = super->child<FunctionParameterList>( 0 ).children;
-  // auto& body = super->child<FunctionBody>( 1 ).children;
+
+  // If the class declaration _has_ a constructor link, then it registered a
+  // constructor but it was never resolved. This should never happen.
+  if ( class_declaration->constructor_link != nullptr )
+  {
+    // If the class has a _linked_ constructor, then we should not have
+    // generated a constructor function.
+    if ( class_declaration->constructor_link->function() != nullptr )
+      class_declaration->internal_error(
+          fmt::format( "class {} has linked ctor", class_declaration->name ) );
+
+    class_declaration->internal_error(
+        fmt::format( "class {} unlinked ctor", class_declaration->name ) );
+  }
 
   to_visit.insert( to_visit.end(), class_declaration->base_class_links.begin(),
                    class_declaration->base_class_links.end() );
@@ -238,90 +254,52 @@ void GeneratedFunctionBuilder::constructor_function( std::unique_ptr<GeneratedFu
 
   if ( base_class_ctor != nullptr )
   {
-    auto& body = super->child<FunctionBody>( 1 ).children;
-    function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-        loc, ScopableName( ScopeName::None, "this" ), true /* byref */, false /* unused */,
-        false /* rest */ ) );
-
-    auto params = base_class_ctor->parameters();
-
+    auto& function_parameters = constructor->child<FunctionParameterList>( 0 ).children;
+    auto& body = constructor->child<FunctionBody>( 1 ).children;
     auto call_arguments = std::vector<std::unique_ptr<Argument>>();
-
     bool first = true;
 
-    for ( auto& param_ref : params )
+    for ( auto& param_ref : base_class_ctor->parameters() )
     {
       auto& param = param_ref.get();
+      auto param_scope = first ? ScopeName::None : ScopeName( base_class_ctor->name );
+      auto param_name = ScopableName( param_scope, param.name.name );
 
-      // Skip the first `this` parameter of the function declaration, as we've already added it.
-      if ( !first )
+      // If the base ctor parameter has a default value, our generated function
+      // parameter will have the same default value.
+      if ( auto default_value = param.default_value() )
       {
-        // If the base ctor parameter is a rest param, our super() function parameter
-        // will _not_ be a rest, but a regular variable with a default [empty]
-        // array value. This only applies if we _cannot_ use rest parameters.
-        if ( param.rest )
+        SimpleValueCloner cloner( report, default_value->source_location );
+
+        // Value must be cloneable
+        if ( auto final_argument = cloner.clone( *default_value ) )
         {
           function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-              loc, ScopableName( ScopeName::None, param.name.name ), param.byref, param.unused,
-              false,
-              std::make_unique<ArrayInitializer>( param.source_location,
-                                                  std::vector<std::unique_ptr<Expression>>() ) ) );
-        }
-        // If the base ctor parameter has a default value, our super() function
-        // parameter will have the same default value.
-        else if ( auto default_value = param.default_value() )
-        {
-          SimpleValueCloner cloner( report, default_value->source_location );
-
-          // Value must be cloneable
-          if ( auto final_argument = cloner.clone( *default_value ) )
-          {
-            function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                loc, ScopableName( ScopeName::None, param.name.name ), param.byref, param.unused,
-                false, std::move( final_argument ) ) );
-          }
-          else
-          {
-            report.error( class_declaration->source_location,
-                          "In construction of '{}': Unable to create argument from default for "
-                          "parameter '{}'.\n"
-                          "  See also: {}",
-                          super->scoped_name(), param.name, param.source_location );
-            return;
-          }
+              loc, param_name, param.byref, param.unused, false, std::move( final_argument ) ) );
         }
         else
         {
-          // This super() alias'ed parameter is a rest parameter if the base
-          // ctor's parameter is rest _and_ we can use a rest parameter.
-          // auto is_rest_param = param.rest && can_use_rest;
-
-          function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-              loc, ScopableName( ScopeName::None, param.name.name ), param.byref, param.unused,
-              param.rest ) );
+          report.error( class_declaration->source_location,
+                        "In construction of '{}': Unable to create argument from default for "
+                        "parameter '{}'.\n"
+                        "  See also: {}",
+                        constructor->scoped_name(), param.name, param.source_location );
+          return;
         }
       }
-
-      // By default, the function call argument inside this super()'s function
-      // declaration will just be the super() alias'ed parameter.
-      std::unique_ptr<Expression> call_argument =
-          std::make_unique<Identifier>( param.source_location, param.name );
-
-      // If the base ctor parameter is a rest param, the base_ctor() function
-      // call will spread the super() function parameter -- an array -- into
-      // the base constructor.
-      if ( param.rest )
+      else
       {
-        // Passing an element that is not spreadable (eg. a string) will result
-        // in an empty array passed to the base constructor.
-        call_argument =
-            std::make_unique<SpreadElement>( param.source_location, std::move( call_argument ) );
+        function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
+            loc, param_name, param.byref, param.unused, param.rest ) );
       }
+      // The function call argument inside this generated function function
+      // declaration will just be the generated function's aliased parameter.
+      std::unique_ptr<Expression> call_argument =
+          std::make_unique<Identifier>( param.source_location, param_name );
 
       call_arguments.insert( call_arguments.end(),
                              std::make_unique<Argument>( param.source_location,
                                                          std::move( call_argument ), param.rest ) );
-
       first = false;
     }
 
@@ -337,7 +315,9 @@ void GeneratedFunctionBuilder::constructor_function( std::unique_ptr<GeneratedFu
     body.push_back( std::move( value_consumer ) );
   }
   std::string desc;
-  Node::describe_tree_to_indented( *super, desc, 0 );
-  workspace.report.debug( loc, "Ctor {} function: {}", super->name, desc );
+  Node::describe_tree_to_indented( *constructor, desc, 0 );
+  workspace.report.debug( loc, "Ctor {} function: {}", constructor->name, desc );
+  class_declaration->constructor_link = std::make_unique<FunctionLink>( loc, "", true );
+  class_declaration->constructor_link->link_to( constructor.get() );
 }
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/adaptor/sliced.hpp>
+#include <list>
 #include <set>
 
 #include "bscript/compiler/Report.h"
@@ -37,18 +38,16 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
 {
   std::vector<UserFunction*> base_class_ctors;
   std::set<ClassDeclaration*> visited;
-  std::vector<std::shared_ptr<ClassLink>> to_link;
+  std::list<std::shared_ptr<ClassLink>> to_visit;
   auto class_declaration = super->class_declaration();
-  const auto& loc = class_declaration->source_location;
 
-  to_link.insert( to_link.end(), class_declaration->base_class_links.begin(),
-                  class_declaration->base_class_links.end() );
+  to_visit.insert( to_visit.end(), class_declaration->base_class_links.begin(),
+                   class_declaration->base_class_links.end() );
 
-  while ( !to_link.empty() )
+  for ( auto to_link_itr = to_visit.begin(); to_link_itr != to_visit.end();
+        to_link_itr = to_visit.erase( to_link_itr ) )
   {
-    auto base_class_link = to_link.back();
-    to_link.pop_back();
-    if ( auto base_cd = base_class_link->class_declaration() )
+    if ( auto base_cd = ( *to_link_itr )->class_declaration() )
     {
       if ( visited.find( base_cd ) != visited.end() )
       {
@@ -66,149 +65,15 @@ void GeneratedFunctionBuilder::super_function( std::unique_ptr<GeneratedFunction
     }
   }
 
-  // If there are no base ctors, skip updating the function's parameters and
-  // body, therefore a super function that is "invalid" will have no parameters
-  // or body.
-  if ( !base_class_ctors.empty() )
-  {
-    auto& function_parameters = super->child<FunctionParameterList>( 0 ).children;
-
-    auto& body = super->child<FunctionBody>( 1 ).children;
-    function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-        loc, ScopableName( ScopeName::None, "this" ), true /* byref */, false /* unused */,
-        false /* rest */ ) );
-
-    // Our super() alias'ed parameter can be a rest parameter only if the not-last
-    // constructors are not variadic.
-    bool can_use_rest = true;
-
-    for ( const auto* base_class_ctor :
-          base_class_ctors | boost::adaptors::reversed |
-              boost::adaptors::sliced( 0, base_class_ctors.size() - 1 ) )
-    {
-      if ( base_class_ctor->is_variadic() )
-      {
-        can_use_rest = false;
-        break;
-      }
-    }
-
-    std::set<ScopableName> visited_arg_names;
-
-    for ( auto base_class_ctor : boost::adaptors::reverse( base_class_ctors ) )
-    {
-      auto params = base_class_ctor->parameters();
-
-      auto call_arguments = std::vector<std::unique_ptr<Argument>>();
-
-      bool first = true;
-
-      for ( auto& param_ref : params )
-      {
-        auto& param = param_ref.get();
-        auto param_scope = first                      ? ScopeName::None
-                           : param.name.scope.empty() ? ScopeName( base_class_ctor->name )
-                                                      : param.name.scope;
-
-        auto param_name = ScopableName( param_scope, param.name.name );
-
-
-        // Skip the first `this` parameter of the function declaration, as we've already added it.
-        if ( !first && visited_arg_names.find( param_name ) == visited_arg_names.end() )
-        {
-          // If the base ctor parameter is a rest param, our super() function parameter
-          // will _not_ be a rest, but a regular variable with a default [empty]
-          // array value. This only applies if we _cannot_ use rest parameters.
-          if ( param.rest && !can_use_rest )
-          {
-            function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                loc, param_name, param.byref, param.unused, false,
-                std::make_unique<ArrayInitializer>(
-                    param.source_location, std::vector<std::unique_ptr<Expression>>() ) ) );
-          }
-          // If the base ctor parameter has a default value, our super() function
-          // parameter will have the same default value.
-          else if ( auto default_value = param.default_value() )
-          {
-            SimpleValueCloner cloner( report, default_value->source_location );
-
-            // Value must be cloneable
-            if ( auto final_argument = cloner.clone( *default_value ) )
-            {
-              function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                  loc, param_name, param.byref, param.unused, false,
-                  std::move( final_argument ) ) );
-            }
-            else
-            {
-              report.error( class_declaration->source_location,
-                            "In construction of '{}': Unable to create argument from default for "
-                            "parameter '{}'.\n"
-                            "  See also: {}",
-                            super->scoped_name(), param.name, param.source_location );
-              return;
-            }
-          }
-          else
-          {
-            // This super() alias'ed parameter is a rest parameter if the base
-            // ctor's parameter is rest _and_ we can use a rest parameter.
-            auto is_rest_param = param.rest && can_use_rest;
-
-            function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-                loc, param_name, param.byref, param.unused, is_rest_param ) );
-          }
-        }
-
-        // By default, the function call argument inside this super()'s function
-        // declaration will just be the super() alias'ed parameter.
-        std::unique_ptr<Expression> call_argument =
-            std::make_unique<Identifier>( param.source_location, param_name );
-
-        // If the base ctor parameter is a rest param, the base_ctor() function
-        // call will spread the super() function parameter -- an array -- into
-        // the base constructor.
-        if ( param.rest )
-        {
-          // Passing an element that is not spreadable (eg. a string) will result
-          // in an empty array passed to the base constructor.
-          call_argument =
-              std::make_unique<SpreadElement>( param.source_location, std::move( call_argument ) );
-        }
-
-        call_arguments.insert( call_arguments.end(), std::make_unique<Argument>(
-                                                         param.source_location, param.name,
-                                                         std::move( call_argument ), param.rest ) );
-        visited_arg_names.insert( param_name );
-        first = false;
-      }
-
-      auto fc = std::make_unique<FunctionCall>(
-          loc, base_class_ctor->name, ScopableName( base_class_ctor->name, base_class_ctor->name ),
-          std::move( call_arguments ) );
-
-      fc->function_link->link_to( base_class_ctor );
-
-      auto value_consumer = std::make_unique<ValueConsumer>( fc->source_location, std::move( fc ) );
-      body.push_back( std::move( value_consumer ) );
-    }
-
-    body.push_back(
-        std::make_unique<ReturnStatement>( loc, std::make_unique<Identifier>( loc, "this" ) ) );
-  }
-
-  std::string desc;
-  Node::describe_tree_to_indented( *super, desc, 0 );
-  workspace.report.debug( loc, "Super function: {}", desc );
+  build( super, base_class_ctors );
 }
 
 void GeneratedFunctionBuilder::constructor_function(
     std::unique_ptr<GeneratedFunction>& constructor )
 {
   std::set<ClassDeclaration*> visited;
-  std::vector<std::shared_ptr<ClassLink>> to_visit;
+  std::list<std::shared_ptr<ClassLink>> to_visit;
   auto class_declaration = constructor->class_declaration();
-  const auto& loc = class_declaration->source_location;
   UserFunction* base_class_ctor = nullptr;
 
   // If the class declaration _has_ a constructor link, then it registered a
@@ -228,11 +93,11 @@ void GeneratedFunctionBuilder::constructor_function(
   to_visit.insert( to_visit.end(), class_declaration->base_class_links.begin(),
                    class_declaration->base_class_links.end() );
 
-  while ( !to_visit.empty() )
+  // while ( !to_visit.empty() )
+  for ( auto to_link_itr = to_visit.begin(); to_link_itr != to_visit.end();
+        to_link_itr = to_visit.erase( to_link_itr ) )
   {
-    auto base_class_link = to_visit.back();
-    to_visit.pop_back();
-    if ( auto base_cd = base_class_link->class_declaration() )
+    if ( auto base_cd = ( *to_link_itr )->class_declaration() )
     {
       if ( visited.find( base_cd ) != visited.end() )
       {
@@ -245,30 +110,104 @@ void GeneratedFunctionBuilder::constructor_function(
         if ( auto ctor = constructor_link->user_function() )
         {
           base_class_ctor = ctor;
-          to_visit.clear();
           break;
         }
       }
     }
   }
 
-  // TODO remove duplicate code from `super_function`
   if ( base_class_ctor != nullptr )
   {
-    auto& function_parameters = constructor->child<FunctionParameterList>( 0 ).children;
-    auto& body = constructor->child<FunctionBody>( 1 ).children;
-    auto call_arguments = std::vector<std::unique_ptr<Argument>>();
-    bool first = true;
+    build( constructor, { base_class_ctor } );
+  }
 
-    for ( auto& param_ref : base_class_ctor->parameters() )
+  // Set the generated function as the class' constructor function.
+  class_declaration->constructor_link =
+      std::make_unique<FunctionLink>( constructor->source_location, "", true );
+  class_declaration->constructor_link->link_to( constructor.get() );
+}
+
+void GeneratedFunctionBuilder::build( std::unique_ptr<GeneratedFunction>& function,
+                                      std::vector<UserFunction*> base_class_ctors )
+{
+  const auto& loc = function->source_location;
+  // If there are no base ctors, skip updating the function's parameters and
+  // body, therefore a super function that is "invalid" will have no parameters
+  // or body.
+  if ( !base_class_ctors.empty() )
+  {
+    auto& function_parameters = function->child<FunctionParameterList>( 0 ).children;
+
+    function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
+        loc, ScopableName( ScopeName::None, "this" ), true /* byref */, false /* unused */,
+        false /* rest */ ) );
+
+    // Our super() alias'ed parameter can be a rest parameter only if the not-last
+    // constructors are not variadic.
+    bool can_use_rest = true;
+
+    for ( const auto* base_class_ctor :
+          base_class_ctors | boost::adaptors::sliced( 0, base_class_ctors.size() - 1 ) )
     {
-      auto& param = param_ref.get();
-      auto param_scope = first ? ScopeName::None : ScopeName( base_class_ctor->name );
-      auto param_name = ScopableName( param_scope, param.name.name );
+      if ( base_class_ctor->is_variadic() )
+      {
+        can_use_rest = false;
+        break;
+      }
+    }
 
-      // If the base ctor parameter has a default value, our generated function
+    std::set<ScopableName> visited_arg_names;
+
+    for ( auto base_class_ctor : base_class_ctors )
+    {
+      add_base_constructor( function, base_class_ctor, visited_arg_names, can_use_rest );
+    }
+  }
+
+  std::string desc;
+  Node::describe_tree_to_indented( *function, desc, 0 );
+  workspace.report.debug( loc, "Generated function: {}", desc );
+}
+
+void GeneratedFunctionBuilder::add_base_constructor( std::unique_ptr<GeneratedFunction>& super,
+                                                     UserFunction* base_class_ctor,
+                                                     std::set<ScopableName>& visited_arg_names,
+                                                     bool can_use_rest )
+{
+  auto& function_parameters = super->child<FunctionParameterList>( 0 ).children;
+  auto& body = super->child<FunctionBody>( 1 ).children;
+  auto params = base_class_ctor->parameters();
+  const auto& loc = super->source_location;
+  auto call_arguments = std::vector<std::unique_ptr<Argument>>();
+
+  bool first = true;
+
+  for ( auto& param_ref : params )
+  {
+    auto& param = param_ref.get();
+    auto param_scope = first                      ? ScopeName::None
+                       : param.name.scope.empty() ? ScopeName( base_class_ctor->name )
+                                                  : param.name.scope;
+
+    auto param_name = ScopableName( param_scope, param.name.name );
+
+
+    // Skip the first `this` parameter of the function declaration, as we've already added it.
+    if ( !first && visited_arg_names.find( param_name ) == visited_arg_names.end() )
+    {
+      // If the base ctor parameter is a rest param, our super() function parameter
+      // will _not_ be a rest, but a regular variable with a default [empty]
+      // array value. This only applies if we _cannot_ use rest parameters.
+      if ( param.rest && !can_use_rest )
+      {
+        function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
+            loc, param_name, param.byref, param.unused, false,
+            std::make_unique<ArrayInitializer>( param.source_location,
+                                                std::vector<std::unique_ptr<Expression>>() ) ) );
+      }
+      // If the base ctor parameter has a default value, our super() function
       // parameter will have the same default value.
-      if ( auto default_value = param.default_value() )
+      else if ( auto default_value = param.default_value() )
       {
         SimpleValueCloner cloner( report, default_value->source_location );
 
@@ -280,43 +219,55 @@ void GeneratedFunctionBuilder::constructor_function(
         }
         else
         {
-          report.error( class_declaration->source_location,
+          report.error( loc,
                         "In construction of '{}': Unable to create argument from default for "
                         "parameter '{}'.\n"
                         "  See also: {}",
-                        constructor->scoped_name(), param.name, param.source_location );
+                        super->scoped_name(), param.name, param.source_location );
           return;
         }
       }
       else
       {
+        // This super() alias'ed parameter is a rest parameter if the base
+        // ctor's parameter is rest _and_ we can use a rest parameter.
+        auto is_rest_param = param.rest && can_use_rest;
+
         function_parameters.push_back( std::make_unique<FunctionParameterDeclaration>(
-            loc, param_name, param.byref, param.unused, param.rest ) );
+            loc, param_name, param.byref, param.unused, is_rest_param ) );
       }
-      // The function call argument inside this generated function function
-      // declaration will just be the generated function's aliased parameter.
-      std::unique_ptr<Expression> call_argument =
-          std::make_unique<Identifier>( param.source_location, param_name );
-
-      call_arguments.insert( call_arguments.end(),
-                             std::make_unique<Argument>( param.source_location,
-                                                         std::move( call_argument ), param.rest ) );
-      first = false;
     }
-    // TODO update after Function implements ScopableName
-    auto fc = std::make_unique<FunctionCall>( loc, base_class_ctor->name,
-                                              ScopableName( constructor->name, constructor->name ),
-                                              std::move( call_arguments ) );
 
-    fc->function_link->link_to( base_class_ctor );
+    // By default, the function call argument inside this super()'s function
+    // declaration will just be the super() alias'ed parameter.
+    std::unique_ptr<Expression> call_argument =
+        std::make_unique<Identifier>( param.source_location, param_name );
 
-    auto value_consumer = std::make_unique<ValueConsumer>( fc->source_location, std::move( fc ) );
-    body.push_back( std::move( value_consumer ) );
+    // If the base ctor parameter is a rest param, the base_ctor() function
+    // call will spread the super() function parameter -- an array -- into
+    // the base constructor.
+    if ( param.rest )
+    {
+      // Passing an element that is not spreadable (eg. a string) will result
+      // in an empty array passed to the base constructor.
+      call_argument =
+          std::make_unique<SpreadElement>( param.source_location, std::move( call_argument ) );
+    }
+
+    call_arguments.insert( call_arguments.end(),
+                           std::make_unique<Argument>( param.source_location, param.name,
+                                                       std::move( call_argument ), param.rest ) );
+    visited_arg_names.insert( param_name );
+    first = false;
   }
-  std::string desc;
-  Node::describe_tree_to_indented( *constructor, desc, 0 );
-  workspace.report.debug( loc, "Ctor {} function: {}", constructor->name, desc );
-  class_declaration->constructor_link = std::make_unique<FunctionLink>( loc, "", true );
-  class_declaration->constructor_link->link_to( constructor.get() );
+
+  auto fc = std::make_unique<FunctionCall>(
+      loc, base_class_ctor->name, ScopableName( base_class_ctor->name, base_class_ctor->name ),
+      std::move( call_arguments ) );
+
+  fc->function_link->link_to( base_class_ctor );
+
+  auto value_consumer = std::make_unique<ValueConsumer>( fc->source_location, std::move( fc ) );
+  body.push_back( std::move( value_consumer ) );
 }
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.cpp
@@ -252,6 +252,7 @@ void GeneratedFunctionBuilder::constructor_function(
     }
   }
 
+  // TODO remove duplicate code from `super_function`
   if ( base_class_ctor != nullptr )
   {
     auto& function_parameters = constructor->child<FunctionParameterList>( 0 ).children;
@@ -302,14 +303,12 @@ void GeneratedFunctionBuilder::constructor_function(
                                                          std::move( call_argument ), param.rest ) );
       first = false;
     }
-
-    auto callee = std::make_unique<FunctionReference>(
-        loc, base_class_ctor->name, std::make_unique<FunctionLink>( loc, base_class_ctor->name ) );
-
-    callee->function_link->link_to( base_class_ctor );
-
-    auto fc = std::make_unique<FunctionCall>( loc, base_class_ctor->name, std::move( callee ),
+    // TODO update after Function implements ScopableName
+    auto fc = std::make_unique<FunctionCall>( loc, base_class_ctor->name,
+                                              ScopableName( constructor->name, constructor->name ),
                                               std::move( call_arguments ) );
+
+    fc->function_link->link_to( base_class_ctor );
 
     auto value_consumer = std::make_unique<ValueConsumer>( fc->source_location, std::move( fc ) );
     body.push_back( std::move( value_consumer ) );

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.h
@@ -4,13 +4,14 @@
 
 namespace Pol::Bscript::Compiler
 {
-class SuperFunction;
+class GeneratedFunction;
 
 class GeneratedFunctionBuilder : public CompoundStatementBuilder
 {
 public:
   GeneratedFunctionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
-  void super_function( std::unique_ptr<SuperFunction>& );
+  void super_function( std::unique_ptr<GeneratedFunction>& );
+  void constructor_function( std::unique_ptr<GeneratedFunction>& );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.h
+++ b/pol-core/bscript/compiler/astbuilder/GeneratedFunctionBuilder.h
@@ -5,6 +5,8 @@
 namespace Pol::Bscript::Compiler
 {
 class GeneratedFunction;
+class ScopableName;
+class UserFunction;
 
 class GeneratedFunctionBuilder : public CompoundStatementBuilder
 {
@@ -12,6 +14,12 @@ public:
   GeneratedFunctionBuilder( const SourceFileIdentifier&, BuilderWorkspace& );
   void super_function( std::unique_ptr<GeneratedFunction>& );
   void constructor_function( std::unique_ptr<GeneratedFunction>& );
+
+private:
+  void build( std::unique_ptr<GeneratedFunction>&, std::vector<UserFunction*> constructors );
+
+  void add_base_constructor( std::unique_ptr<GeneratedFunction>&, UserFunction* constructor,
+                             std::set<ScopableName>& visited_arg_names, bool can_use_rest );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -221,12 +221,12 @@ std::unique_ptr<UserFunction> UserFunctionBuilder::make_user_function(
       bool first = !class_name.empty();
       for ( auto param : param_list->functionParameter() )
       {
-        ScopableName parameter_name( ScopeName::None, text( param->IDENTIFIER() ) );
+        auto param_text = text( param->IDENTIFIER() );
         bool is_this_arg = false;
 
         if ( first )
         {
-          if ( Clib::caseInsensitiveEqual( parameter_name.string(), "this" ) )
+          if ( Clib::caseInsensitiveEqual( param_text, "this" ) )
           {
             class_method = true;
             is_this_arg = true;
@@ -234,6 +234,8 @@ std::unique_ptr<UserFunction> UserFunctionBuilder::make_user_function(
 
           first = false;
         }
+
+        auto parameter_name = ScopableName( ScopeName::None, param_text );
 
         std::unique_ptr<FunctionParameterDeclaration> parameter_declaration;
         bool byref = param->BYREF() != nullptr || is_this_arg;

--- a/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
+++ b/pol-core/bscript/compiler/astbuilder/UserFunctionBuilder.cpp
@@ -221,12 +221,12 @@ std::unique_ptr<UserFunction> UserFunctionBuilder::make_user_function(
       bool first = !class_name.empty();
       for ( auto param : param_list->functionParameter() )
       {
-        auto param_text = text( param->IDENTIFIER() );
+        ScopableName parameter_name( ScopeName::None, text( param->IDENTIFIER() ) );
         bool is_this_arg = false;
 
         if ( first )
         {
-          if ( Clib::caseInsensitiveEqual( param_text, "this" ) )
+          if ( Clib::caseInsensitiveEqual( parameter_name.string(), "this" ) )
           {
             class_method = true;
             is_this_arg = true;
@@ -234,8 +234,6 @@ std::unique_ptr<UserFunction> UserFunctionBuilder::make_user_function(
 
           first = false;
         }
-
-        auto parameter_name = ScopableName( ScopeName::None, param_text );
 
         std::unique_ptr<FunctionParameterDeclaration> parameter_declaration;
         bool byref = param->BYREF() != nullptr || is_this_arg;

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -37,6 +37,7 @@
 #include "bscript/compiler/ast/FunctionParameterDeclaration.h"
 #include "bscript/compiler/ast/FunctionParameterList.h"
 #include "bscript/compiler/ast/FunctionReference.h"
+#include "bscript/compiler/ast/GeneratedFunction.h"
 #include "bscript/compiler/ast/Identifier.h"
 #include "bscript/compiler/ast/IfThenElseStatement.h"
 #include "bscript/compiler/ast/IntegerValue.h"
@@ -480,11 +481,14 @@ void InstructionGenerator::visit_function_call( FunctionCall& call )
     {
       emit_args( *uf );
       FlowControlLabel& label = user_function_labels[uf->scoped_name()];
-      if ( !user_functions.empty() && user_functions.top()->type == UserFunctionType::Super )
+      // Emit the `check_mro` instruction if the current function is a generated
+      // function (super or generated constructor).
+      if ( !user_functions.empty() &&
+           dynamic_cast<GeneratedFunction*>( user_functions.top() ) != nullptr )
       {
         if ( call.children.empty() )
         {
-          call.internal_error( "super call missing 'this'" );
+          call.internal_error( "super/ctor call missing 'this'" );
         }
 
         // Arg to cast can never be negative, since size is >= 1.

--- a/testsuite/escript/classes/fail-no-ctor-04.err
+++ b/testsuite/escript/classes/fail-no-ctor-04.err
@@ -1,0 +1,1 @@
+fail-no-ctor-04.src:12:12: error: In call to 'Animal': No base class defines a constructor.

--- a/testsuite/escript/classes/fail-no-ctor-04.src
+++ b/testsuite/escript/classes/fail-no-ctor-04.src
@@ -1,0 +1,13 @@
+// No base class defines a constructor
+
+class BaseClass1()
+endclass
+
+class BaseClass2()
+endclass
+
+class Animal( BaseClass1, BaseClass2 )
+endclass
+
+var obj := Animal();
+print( obj );

--- a/testsuite/escript/classes/scopes-05.err
+++ b/testsuite/escript/classes/scopes-05.err
@@ -1,0 +1,1 @@
+error: In call to 'B': Too many arguments passed.  Expected -1, got 1.

--- a/testsuite/escript/classes/scopes-05.err
+++ b/testsuite/escript/classes/scopes-05.err
@@ -1,1 +1,0 @@
-error: In call to 'B': Too many arguments passed.  Expected -1, got 1.

--- a/testsuite/escript/classes/scopes-05.out
+++ b/testsuite/escript/classes/scopes-05.out
@@ -5,5 +5,4 @@ A::A this=<class B> arg0=argB
 A::A this=<class C> arg0=argC
 ----
 A::A this=<class D> arg0=argD
-A::A this=<class D> arg0=argD
 D::D this=<class D> this.arg0=argD

--- a/testsuite/escript/classes/scopes-05.out
+++ b/testsuite/escript/classes/scopes-05.out
@@ -1,0 +1,4 @@
+A::A this=<class A> arg0=arg0
+A::A this=<class B> arg0=arg0
+A::A this=<class C> arg0=arg0
+A::A this=<class D> arg0=super-arg0

--- a/testsuite/escript/classes/scopes-05.out
+++ b/testsuite/escript/classes/scopes-05.out
@@ -1,4 +1,9 @@
-A::A this=<class A> arg0=arg0
-A::A this=<class B> arg0=arg0
-A::A this=<class C> arg0=arg0
-A::A this=<class D> arg0=super-arg0
+A::A this=<class A> arg0=argA
+----
+A::A this=<class B> arg0=argB
+----
+A::A this=<class C> arg0=argC
+----
+A::A this=<class D> arg0=argD
+A::A this=<class D> arg0=argD
+D::D this=<class D> this.arg0=argD

--- a/testsuite/escript/classes/scopes-05.src
+++ b/testsuite/escript/classes/scopes-05.src
@@ -1,0 +1,31 @@
+// Can construct an object through its base-class ctor
+// TODO implement this
+
+class A()
+  function A( this )
+    print( $"A::A this={this}" );
+  endfunction
+  function Foo()
+  endfunction
+endclass
+
+class B(A)
+  function MethodB( this )
+    print( $"B::MethodB this={this}" );
+  endfunction
+endclass
+
+class C(A)
+  function MethodB( this )
+    print( $"C::MethodB this={this}" );
+  endfunction
+endclass
+
+class D(C, B)
+  function D( this )
+    //super();
+  endfunction
+endclass
+
+var a := A();
+var b := B();

--- a/testsuite/escript/classes/scopes-05.src
+++ b/testsuite/escript/classes/scopes-05.src
@@ -1,9 +1,8 @@
 // Can construct an object through its base-class ctor
-// TODO implement this
 
 class A()
-  function A( this )
-    print( $"A::A this={this}" );
+  function A( this, arg0 )
+    print( $"A::A this={this} arg0={arg0}" );
   endfunction
   function Foo()
   endfunction
@@ -23,9 +22,11 @@ endclass
 
 class D(C, B)
   function D( this )
-    //super();
+    super( "super-arg0" );
   endfunction
 endclass
 
-var a := A();
-var b := B();
+var a := A( "arg0" );
+var b := B( "arg0" );
+var c := C( "arg0" );
+var d := D();

--- a/testsuite/escript/classes/scopes-05.src
+++ b/testsuite/escript/classes/scopes-05.src
@@ -2,31 +2,30 @@
 
 class A()
   function A( this, arg0 )
+    this.arg0 := arg0;
     print( $"A::A this={this} arg0={arg0}" );
-  endfunction
-  function Foo()
   endfunction
 endclass
 
 class B(A)
-  function MethodB( this )
-    print( $"B::MethodB this={this}" );
-  endfunction
 endclass
 
 class C(A)
-  function MethodB( this )
-    print( $"C::MethodB this={this}" );
-  endfunction
 endclass
 
 class D(C, B)
   function D( this )
-    super( "super-arg0" );
+    super( "argD" );
+    print( $"D::D this={this} this.arg0={this.arg0}" );
   endfunction
 endclass
 
-var a := A( "arg0" );
-var b := B( "arg0" );
-var c := C( "arg0" );
+
+var a := A( "argA" );
+print( "----" );
+var b := B( "argB" );
+print( "----" );
+var c := C( "argC" );
+print( "----" );
 var d := D();
+


### PR DESCRIPTION
### Second-pass AST Generation Changes
- Uses polymorphism on `AvailableParseTree` (now renamed to `SecondPassTarget`) to split into AST building targets into ANTLR nodes (eg. building a user-defined function AST node via a `AvailableParseTree`) and generated functions (eg.  building a super() function via `AvailableGeneratedFunction`)
- Make generated functions have scoped function parameters, used to prevent duplicate function parameters being generated for super().
  - See PR comments for example of compiler-generated ctors and supers