### PR TITLE
Add semantic error on cyclic inheritance

### DIFF
--- a/testsuite/escript/classes/fail-self-base-inheritance.err
+++ b/testsuite/escript/classes/fail-self-base-inheritance.err
@@ -1,0 +1,1 @@
+fail-self-base-inheritance.src:10:1: error: Class 'Animal' references itself as a base class through inheritance.

--- a/testsuite/escript/classes/fail-self-base-inheritance.src
+++ b/testsuite/escript/classes/fail-self-base-inheritance.src
@@ -1,0 +1,14 @@
+// A class cannot reference itself as a base class.
+
+class BaseClass1(Animal)
+
+endclass
+
+class BaseClass2(BaseClass1)
+endclass
+
+class Animal(BaseClass2)
+  function Animal( this ) endfunction
+endclass
+
+Animal();


### PR DESCRIPTION
### Semantic Analysis changes
- Error if a child class references itself through cyclic inheritance, eg. `A` inherits `B`, `B` inherits `A`.