### PR TITLE
Add `BClassInstanceRef`; better error messages on bad method calls

### DIFF
--- a/pol-core/bscript/bclassinstance.cpp
+++ b/pol-core/bscript/bclassinstance.cpp
@@ -2,6 +2,7 @@
 
 #include "berror.h"
 #include "bobject.h"
+#include "clib/stlutil.h"
 #include "objmembers.h"
 #include "objmethods.h"
 
@@ -92,7 +93,8 @@ u8 BClassInstance::typeOfInt() const
 
 BObjectImp* BClassInstance::copy() const
 {
-  return new BClassInstance( *this );
+  passert_always_r( false, "BClassInstance::copy() should never be called" );
+  return nullptr;
 }
 
 bool BClassInstance::isTrue() const
@@ -144,5 +146,93 @@ std::string BClassInstance::getStringRep() const
 {
   auto class_name = prog_->symbols.array() + prog_->class_descriptors[index_].name_offset;
   return fmt::format( "<class {}>", class_name );
+}
+
+BClassInstanceRef::BClassInstanceRef( BClassInstance* inst )
+    : BObjectImp( BObjectType::OTClassInstanceRef ), class_instance_( inst )
+{
+}
+
+size_t BClassInstanceRef::sizeEstimate() const
+{
+  return sizeof( BClassInstanceRef ) + class_instance_->sizeEstimate();
+}
+const char* BClassInstanceRef::typeOf() const
+{
+  return class_instance_->typeOf();
+}
+u8 BClassInstanceRef::typeOfInt() const
+{
+  return class_instance_->typeOfInt();
+}
+
+BObjectImp* BClassInstanceRef::copy() const
+{
+  return new BClassInstanceRef( class_instance_.get() );
+}
+
+bool BClassInstanceRef::isTrue() const
+{
+  return true;
+}
+
+BObjectImp* BClassInstanceRef::call_method( const char* methodname, Executor& ex )
+{
+  return class_instance_->call_method( methodname, ex );
+}
+
+BObjectImp* BClassInstanceRef::call_method_id( const int id, Executor& ex, bool forcebuiltin )
+{
+  return class_instance_->call_method_id( id, ex, forcebuiltin );
+}
+
+BObjectRef BClassInstanceRef::get_member_id( const int id )
+{
+  return class_instance_->get_member_id( id );
+}
+
+std::string BClassInstanceRef::getStringRep() const
+{
+  return class_instance_->getStringRep();
+}
+
+ContIterator* BClassInstanceRef::createIterator( BObject* pIterVal )
+{
+  return class_instance_->createIterator( pIterVal );
+}
+
+BObjectRef BClassInstanceRef::OperSubscript( const BObject& obj )
+{
+  return class_instance_->OperSubscript( obj );
+}
+
+BObjectRef BClassInstanceRef::set_member( const char* membername, BObjectImp* value, bool copy )
+{
+  return class_instance_->set_member( membername, value, copy );
+}
+
+BObjectRef BClassInstanceRef::get_member( const char* membername )
+{
+  return class_instance_->get_member( membername );
+}
+
+BObjectRef BClassInstanceRef::operDotPlus( const char* name )
+{
+  return class_instance_->operDotPlus( name );
+}
+
+BObjectRef BClassInstanceRef::operDotMinus( const char* name )
+{
+  return class_instance_->operDotMinus( name );
+}
+
+BObjectRef BClassInstanceRef::operDotQMark( const char* name )
+{
+  return class_instance_->operDotQMark( name );
+}
+
+BObjectImp* BClassInstanceRef::array_assign( BObjectImp* idx, BObjectImp* target, bool copy )
+{
+  return class_instance_->array_assign( idx, target, copy );
 }
 }  // namespace Pol::Bscript

--- a/pol-core/bscript/bclassinstance.h
+++ b/pol-core/bscript/bclassinstance.h
@@ -17,8 +17,6 @@ public:
   BClassInstance( ref_ptr<EScriptProgram> program, int index,
                   std::shared_ptr<ValueStackCont> globals );
   BClassInstance( const BClassInstance& B );
-
-private:
   ~BClassInstance() = default;
 
 public:
@@ -28,7 +26,7 @@ public:
   // returns nullptr if no function found
   BFunctionRef* makeMethod( const char* method_name );
 
-// Inherited from BStruct
+  // Inherited from BStruct
   virtual const char* typetag() const override;
 
   std::set<unsigned> constructors_called;
@@ -53,5 +51,44 @@ private:
 public:
   std::shared_ptr<ValueStackCont> globals;
 };
+
+class BClassInstanceRef final : public BObjectImp
+{
+public:
+  BClassInstanceRef( BClassInstance* );
+
+private:
+  ~BClassInstanceRef() = default;
+
+public:  // Class Machinery
+  virtual size_t sizeEstimate() const override;
+  virtual const char* typeOf() const override;
+  virtual u8 typeOfInt() const override;
+  virtual BObjectImp* copy() const override;
+  virtual bool isTrue() const override;
+  virtual BObjectImp* call_method( const char* methodname, Executor& ex ) override;
+  virtual BObjectImp* call_method_id( const int id, Executor& ex,
+                                      bool forcebuiltin = false ) override;
+  virtual BObjectRef get_member_id( const int id ) override;
+
+  virtual std::string getStringRep() const override;
+
+  virtual ContIterator* createIterator( BObject* pIterVal ) override;
+
+  virtual BObjectRef OperSubscript( const BObject& obj ) override;
+  virtual BObjectRef set_member( const char* membername, BObjectImp* value, bool copy ) override;
+  virtual BObjectRef get_member( const char* membername ) override;
+  virtual BObjectRef operDotPlus( const char* name ) override;
+  virtual BObjectRef operDotMinus( const char* name ) override;
+  virtual BObjectRef operDotQMark( const char* name ) override;
+  virtual BObjectImp* array_assign( BObjectImp* idx, BObjectImp* target, bool copy ) override;
+
+  inline BClassInstance* instance() const { return class_instance_.get(); }
+
+
+private:
+  ref_ptr<BClassInstance> class_instance_;
+};
+
 
 }  // namespace Pol::Bscript

--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -65,6 +65,7 @@ class BDictionary;
 class BBoolean;
 class BFunctionRef;
 class BClassInstance;
+class BClassInstanceRef;
 class BContinuation;
 class BSpread;
 
@@ -129,12 +130,13 @@ public:
     OTFuncRef = 39,
     OTExportScript = 40,
     OTStorageArea = 41,
-    OTClassInstance = 42,
+    OTClassInstanceRef = 42,
 
     // Used internally only during executor runtime. Can be modified without
     // breaking compatibility.
     OTContinuation = 100,
     OTSpread = 101,
+    OTClassInstance = 102,
   };
 
 #if INLINE_BOBJECTIMP_CTOR
@@ -416,7 +418,9 @@ T* impptrIf( BObjectImp* objimp )
   impif_e( BObjectImp::OTStruct, BStruct );
   impif_e( BObjectImp::OTBoolean, BBoolean );
   impif_e( BObjectImp::OTFuncRef, BFunctionRef );
-  impif_e( BObjectImp::OTClassInstance, BClassInstance );
+  // BClassInstance objects are never given to scripts directly, so no need for
+  // inclusion here (so far...)
+  impif_e( BObjectImp::OTClassInstanceRef, BClassInstanceRef );
   impif_e( BObjectImp::OTContinuation, BContinuation );
   impif_e( BObjectImp::OTSpread, BSpread );
   else static_assert( always_false<T>::value, "unsupported type" );
@@ -432,7 +436,7 @@ public:
   explicit BObject( BObjectImp* objimp ) : ref_counted(), objimp( objimp ) { passert( objimp ); }
   BObject( const BObject& obj ) : ref_counted(), objimp( obj.objimp ) {}
   virtual ~BObject() = default;
-  BObject& operator=(const BObject&) = delete;
+  BObject& operator=( const BObject& ) = delete;
   size_t sizeEstimate() const;
 
   void* operator new( std::size_t len );
@@ -471,7 +475,6 @@ public:
 
 private:
   ref_ptr<BObjectImp> objimp;
-
 };
 
 class BConstObject : public BObject

--- a/pol-core/bscript/bstruct.h
+++ b/pol-core/bscript/bstruct.h
@@ -25,6 +25,7 @@ namespace Pol
 namespace Bscript
 {
 class ContIterator;
+class BClassInstanceRef;
 class Executor;
 }  // namespace Bscript
 }  // namespace Pol
@@ -82,6 +83,7 @@ protected:
   virtual BObjectImp* array_assign( BObjectImp* idx, BObjectImp* target, bool copy ) override;
 
   friend class BStructIterator;
+  friend class BClassInstanceRef;
 
 private:
   Contents contents_;

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2357,10 +2357,11 @@ bool BFunctionRef::operator==( const BObjectImp& /*objimp*/ ) const
 
 BObjectImp* BFunctionRef::selfIsObjImp( const BObjectImp& other ) const
 {
-  auto classinst = dynamic_cast<const BClassInstance*>( &other );
-  if ( !classinst )
+  auto classinstref = dynamic_cast<const BClassInstanceRef*>( &other );
+  if ( !classinstref )
     return new BBoolean( false );
 
+  auto classinst = classinstref->instance();
   if ( classinst->prog() != prog_ )
     return new BBoolean( false );
 

--- a/testsuite/escript/classes/method-bad-call.out
+++ b/testsuite/escript/classes/method-bad-call.out
@@ -1,0 +1,1 @@
+error{ errortext = "Invalid argument count: expected 2, got 1" }

--- a/testsuite/escript/classes/method-bad-call.src
+++ b/testsuite/escript/classes/method-bad-call.src
@@ -1,0 +1,11 @@
+class Foo()
+  function Foo( this )
+  endfunction
+
+  function method( this, arg0, arg1 := "defaulted" )
+    return "success";
+  endfunction
+endclass
+
+var obj := Foo();
+print( obj.method( "a0" ) );


### PR DESCRIPTION
### Add `BClassInstanceRef`
- As discussed in discord
- Only expose the `Ref` to escript, and pass all BObjectImp class machinery methods to the underlying BClassInstance ref

### Better error messages
- If a method function call was failing (eg. due to invalid number of parameters), it was going to `BClassInstance::call_method_id`, which has a default error message of "method not found". This was not correct, as the method exists, but the args were incorrect.
  - Changing the `callee` to the function reference and the method to `MTH_CALL` allows it go to to the function reference failure, which has "invalid parameter count" message