### PR TITLE
Fix `is` operator to work across executors

### DIFF
--- a/pol-core/bscript/bclassinstance.cpp
+++ b/pol-core/bscript/bclassinstance.cpp
@@ -12,6 +12,7 @@ BClassInstance::BClassInstance( ref_ptr<EScriptProgram> program, int index,
                                 std::shared_ptr<ValueStackCont> globals )
     : BStruct( OTClassInstance ), prog_( program ), index_( index ), globals( std::move( globals ) )
 {
+  passert( index_ < prog_->class_descriptors.size() );
 }
 
 BClassInstance::BClassInstance( const BClassInstance& B ) : BStruct( B, OTClassInstance )
@@ -109,18 +110,10 @@ BObjectRef BClassInstance::get_member_id( const int id )
 {
   if ( id == MBR_FUNCTION )
   {
-    if ( index_ < prog_->class_descriptors.size() )
-    {
-      const auto& constructors = prog_->class_descriptors.at( index_ ).constructors;
-      if ( !constructors.empty() )
-      {
-        auto funcref_index = constructors.front().function_reference_index;
-        if ( funcref_index < prog_->function_references.size() )
-        {
-          return BObjectRef( new BFunctionRef( prog_, funcref_index, globals, ValueStackCont{} ) );
-        }
-      }
-    }
+    const auto funcref_index =
+        prog_->class_descriptors.at( index_ ).constructor_function_reference_index;
+
+    return BObjectRef( new BFunctionRef( prog_, funcref_index, globals, ValueStackCont{} ) );
   }
 
   return base::get_member_id( id );

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.cpp
@@ -4,6 +4,7 @@
 #include "bscript/compiler/ast/ClassParameterList.h"
 #include "bscript/compiler/ast/NodeVisitor.h"
 #include "bscript/compiler/ast/UserFunction.h"
+#include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/model/ClassLink.h"
 #include "bscript/compiler/model/FunctionLink.h"
 
@@ -43,5 +44,10 @@ std::vector<std::reference_wrapper<ClassParameterDeclaration>> ClassDeclaration:
   child<ClassParameterList>( 0 ).get_children<ClassParameterDeclaration>( params );
 
   return params;
+}
+
+std::string ClassDeclaration::type_tag() const
+{
+  return fmt::format( "{}@{}", name, source_location.source_file_identifier->pathname );
 }
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/ast/ClassDeclaration.h
+++ b/pol-core/bscript/compiler/ast/ClassDeclaration.h
@@ -27,6 +27,7 @@ public:
   void accept( NodeVisitor& visitor ) override;
   void describe_to( std::string& ) const override;
   std::vector<std::reference_wrapper<ClassParameterDeclaration>> parameters();
+  std::string type_tag() const;
 
   const std::string name;
 

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.cpp
@@ -10,10 +10,12 @@ ClassDeclarationRegistrar::ClassDeclarationRegistrar() = default;
 
 
 void ClassDeclarationRegistrar::register_class(
-    unsigned class_name_offset, const std::vector<ConstructorDescriptor>& constructors,
+    unsigned class_name_offset, unsigned constructor_function_reference_index,
+    const std::vector<ConstructorDescriptor>& constructors,
     const std::vector<MethodDescriptor>& method_descriptors )
 {
-  descriptors.emplace_back( class_name_offset, constructors, method_descriptors );
+  descriptors.emplace_back( class_name_offset, constructor_function_reference_index, constructors,
+                            method_descriptors );
 }
 
 std::vector<ClassDescriptor> ClassDeclarationRegistrar::take_descriptors()

--- a/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
+++ b/pol-core/bscript/compiler/codegen/ClassDeclarationRegistrar.h
@@ -13,7 +13,7 @@ class ClassDeclarationRegistrar
 public:
   ClassDeclarationRegistrar();
 
-  void register_class( unsigned class_name_offset,
+  void register_class( unsigned class_name_offset, unsigned constructor_function_reference_index,
                        const std::vector<ConstructorDescriptor>& constructor_descriptors,
                        const std::vector<MethodDescriptor>& method_descriptors );
 

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -105,13 +105,10 @@ void InstructionEmitter::register_class_declaration(
     visited.insert( cd->name );
     report.debug( *cd, "Class {} with {} methods", cd->name, cd->methods.size() );
 
-    if ( cd->constructor_link )
+    if ( cd->constructor_link && cd->constructor_link->user_function() )
     {
-      if ( auto uf = cd->constructor_link->user_function() )
-      {
-        auto type_tag_offset = emit_data( cd->type_tag() );
-        constructor_descriptors.push_back( type_tag_offset );
-      }
+      auto type_tag_offset = emit_data( cd->type_tag() );
+      constructor_descriptors.push_back( type_tag_offset );
     }
 
     for ( const auto& [method, uf_link] : cd->methods )

--- a/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionEmitter.cpp
@@ -1,5 +1,6 @@
 #include "InstructionEmitter.h"
 
+#include <limits>
 #include <list>
 #include <set>
 
@@ -71,8 +72,30 @@ void InstructionEmitter::register_class_declaration(
 
   const auto& class_name = node.name;
   auto class_name_offset = this->emit_data( class_name );
+  unsigned constructor_function_reference_index = std::numeric_limits<unsigned>::max();
 
   report.debug( node, "Registering class: {}", node.name );
+
+  if ( node.constructor_link )
+  {
+    if ( auto uf = node.constructor_link->user_function() )
+    {
+      auto ctor_itr = user_function_labels.find( uf->scoped_name() );
+
+      if ( ctor_itr == user_function_labels.end() )
+      {
+        uf->internal_error(
+            fmt::format( "Constructor {} not found in user_function_labels", uf->scoped_name() ) );
+      }
+
+      function_reference_registrar.lookup_or_register_reference(
+          *uf, ctor_itr->second, constructor_function_reference_index );
+    }
+  }
+  if ( constructor_function_reference_index < std::numeric_limits<unsigned>::max() )
+    report.debug( node, " - Constructor at FuncRef index {}",
+                  constructor_function_reference_index );
+
   for ( auto itr = to_link.begin(); itr != to_link.end(); ++itr )
   {
     auto cd = *itr;
@@ -86,17 +109,8 @@ void InstructionEmitter::register_class_declaration(
     {
       if ( auto uf = cd->constructor_link->user_function() )
       {
-        auto ctor_itr = user_function_labels.find( uf->scoped_name() );
-        if ( ctor_itr == user_function_labels.end() )
-        {
-          report.debug( *cd, " - Constructor: {} PC=???", cd->name );
-          cd->internal_error(
-              fmt::format( "Constructor {} not found in user_function_labels", cd->name ) );
-        }
-        unsigned funcref_index;
-        function_reference_registrar.lookup_or_register_reference( *uf, ctor_itr->second,
-                                                                   funcref_index );
-        constructor_descriptors.push_back( funcref_index );
+        auto type_tag_offset = emit_data( cd->type_tag() );
+        constructor_descriptors.push_back( type_tag_offset );
       }
     }
 
@@ -154,7 +168,7 @@ void InstructionEmitter::register_class_declaration(
   for ( const auto& constructor : constructor_descriptors )
   {
     report.debug(
-        node, fmt::format( " - Constructor @ FuncRef={}", constructor.function_reference_index ) );
+        node, fmt::format( " - Constructor @ type_tag_offset={}", constructor.type_tag_offset ) );
   }
 
   for ( const auto& method_info : method_descriptors )
@@ -164,8 +178,9 @@ void InstructionEmitter::register_class_declaration(
                                      method_info.function_reference_index ) );
   }
 
-  class_declaration_registrar.register_class( class_name_offset, constructor_descriptors,
-                                              method_descriptors );
+  class_declaration_registrar.register_class( class_name_offset,
+                                              constructor_function_reference_index,
+                                              constructor_descriptors, method_descriptors );
 }
 
 unsigned InstructionEmitter::enter_debug_block(

--- a/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
+++ b/pol-core/bscript/compiler/format/CompiledScriptSerializer.cpp
@@ -144,6 +144,7 @@ void CompiledScriptSerializer::write( const std::string& pathname ) const
       // Handle class entry
       BSCRIPT_CLASS_TABLE_ENTRY bcte{};
       bcte.name_offset = elem.name_offset;
+      bcte.constructor_function_reference_index = elem.constructor_function_reference_index;
       bcte.constructor_count = static_cast<unsigned>( elem.constructors.size() );
       bcte.method_count = static_cast<unsigned>( elem.methods.size() );
       ofs.write( reinterpret_cast<const char*>( &bcte ), sizeof bcte );
@@ -152,7 +153,7 @@ void CompiledScriptSerializer::write( const std::string& pathname ) const
       for ( const auto& constructor : elem.constructors )
       {
         BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY bctce{};
-        bctce.function_reference_index = constructor.function_reference_index;
+        bctce.type_tag_offset = constructor.type_tag_offset;
         ofs.write( reinterpret_cast<const char*>( &bctce ), sizeof bctce );
       }
 

--- a/pol-core/bscript/compiler/format/DebugStoreSerializer.cpp
+++ b/pol-core/bscript/compiler/format/DebugStoreSerializer.cpp
@@ -168,10 +168,13 @@ void DebugStoreSerializer::write( std::ofstream& ofs, std::ofstream* text_ofs )
       // Handle constructors
       if ( !class_descriptor.constructors.empty() )
       {
-        *text_ofs << "    - Constructor chain (funcref idxs):";
+        *text_ofs << "    - Constructor chain (type tag offset):";
         for ( const auto& constructor : class_descriptor.constructors )
         {
-          *text_ofs << fmt::format( " {}", constructor.function_reference_index );
+          *text_ofs << fmt::format( "\n      - {} ({})",
+                                    reinterpret_cast<const char*>( compiled_script.data.data() +
+                                                                   constructor.type_tag_offset ),
+                                    constructor.type_tag_offset );
         }
         *text_ofs << std::endl;
       }

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.cpp
@@ -3,9 +3,11 @@
 namespace Pol::Bscript::Compiler
 {
 ClassDescriptor::ClassDescriptor( unsigned name_offset,
+                                  unsigned constructor_function_reference_index,
                                   std::vector<ConstructorDescriptor> constructors,
                                   std::vector<MethodDescriptor> methods )
     : name_offset( name_offset ),
+      constructor_function_reference_index( constructor_function_reference_index ),
       constructors( std::move( constructors ) ),
       methods( std::move( methods ) )
 {

--- a/pol-core/bscript/compiler/representation/ClassDescriptor.h
+++ b/pol-core/bscript/compiler/representation/ClassDescriptor.h
@@ -11,10 +11,12 @@ namespace Pol::Bscript::Compiler
 class ClassDescriptor
 {
 public:
-  ClassDescriptor( unsigned name_offset, std::vector<ConstructorDescriptor> constructors,
+  ClassDescriptor( unsigned name_offset, unsigned constructor_function_reference_index,
+                   std::vector<ConstructorDescriptor> constructors,
                    std::vector<MethodDescriptor> methods );
 
   const unsigned name_offset;
+  const unsigned constructor_function_reference_index;
   const std::vector<ConstructorDescriptor> constructors;
   const std::vector<MethodDescriptor> methods;
 };

--- a/pol-core/bscript/compiler/representation/ConstructorDescriptor.cpp
+++ b/pol-core/bscript/compiler/representation/ConstructorDescriptor.cpp
@@ -2,8 +2,8 @@
 
 namespace Pol::Bscript::Compiler
 {
-ConstructorDescriptor::ConstructorDescriptor( unsigned function_reference_index )
-    : function_reference_index( function_reference_index )
+ConstructorDescriptor::ConstructorDescriptor( unsigned type_tag_offset )
+    : type_tag_offset( type_tag_offset )
 {
 }
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/ConstructorDescriptor.h
+++ b/pol-core/bscript/compiler/representation/ConstructorDescriptor.h
@@ -5,8 +5,8 @@ namespace Pol::Bscript::Compiler
 class ConstructorDescriptor
 {
 public:
-  ConstructorDescriptor( unsigned function_reference_index );
+  ConstructorDescriptor( unsigned type_tag_offset );
 
-  const unsigned function_reference_index;
+  const unsigned type_tag_offset;
 };
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/eprog.h
+++ b/pol-core/bscript/eprog.h
@@ -106,14 +106,19 @@ struct EPMethodDescriptor
 {
   unsigned function_reference_index;
 };
+struct EPConstructorDescriptor
+{
+  unsigned type_tag_offset;
+};
 
-using EPConstructorList = std::vector<EPMethodDescriptor>;
+using EPConstructorList = std::vector<EPConstructorDescriptor>;
 
 using EPMethodMap = std::map<unsigned /* name_offset */, EPMethodDescriptor>;
 
 struct EPClassDescriptor
 {
   unsigned name_offset;
+  unsigned constructor_function_reference_index;
   EPConstructorList constructors;
   EPMethodMap methods;
 };

--- a/pol-core/bscript/eprog_read.cpp
+++ b/pol-core/bscript/eprog_read.cpp
@@ -474,7 +474,7 @@ int EScriptProgram::read_class_table( FILE* fp )
       BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY bctce;
       if ( fread( &bctce, sizeof bctce, 1, fp ) != 1 )
         return -1;
-      constructors.push_back( EPMethodDescriptor{ bctce.function_reference_index } );
+      constructors.push_back( EPConstructorDescriptor{ bctce.type_tag_offset } );
     }
 
     // Handle methods
@@ -489,7 +489,8 @@ int EScriptProgram::read_class_table( FILE* fp )
     }
 
     class_descriptors.push_back(
-        EPClassDescriptor{ bcte.name_offset, std::move( constructors ), std::move( methods ) } );
+        EPClassDescriptor{ bcte.name_offset, bcte.constructor_function_reference_index,
+                           std::move( constructors ), std::move( methods ) } );
   }
   return 0;
 }

--- a/pol-core/bscript/filefmt.h
+++ b/pol-core/bscript/filefmt.h
@@ -155,14 +155,15 @@ static_assert( sizeof( BSCRIPT_CLASS_TABLE ) == 4, "size missmatch" );
 struct BSCRIPT_CLASS_TABLE_ENTRY
 {
   unsigned name_offset;
+  unsigned constructor_function_reference_index;
   unsigned constructor_count;
   unsigned method_count;
 };
-static_assert( sizeof( BSCRIPT_CLASS_TABLE_ENTRY ) == 12, "size missmatch" );
+static_assert( sizeof( BSCRIPT_CLASS_TABLE_ENTRY ) == 16, "size missmatch" );
 
 struct BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY
 {
-  unsigned function_reference_index;
+  unsigned type_tag_offset;
 };
 static_assert( sizeof( BSCRIPT_CLASS_TABLE_CONSTRUCTOR_ENTRY ) == 4, "size missmatch" );
 

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2358,25 +2358,42 @@ BObjectImp* BFunctionRef::selfIsObjImp( const BObjectImp& other ) const
     return new BBoolean( false );
 
   auto classinst = classinstref->instance();
-  if ( classinst->prog() != prog_ )
+
+  // Class index could be maxint if the function reference is not a class
+  // method.
+  if ( class_index() >= prog_->class_descriptors.size() )
     return new BBoolean( false );
 
-  if ( classinst->index() > prog_->class_descriptors.size() )
-    return new BBoolean( false );
+  const auto& my_constructors = prog_->class_descriptors.at( class_index() ).constructors;
+  passert( !my_constructors.empty() );
+  const auto& my_descriptor = my_constructors.front();
 
-  // Find the address in the constructor addresses.
-  auto& addresses = prog_->class_descriptors[classinst->index()].constructors;
+  const auto& other_descriptors =
+      classinst->prog()->class_descriptors.at( classinst->index() ).constructors;
 
-  auto result =
-      std::find_if(
-          addresses.begin(), addresses.end(),
-          [this]( const EPMethodDescriptor& address )
-          {
-            return address.function_reference_index < prog_->function_references.size() &&
-                   prog_->function_references.at( address.function_reference_index ).address ==
-                       pc();
-          } ) != addresses.end();
-  return new BBoolean( result );
+  // An optimization for same program: since strings are never duplicated inside
+  // the data section, we can just check for offset equality.
+  if ( prog_ == classinst->prog() )
+  {
+    for ( const auto& other_descriptor : other_descriptors )
+    {
+      if ( my_descriptor.type_tag_offset == other_descriptor.type_tag_offset )
+        return new BBoolean( true );
+    }
+  }
+  // For different programs, we must check for string equality.
+  else
+  {
+    auto type_tag = prog_->symbols.array() + my_descriptor.type_tag_offset;
+    for ( const auto& other_descriptor : other_descriptors )
+    {
+      auto other_type_tag = classinst->prog()->symbols.array() + other_descriptor.type_tag_offset;
+      if ( strcmp( type_tag, other_type_tag ) == 0 )
+        return new BBoolean( true );
+    }
+  }
+
+  return new BBoolean( false );
 }
 
 std::string BFunctionRef::getStringRep() const

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2355,14 +2355,14 @@ BObjectImp* BFunctionRef::selfIsObjImp( const BObjectImp& other ) const
 {
   auto classinstref = dynamic_cast<const BClassInstanceRef*>( &other );
   if ( !classinstref )
-    return new BBoolean( false );
+    return new BLong( 0 );
 
   auto classinst = classinstref->instance();
 
   // Class index could be maxint if the function reference is not a class
   // method.
   if ( class_index() >= prog_->class_descriptors.size() )
-    return new BBoolean( false );
+    return new BLong( 0 );
 
   const auto& my_constructors = prog_->class_descriptors.at( class_index() ).constructors;
   passert( !my_constructors.empty() );
@@ -2378,7 +2378,7 @@ BObjectImp* BFunctionRef::selfIsObjImp( const BObjectImp& other ) const
     for ( const auto& other_descriptor : other_descriptors )
     {
       if ( my_descriptor.type_tag_offset == other_descriptor.type_tag_offset )
-        return new BBoolean( true );
+        return new BLong( 1 );
     }
   }
   // For different programs, we must check for string equality.
@@ -2389,11 +2389,11 @@ BObjectImp* BFunctionRef::selfIsObjImp( const BObjectImp& other ) const
     {
       auto other_type_tag = classinst->prog()->symbols.array() + other_descriptor.type_tag_offset;
       if ( strcmp( type_tag, other_type_tag ) == 0 )
-        return new BBoolean( true );
+        return new BLong( 1 );
     }
   }
 
-  return new BBoolean( false );
+  return new BLong( 0 );
 }
 
 std::string BFunctionRef::getStringRep() const

--- a/testsuite/escript/classes/classinst-is.out
+++ b/testsuite/escript/classes/classinst-is.out
@@ -1,14 +1,14 @@
-true
-true
-true
-true
-false
+1
+1
+1
+1
+0
 --
-true
-true
-true
-false
-true
+1
+1
+1
+0
+1
 ----
 d is A = 1 ; e is A = 1
 d is B = 1 ; e is B = 1
@@ -16,5 +16,5 @@ d is C = 1 ; e is C = 1
 d is D = 1 ; e is D = 0
 d is E = 0 ; e is E = 1
 ----
-false
-false
+0
+0

--- a/testsuite/pol/testpkgs/funcref/check-class-is.src
+++ b/testsuite/pol/testpkgs/funcref/check-class-is.src
@@ -1,0 +1,13 @@
+include "class-def";
+
+program checkclass( foo )
+    var res := {
+        foo is @A,
+        foo is @B,
+        foo is @C,
+        foo is @D,
+        foo is @E
+    };
+
+    return res;
+endprogram

--- a/testsuite/pol/testpkgs/funcref/class-def.inc
+++ b/testsuite/pol/testpkgs/funcref/class-def.inc
@@ -1,0 +1,28 @@
+class A()
+  function A( this )
+  endfunction
+endclass
+
+class B( A )
+  function B( this )
+    super();
+  endfunction
+endclass
+
+class C( A )
+  function C( this )
+    super();
+  endfunction
+endclass
+
+class D( B, C )
+  function D( this )
+    super();
+  endfunction
+endclass
+
+class E( B, C )
+  function E( this )
+    super();
+  endfunction
+endclass

--- a/testsuite/pol/testpkgs/funcref/set-class-member.src
+++ b/testsuite/pol/testpkgs/funcref/set-class-member.src
@@ -1,0 +1,5 @@
+include "class-def";
+
+program checkclass( foo )
+    foo.set_from_script := 1;
+endprogram

--- a/testsuite/pol/testpkgs/funcref/test_class.src
+++ b/testsuite/pol/testpkgs/funcref/test_class.src
@@ -12,11 +12,11 @@ exported function test_class_is()
   var res := {};
 
   var expected := {
-    { true, false, false, false, false },
-    { true, true, false, false, false },
-    { true, false, true, false, false },
-    { true, true, true, true, false },
-    { true, true, true, false, true }
+    { 1, 0, 0, 0, 0 },
+    { 1, 1, 0, 0, 0 },
+    { 1, 0, 1, 0, 0 },
+    { 1, 1, 1, 1, 0 },
+    { 1, 1, 1, 0, 1 }
   };
 
   foreach obj in objs

--- a/testsuite/pol/testpkgs/funcref/test_class.src
+++ b/testsuite/pol/testpkgs/funcref/test_class.src
@@ -1,0 +1,41 @@
+use os;
+
+include "testutil";
+include "class-def";
+
+program setup()
+  return 1;
+endprogram
+
+exported function test_class_is()
+  var objs := { A(), B(), C(), D(), E() };
+  var res := {};
+
+  var expected := {
+    { true, false, false, false, false },
+    { true, true, false, false, false },
+    { true, false, true, false, false },
+    { true, true, true, true, false },
+    { true, true, true, false, true }
+  };
+
+  foreach obj in objs
+    res.append( run_script_to_completion( ":testfuncref:check-class-is", obj ) );
+  endforeach
+
+  return ret_error_not_equal( res, expected, $"Unexpected aggegate, expected {expected} got {res}" );
+endfunction
+
+exported function test_set_class_members()
+  var obj := A();
+  obj.set_from_test := 1;
+  var res := run_script_to_completion( ":testfuncref:set-class-member", obj );
+
+  if (obj.set_from_script != 1)
+    return ret_error( $"Unexpected obj.set_from_script: expected 1, got {obj.set_from_script}" );
+  elseif (obj.set_from_test != 1)
+    return ret_error( $"Unexpected obj.set_from_test: expected 1, got {obj.set_from_test}" );
+  endif
+
+  return 1;
+endfunction


### PR DESCRIPTION
### Function Table changes
- Replace list of "constructor address/PC" with a list of "type tag offsets": data strings in the ECL program.
  - A type tag is defined as `<class name>@<source file>`, method added to `ClassInstance` AST node.
- Add a single, scalar "constructor address/PC" for _this specific_ class.
  - Needed for BClassInstance get-member MBR_FUNCTION
 
### Fix `is` operator
- The `classInstance is funcref` will check if `classInstance`'s type tag exists in the list of type tags for `funcref`.