### PR TITLE
fixed missing space when packing funcrefs

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>09-12-2024</datemodified>
+		<datemodified>09-27-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>09-27-2024</date>
+			<author>Turley:</author>
+			<change type="Fixed">EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs</change>
+		</entry>
 		<entry>
 			<date>09-12-2024</date>
 			<author>Turley:</author>

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -130,6 +130,9 @@ void Compiler::compile_file_steps( const std::string& pathname, Report& report )
 
 bool Compiler::format_file( const std::string& filename, bool is_module, bool inplace )
 {
+  if ( !Clib::filesize( filename.c_str() ) )
+    return true;
+
   Report report( false, true );
   PrettifyBuilder prettify_builder( profile, report );
   auto formatted = prettify_builder.build( filename, is_module );

--- a/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
@@ -130,6 +130,11 @@ std::string PrettifyFileProcessor::prettify() const
   auto result =
       fmt::format( "{}", fmt::join( linebuilder.formattedLines(),
                                     compilercfg.FormatterWindowsLineEndings ? "\r\n" : "\n" ) );
+  if ( result.empty() )
+  {
+    report.error( source_file_identifier, "formatting result is empty" );
+    return {};
+  }
   if ( compilercfg.FormatterInsertNewlineAtEOF && !result.empty() && result.back() != '\n' )
     result += compilercfg.FormatterWindowsLineEndings ? "\r\n" : "\n";
   return result;

--- a/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyFileProcessor.cpp
@@ -10,7 +10,9 @@
 #include "clib/logfacility.h"
 
 #include <algorithm>
+#include <any>
 #include <iostream>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -148,9 +150,8 @@ antlrcpp::Any PrettifyFileProcessor::visitVarStatement( EscriptParser::VarStatem
 antlrcpp::Any PrettifyFileProcessor::visitParExpression( EscriptParser::ParExpressionContext* ctx )
 {
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle() & ~FmtToken::ATTACHED );
-  auto curcount = linebuilder.currentTokens().size();
-  visitExpression( ctx->expression() );
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+  auto args = std::any_cast<bool>( visitExpression( ctx->expression() ) );
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   return {};
 }
 
@@ -317,14 +318,15 @@ antlrcpp::Any PrettifyFileProcessor::visitArrayInitializer(
     addToken( "(", lparen, linebuilder.openingParenthesisStyle() );
   ++_currentgroup;
   size_t curcount = linebuilder.currentTokens().size();
+  bool args = false;
   if ( auto expr = ctx->expressionList() )
-    visitExpressionList( expr );
+    args = std::any_cast<bool>( visitExpressionList( expr ) );
   --_currentgroup;
 
   if ( auto rbrace = ctx->RBRACE() )
     addToken( "}", rbrace, linebuilder.closingBracketStyle( curcount ) );
   else if ( auto rparen = ctx->RPAREN() )
-    addToken( ")", rparen, linebuilder.closingParenthesisStyle( curcount ) );
+    addToken( ")", rparen, linebuilder.closingParenthesisStyle( args ) );
   return {};
 }
 
@@ -459,7 +461,7 @@ antlrcpp::Any PrettifyFileProcessor::visitExpressionList(
     if ( i < args.size() - 1 )
       addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
-  return {};
+  return !args.empty();
 }
 
 antlrcpp::Any PrettifyFileProcessor::visitIndexList( EscriptParser::IndexListContext* ctx )
@@ -477,17 +479,22 @@ antlrcpp::Any PrettifyFileProcessor::visitIndexList( EscriptParser::IndexListCon
 antlrcpp::Any PrettifyFileProcessor::visitExpression( EscriptParser::ExpressionContext* ctx )
 {
   if ( auto prim = ctx->primary() )
+  {
     visitPrimary( prim );
+    return true;
+  }
   else if ( ctx->prefix )
   {
     addToken( ctx->prefix->getText(), ctx->prefix,
               ctx->prefix->getType() == EscriptLexer::BANG_B ? FmtToken::SPACE : FmtToken::NONE );
     visitExpression( ctx->expression( 0 ) );
+    return true;
   }
   else if ( ctx->postfix )
   {
     visitExpression( ctx->expression( 0 ) );
     addToken( ctx->postfix->getText(), ctx->postfix, FmtToken::SPACE | FmtToken::ATTACHED );
+    return true;
   }
   else if ( ctx->bop && ctx->expression().size() == 2 )
   {
@@ -551,10 +558,12 @@ antlrcpp::Any PrettifyFileProcessor::visitExpression( EscriptParser::ExpressionC
     addToken( ctx->bop->getText(), ctx->bop, style );
 
     visitExpression( ctx->expression( 1 ) );  // right
+    return true;
   }
   else if ( auto suffix = ctx->expressionSuffix() )
   {
     expression_suffix( ctx->expression( 0 ), suffix );
+    return true;
   }
   else if ( ctx->QUESTION() )
   {
@@ -564,9 +573,10 @@ antlrcpp::Any PrettifyFileProcessor::visitExpression( EscriptParser::ExpressionC
     addToken( ":", ctx->COLON(), FmtToken::SPACE | FmtToken::BREAKPOINT );
 
     visitExpression( ctx->expression( 2 ) );  // alternate
+    return true;
   }
 
-  return {};
+  return false;
 }
 
 antlrcpp::Any PrettifyFileProcessor::expression_suffix(
@@ -595,19 +605,19 @@ antlrcpp::Any PrettifyFileProcessor::expression_suffix(
     addToken( ".", method->DOT(), FmtToken::ATTACHED );
     make_identifier( method->IDENTIFIER() );
     addToken( "(", method->LPAREN(), linebuilder.openingParenthesisStyle() );
-    size_t curcount = linebuilder.currentTokens().size();
+    bool args = false;
     if ( auto expr = method->expressionList() )
-      visitExpressionList( expr );
-    addToken( ")", method->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+      args = std::any_cast<bool>( visitExpressionList( expr ) );
+    addToken( ")", method->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   }
   else if ( auto function_call = expr_suffix_ctx->functionCallSuffix() )
   {
     visitExpression( expr_ctx );
     addToken( "(", function_call->LPAREN(), linebuilder.openingParenthesisStyle() );
-    size_t curcount = linebuilder.currentTokens().size();
+    bool args = false;
     if ( auto expr = function_call->expressionList() )
-      visitExpressionList( expr );
-    addToken( ")", function_call->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+      args = std::any_cast<bool>( visitExpressionList( expr ) );
+    addToken( ")", function_call->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   }
   return {};
 }
@@ -693,11 +703,11 @@ antlrcpp::Any PrettifyFileProcessor::visitFunctionCall( EscriptParser::FunctionC
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle(),
             FmtContext::PREFERRED_BREAK_START );
 
-  size_t curcount = linebuilder.currentTokens().size();
+  bool argcount = false;
   if ( auto args = ctx->expressionList() )
-    visitExpressionList( args );
+    argcount = std::any_cast<bool>( visitExpressionList( args ) );
 
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ),
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( argcount ),
             FmtContext::PREFERRED_BREAK_END );
   _currentscope &= ~FmtToken::Scope::FUNCTION;
   return {};
@@ -724,11 +734,11 @@ antlrcpp::Any PrettifyFileProcessor::visitFunctionParameters(
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle(),
             FmtContext::PREFERRED_BREAK_START );
 
-  size_t curcount = linebuilder.currentTokens().size();
+  bool argcount = false;
   if ( auto args = ctx->functionParameterList() )
-    visitFunctionParameterList( args );
+    argcount = std::any_cast<bool>( visitFunctionParameterList( args ) );
 
-  auto closingstyle = linebuilder.closingParenthesisStyle( curcount );
+  auto closingstyle = linebuilder.closingParenthesisStyle( argcount );
   if ( _suppressnewline )  // add space if newline is suppressed
     closingstyle |= FmtToken::SPACE;
   addToken( ")", ctx->RPAREN(), closingstyle, FmtContext::PREFERRED_BREAK_END );
@@ -747,7 +757,7 @@ antlrcpp::Any PrettifyFileProcessor::visitFunctionParameterList(
     if ( i < params.size() - 1 )
       addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
-  return {};
+  return !params.empty();
 }
 
 antlrcpp::Any PrettifyFileProcessor::visitFunctionParameter(
@@ -825,9 +835,8 @@ antlrcpp::Any PrettifyFileProcessor::visitCaseStatement( EscriptParser::CaseStat
   make_statement_label( ctx->statementLabel() );
   addToken( "case", ctx->CASE(), FmtToken::SPACE | FmtToken::BREAKPOINT );
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle() & ~FmtToken::ATTACHED );
-  auto curcount = linebuilder.currentTokens().size();
-  visitExpression( ctx->expression() );
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+  auto args = std::any_cast<bool>( visitExpression( ctx->expression() ) );
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   linebuilder.buildLine( _currindent );
   ++_currindent;
   size_t start = linebuilder.formattedLines().size();
@@ -873,13 +882,12 @@ antlrcpp::Any PrettifyFileProcessor::visitCstyleForStatement(
     EscriptParser::CstyleForStatementContext* ctx )
 {
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle() & ~FmtToken::ATTACHED );
-  auto curcount = linebuilder.currentTokens().size();
   visitExpression( ctx->expression( 0 ) );
   addToken( ";", ctx->SEMI( 0 ), linebuilder.delimiterStyle() );
   visitExpression( ctx->expression( 1 ) );
   addToken( ";", ctx->SEMI( 1 ), linebuilder.delimiterStyle() );
   visitExpression( ctx->expression( 2 ) );
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( true ) );
   linebuilder.buildLine( _currindent );
 
   visitBlock( ctx->block() );
@@ -1102,11 +1110,11 @@ antlrcpp::Any PrettifyFileProcessor::visitModuleFunctionDeclaration(
 {
   make_identifier( ctx->IDENTIFIER() );
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle() );
-  size_t curcount = linebuilder.currentTokens().size();
+  bool args = false;
   if ( auto moduleFunctionParameterList = ctx->moduleFunctionParameterList() )
-    visitModuleFunctionParameterList( moduleFunctionParameterList );
+    args = std::any_cast<bool>( visitModuleFunctionParameterList( moduleFunctionParameterList ) );
 
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   addToken( ";", ctx->SEMI(), linebuilder.terminatorStyle() );
   linebuilder.buildLine( _currindent );
   return {};
@@ -1122,7 +1130,7 @@ antlrcpp::Any PrettifyFileProcessor::visitModuleFunctionParameterList(
     if ( i < params.size() - 1 )
       addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
-  return {};
+  return !params.empty();
 }
 
 antlrcpp::Any PrettifyFileProcessor::visitModuleFunctionParameter(
@@ -1193,7 +1201,7 @@ antlrcpp::Any PrettifyFileProcessor::visitProgramParameterList(
     if ( i < params.size() - 1 && ctx->COMMA( i ) )
       addToken( ",", ctx->COMMA( i ), linebuilder.delimiterStyle() | FmtToken::PREFERRED_BREAK );
   }
-  return {};
+  return !params.empty();
 }
 
 antlrcpp::Any PrettifyFileProcessor::visitProgramParameters(
@@ -1201,11 +1209,11 @@ antlrcpp::Any PrettifyFileProcessor::visitProgramParameters(
 {
   addToken( "(", ctx->LPAREN(), linebuilder.openingParenthesisStyle() );
 
-  size_t curcount = linebuilder.currentTokens().size();
+  bool args = false;
   if ( auto programParameterList = ctx->programParameterList() )
-    visitProgramParameterList( programParameterList );
+    args = std::any_cast<bool>( visitProgramParameterList( programParameterList ) );
 
-  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( curcount ) );
+  addToken( ")", ctx->RPAREN(), linebuilder.closingParenthesisStyle( args ) );
   return {};
 }
 

--- a/pol-core/bscript/compiler/file/PrettifyLineBuilder.cpp
+++ b/pol-core/bscript/compiler/file/PrettifyLineBuilder.cpp
@@ -691,7 +691,10 @@ std::vector<std::string> PrettifyLineBuilder::createBasedOnGroups(
     else  // same group
     {
       // only if we already had a different group split the line
-      if ( groupdiffered )
+      bool closing = false;
+      if ( !part.text.empty() )
+        closing = part.text[0] == ')';  // shouldnt force a new line
+      if ( groupdiffered && !closing )
       {
         newline = false;
         stripline( line );
@@ -702,7 +705,7 @@ std::vector<std::string> PrettifyLineBuilder::createBasedOnGroups(
       }
       line += part.text;
 #ifdef DEBUG_FORMAT_BREAK
-      INFO_PRINTLN( "same {} - {}", line, alignmentspace );
+      INFO_PRINTLN( "same {} - {} {} {}", line, alignmentspace, groupdiffered, part.text );
 #endif
       if ( line.size() > compilercfg.FormatterLineWidth )
       {

--- a/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
+++ b/pol-core/bscript/compiler/file/PrettifyLineBuilder.h
@@ -114,7 +114,7 @@ public:
   bool finalize();
   const std::vector<FmtToken>& currentTokens() const;
 
-  int closingParenthesisStyle( size_t begin_size );
+  int closingParenthesisStyle( bool args );
   int closingBracketStyle( size_t begin_size );
   int openingParenthesisStyle() const;
   int openingBracketStyle( bool typeinit = false ) const;
@@ -154,7 +154,7 @@ private:
   void stripline( std::string& line ) const;
 
   std::vector<FmtToken> buildLineSplits();
-  std::vector<std::string> createBasedOnGroups( const std::vector<FmtToken>& lines ) const;
+  std::vector<std::string> createBasedOnGroups( std::vector<FmtToken>& lines ) const;
   std::vector<std::string> createBasedOnPreferredBreaks( const std::vector<FmtToken>& lines,
                                                          bool logical ) const;
   std::vector<std::string> createSimple( const std::vector<FmtToken>& lines ) const;
@@ -162,7 +162,8 @@ private:
   bool binPack( const FmtToken& part, std::string line, size_t index, size_t upto,
                 const std::vector<FmtToken>& lines, bool only_single_line,
                 std::vector<std::string>* finallines, std::map<size_t, size_t>* alignmentspace,
-                size_t* skipindex, const std::map<size_t, size_t>& initial_alignmentspace ) const;
+                size_t* skipindex, const std::map<size_t, size_t>& initial_alignmentspace,
+                std::string& newpart ) const;
   void alignComments( std::vector<std::string>& finallines );
   void packLines();
 };

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+09-27-2024 Turley:
+    Fixed: EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs
 09-12-2024 Turley:
     Fixed: multiple problems with the EScript formatter
     Added: more ecompile.cfg options for the formatter, see ecompile.cfg.example for details

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -1082,7 +1082,7 @@ void AutoCompile()
   // Load and analyze the package structure
   for ( const auto& elem : compilercfg.PackageRoot )
   {
-    Plib::load_packages( elem, false /* quiet */ );
+    Plib::load_packages( elem, true /* quiet */ );
   }
   Plib::replace_packages();
   Plib::check_package_deps();


### PR DESCRIPTION
pack functioncall during group formatting without forcing a newline
preventing something like this:
```
struct{ "b" := B(
        1 ),
        "c some very long token so that the struct cannot be all one one line yes please" };
```
```B( 1 ),``` is now in a single line