### PR TITLE
Configurable visual range

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -992,7 +992,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [ShowWarningItem=(1/0 {default 1})]
 [ShowWarningCursorSequence=(1/0 {default 1})]
 [AllowedEnvironmentVariablesAccess=(string {default ""})]
-[VisualRange=(byte {default 18})]
+[DefaultVisualRange=(byte {default 18})]
 [EnableColoredOutput=(1/0 {default 1})]
 </structure>
     <explain>Your own pol.cfg should give descriptions on most of these. I'll describe them here if people want me to.</explain>
@@ -1015,7 +1015,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
     <explain>MaxTileID: maximum tile id. If 0, it will be chosen according to the graphics in tiles.cfg.</explain>
     <explain>DebugPort: TCP/IP port to listen for debugger connections.</explain>
     <explain>DAPDebugPort: TCP/IP port to listen for debugger connections using the DAP implementation.</explain>
-    <explain>VisualRange: distance at which player can see information around his surroundings. Keep in mind this value needs to be same as client as there are assumptions made based on it whether client can still see an object or not as client will automatically remove objects out of its configured range.</explain>
+    <explain>DefaultVisualRange: distance at which player can see information around his surroundings. Keep in mind this value needs to be same as client as there are assumptions made based on it whether client can still see an object or not as client will automatically remove objects out of its configured range.</explain>
 </cfgfile>
 
 

--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -992,6 +992,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [ShowWarningItem=(1/0 {default 1})]
 [ShowWarningCursorSequence=(1/0 {default 1})]
 [AllowedEnvironmentVariablesAccess=(string {default ""})]
+[VisualRange=(byte {default 18})]
 [EnableColoredOutput=(1/0 {default 1})]
 </structure>
     <explain>Your own pol.cfg should give descriptions on most of these. I'll describe them here if people want me to.</explain>
@@ -1014,6 +1015,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
     <explain>MaxTileID: maximum tile id. If 0, it will be chosen according to the graphics in tiles.cfg.</explain>
     <explain>DebugPort: TCP/IP port to listen for debugger connections.</explain>
     <explain>DAPDebugPort: TCP/IP port to listen for debugger connections using the DAP implementation.</explain>
+    <explain>VisualRange: distance at which player can see information around his surroundings. Keep in mind this value needs to be same as client as there are assumptions made based on it whether client can still see an object or not as client will automatically remove objects out of its configured range.</explain>
 </cfgfile>
 
 

--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -372,6 +372,7 @@ Spell (int spellid)
 [EditServer                     (0/1 {default 0})]
 [CarryingCapacityMod            (double {default 1.0})]
 [SpeechRange                    (int range {default 12})]
+[DefaultVisualRange             (byte {default 18})]
 [WhisperRange                   (int range {default 2})]
 [YellRange                      (int range {default 25})]
 [CoreSendsSeason                (0/1 {default 1})]
@@ -419,6 +420,7 @@ Spell (int spellid)
   <explain><i>UseContainerSlots:</i> check to can add bulk code to ensure not going over max slot capacity of 255 and a container's max slot capacity.</explain>
   <explain><i>EditServer:</i> for bypassing cryptseed packet</explain>
   <explain><i>CarryingCapacityMod:</i> * modifier for mobile max_weight</explain>
+  <explain><i>DefaultVisualRange:</i> default distance at which player can see information around his surroundings. Keep in mind this value needs to be same as client as there are assumptions made based on it whether client can still see an object or not as client will automatically remove objects out of its configured range.</explain>
   <explain><i>SpeechRange:</i> definies the range of normal speech</explain>
   <explain><i>WhisperRange:</i> definies the range of whispered speech</explain>
   <explain><i>YellRange:</i> definies the range of yelled speech</explain>
@@ -992,7 +994,6 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [ShowWarningItem=(1/0 {default 1})]
 [ShowWarningCursorSequence=(1/0 {default 1})]
 [AllowedEnvironmentVariablesAccess=(string {default ""})]
-[DefaultVisualRange=(byte {default 18})]
 [EnableColoredOutput=(1/0 {default 1})]
 </structure>
     <explain>Your own pol.cfg should give descriptions on most of these. I'll describe them here if people want me to.</explain>
@@ -1015,7 +1016,6 @@ PidFilePath=(where POL will write its .pid file {default ./})
     <explain>MaxTileID: maximum tile id. If 0, it will be chosen according to the graphics in tiles.cfg.</explain>
     <explain>DebugPort: TCP/IP port to listen for debugger connections.</explain>
     <explain>DAPDebugPort: TCP/IP port to listen for debugger connections using the DAP implementation.</explain>
-    <explain>DefaultVisualRange: distance at which player can see information around his surroundings. Keep in mind this value needs to be same as client as there are assumptions made based on it whether client can still see an object or not as client will automatically remove objects out of its configured range.</explain>
 </cfgfile>
 
 

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,8 +8,8 @@
 		<entry>
 			<date>10-19-2024</date>
 			<author>Kukkino:</author>
-			<change type="Added">DefaultVisualRange setting to pol.cfg. This setting declares how far clients can see by default. Note that the same<br/>
-value needs to be set on both server and in client (usually 18 or 21).</change>
+			<change type="Added">DefaultVisualRange setting to servspecopt.cfg. This setting declares how far clients can see by default.<br/>
+Note that the same value needs to be set on both server and in client (usually 18 or 21).</change>
 		</entry>
 		<entry>
 			<date>10-18-2024</date>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -55,6 +55,12 @@ See the Racalac Escript Guide for additional details.</change>
 			<change type="Fixed">EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs</change>
 		</entry>
 		<entry>
+			<date>09-16-2024</date>
+			<author>Kukkino:</author>
+			<change type="Added">VisualRange setting to pol.cfg. This setting declares how far clients can see. Note that the same<br/>
+value needs to be set on both server and in client (usually 18 or 21).</change>
+		</entry>
+		<entry>
 			<date>09-12-2024</date>
 			<author>Turley:</author>
 			<change type="Fixed">multiple problems with the EScript formatter</change>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>10-17-2024</datemodified>
+		<datemodified>10-19-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>10-19-2024</date>
+			<author>Kukkino:</author>
+			<change type="Added">DefaultVisualRange setting to pol.cfg. This setting declares how far clients can see by default. Note that the same<br/>
+value needs to be set on both server and in client (usually 18 or 21).</change>
+		</entry>
 		<entry>
 			<date>10-18-2024</date>
 			<author>Kevin:</author>
@@ -53,12 +59,6 @@ See the Racalac Escript Guide for additional details.</change>
 			<date>09-27-2024</date>
 			<author>Turley:</author>
 			<change type="Fixed">EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs</change>
-		</entry>
-		<entry>
-			<date>09-16-2024</date>
-			<author>Kukkino:</author>
-			<change type="Added">VisualRange setting to pol.cfg. This setting declares how far clients can see. Note that the same<br/>
-value needs to be set on both server and in client (usually 18 or 21).</change>
 		</entry>
 		<entry>
 			<date>09-12-2024</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,7 +1,7 @@
 -- POL100.2.0 --
 10-19-2024 Kukkino:
-    Added: DefaultVisualRange setting to pol.cfg. This setting declares how far clients can see by default. Note that the same
-           value needs to be set on both server and in client (usually 18 or 21).
+    Added: DefaultVisualRange setting to servspecopt.cfg. This setting declares how far clients can see by default.
+           Note that the same value needs to be set on both server and in client (usually 18 or 21).
 10-18-2024 Kevin:
     Fixed: Correctly declare parameters in generated super() function as used.
     Fixed: Correctly handle case insensitivity with classes.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -34,6 +34,9 @@
            See the Racalac Escript Guide for additional details.
 09-27-2024 Turley:
     Fixed: EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs
+09-16-2024 Kukkino:
+    Added: VisualRange setting to pol.cfg. This setting declares how far clients can see. Note that the same
+           value needs to be set on both server and in client (usually 18 or 21).
 09-12-2024 Turley:
     Fixed: multiple problems with the EScript formatter
     Added: more ecompile.cfg options for the formatter, see ecompile.cfg.example for details

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.2.0 --
+10-19-2024 Kukkino:
+    Added: DefaultVisualRange setting to pol.cfg. This setting declares how far clients can see by default. Note that the same
+           value needs to be set on both server and in client (usually 18 or 21).
 10-18-2024 Kevin:
     Fixed: Correctly declare parameters in generated super() function as used.
     Fixed: Correctly handle case insensitivity with classes.
@@ -34,9 +37,6 @@
            See the Racalac Escript Guide for additional details.
 09-27-2024 Turley:
     Fixed: EScript formatter missing spaces while packing function refs, better packing of function calls in eg structs
-09-16-2024 Kukkino:
-    Added: VisualRange setting to pol.cfg. This setting declares how far clients can see. Note that the same
-           value needs to be set on both server and in client (usually 18 or 21).
 09-12-2024 Turley:
     Fixed: multiple problems with the EScript formatter
     Added: more ecompile.cfg options for the formatter, see ecompile.cfg.example for details

--- a/pol-core/plib/uconst.h
+++ b/pol-core/plib/uconst.h
@@ -42,16 +42,6 @@ enum UTEXTTYPE : u8
 };
 
 
-/* how to validate these values (and how range checking works on the client):
-   tell the client about a character.  Take your character to the spot that
-   character is standing on.  Walk straight, 18 steps in any direction.  Run back
-   to the spot.  The character will still be there.  If you walk 19 steps, the
-   client automatically removes the object - the server doesn't need to tell it to.
-   Simple rectangular distance is used - if the x's differ by <= 18, and the y's differ
-   by <= 18, you're in range.  If either is out of range, you're out.
-   */
-constexpr u8 RANGE_VISUAL = 18;
-
 const unsigned VALID_ITEM_COLOR_MASK = 0x0FFF;
 
 

--- a/pol-core/pol/globals/uvars.cpp
+++ b/pol-core/pol/globals/uvars.cpp
@@ -171,8 +171,8 @@ GameState::GameState()
       uo_skills(),
       task_thread_pool(),
       decay(),
-      max_update_range( Plib::RANGE_VISUAL ),
-      max_update_range_client( Plib::RANGE_VISUAL ),
+      max_update_range( 0 ),
+      max_update_range_client( 0 ),
       max_update_range_multi( 0 )
 
 {
@@ -185,7 +185,11 @@ GameState::~GameState()
   // or make sure that the globals get deconstructed before eg the flyweight string container
 }
 
-
+void GameState::initialize_range_from_config( u16 range )
+{
+  max_update_range_client = range;
+  max_update_range = max_update_range_multi + max_update_range_client;
+}
 void GameState::update_range_from_multis()
 {
   for ( const auto& m_pair : Multi::multidef_buffer.multidefs_by_multiid )

--- a/pol-core/pol/globals/uvars.cpp
+++ b/pol-core/pol/globals/uvars.cpp
@@ -187,8 +187,11 @@ GameState::~GameState()
 
 void GameState::initialize_range_from_config( u16 range )
 {
-  max_update_range_client = range;
-  max_update_range = max_update_range_multi + max_update_range_client;
+  if ( range > max_update_range_client )
+  {
+    max_update_range_client = range;
+    max_update_range = max_update_range_multi + max_update_range_client;
+  }
 }
 void GameState::update_range_from_multis()
 {

--- a/pol-core/pol/globals/uvars.h
+++ b/pol-core/pol/globals/uvars.h
@@ -250,6 +250,7 @@ public:
 
   Decay decay;
 
+  void initialize_range_from_config( u16 range );
   void update_range_from_multis();
   void update_range_from_client( u16 range );
   u16 max_update_range;  // maximum update range (client view range/multi footprint) used as

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -472,7 +472,7 @@ void handle_update_range_change( Client* client, PKTBI_C8* msg )
 
   Network::PktHelper::PacketOut<Network::PktOut_C8> outMsg;
   // TODO Pos: send updated client->update_range()
-  outMsg->Write<u8>( Plib::systemstate.config.default_visual_range );
+  outMsg->Write<u8>( settingsManager.ssopt.default_visual_range );
   outMsg.Send( client );
 }
 

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -472,7 +472,7 @@ void handle_update_range_change( Client* client, PKTBI_C8* msg )
 
   Network::PktHelper::PacketOut<Network::PktOut_C8> outMsg;
   // TODO Pos: send updated client->update_range()
-  outMsg->Write<u8>( Plib::RANGE_VISUAL );
+  outMsg->Write<u8>( Plib::systemstate.config.visual_range );
   outMsg.Send( client );
 }
 

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -472,7 +472,7 @@ void handle_update_range_change( Client* client, PKTBI_C8* msg )
 
   Network::PktHelper::PacketOut<Network::PktOut_C8> outMsg;
   // TODO Pos: send updated client->update_range()
-  outMsg->Write<u8>( Plib::systemstate.config.visual_range );
+  outMsg->Write<u8>( Plib::systemstate.config.default_visual_range );
   outMsg.Send( client );
 }
 

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -4316,8 +4316,8 @@ void Character::send_buffs()
 u8 Character::los_size() const
 {
   // TODO Pos activate
-  return Plib::systemstate.config.default_visual_range;
-  //  return client ? client->update_range() : Plib::systemstate.config.default_visual_range;
+  return Core::settingsManager.ssopt.default_visual_range;
+  //  return client ? client->update_range() : Core::settingsManager.ssopt.default_visual_range;
 }
 
 size_t Character::estimatedSize() const

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -4316,8 +4316,8 @@ void Character::send_buffs()
 u8 Character::los_size() const
 {
   // TODO Pos activate
-  return Plib::RANGE_VISUAL;
-  //  return client ? client->update_range() : Plib::RANGE_VISUAL;
+  return Plib::systemstate.config.visual_range;
+  //  return client ? client->update_range() : Plib::systemstate.config.visual_range;
 }
 
 size_t Character::estimatedSize() const

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -4316,8 +4316,8 @@ void Character::send_buffs()
 u8 Character::los_size() const
 {
   // TODO Pos activate
-  return Plib::systemstate.config.visual_range;
-  //  return client ? client->update_range() : Plib::systemstate.config.visual_range;
+  return Plib::systemstate.config.default_visual_range;
+  //  return client ? client->update_range() : Plib::systemstate.config.default_visual_range;
 }
 
 size_t Character::estimatedSize() const

--- a/pol-core/pol/network/cgdata.cpp
+++ b/pol-core/pol/network/cgdata.cpp
@@ -50,7 +50,7 @@ ClientGameData::ClientGameData()
       lightlevel( 0 ),
       custom_house_serial( 0 ),
       custom_house_chrserial( 0 ),
-      update_range( Plib::systemstate.config.default_visual_range )
+      update_range( Core::settingsManager.ssopt.default_visual_range )
 {
 }
 

--- a/pol-core/pol/network/cgdata.cpp
+++ b/pol-core/pol/network/cgdata.cpp
@@ -19,6 +19,7 @@
 #include "../multi/customhouses.h"
 #include "../multi/house.h"
 #include "../multi/multi.h"
+#include "../plib/systemstate.h"
 #include "../target.h"
 #include "../uoexec.h"
 #include "pktin.h"
@@ -49,7 +50,7 @@ ClientGameData::ClientGameData()
       lightlevel( 0 ),
       custom_house_serial( 0 ),
       custom_house_chrserial( 0 ),
-      update_range( Plib::RANGE_VISUAL )
+      update_range( Plib::systemstate.config.visual_range )
 {
 }
 

--- a/pol-core/pol/network/cgdata.cpp
+++ b/pol-core/pol/network/cgdata.cpp
@@ -50,7 +50,7 @@ ClientGameData::ClientGameData()
       lightlevel( 0 ),
       custom_house_serial( 0 ),
       custom_house_chrserial( 0 ),
-      update_range( Plib::systemstate.config.visual_range )
+      update_range( Plib::systemstate.config.default_visual_range )
 {
 }
 

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -108,9 +108,9 @@ void PolConfig::read_pol_config( bool initial_load )
       gamestate.write_account_task->start();
     }
 
-    Plib::systemstate.config.visual_range = static_cast<u8>( elem.remove_int( "VisualRange", 18 ) );
+    Plib::systemstate.config.default_visual_range = static_cast<u8>( elem.remove_int( "DefaultVisualRange", 18 ) );
     // default value needs to be reset as the object is created before config is loaded
-    Core::gamestate.initialize_range_from_config( Plib::systemstate.config.visual_range );
+    Core::gamestate.initialize_range_from_config( Plib::systemstate.config.default_visual_range );
   }
   Plib::systemstate.config.verbose = elem.remove_bool( "Verbose", false );
   Plib::systemstate.config.watch_mapcache = elem.remove_bool( "WatchMapCache", false );

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -107,6 +107,10 @@ void PolConfig::read_pol_config( bool initial_load )
       gamestate.write_account_task->set_secs( Plib::systemstate.config.account_save );
       gamestate.write_account_task->start();
     }
+
+    Plib::systemstate.config.visual_range = static_cast<u8>( elem.remove_int( "VisualRange", 18 ) );
+    // default value needs to be reset as the object is created before config is loaded
+    Core::gamestate.initialize_range_from_config( Plib::systemstate.config.visual_range );
   }
   Plib::systemstate.config.verbose = elem.remove_bool( "Verbose", false );
   Plib::systemstate.config.watch_mapcache = elem.remove_bool( "WatchMapCache", false );

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -32,7 +32,8 @@
 #include "../plib/systemstate.h"
 #include "../plib/uoinstallfinder.h"
 // TODO: get rid of the dependencies and move to plib
-#include "core.h"           // todo save_full does not belong here
+#include "core.h"  // todo save_full does not belong here
+#include "globals/settings.h"
 #include "globals/state.h"  // todo polsig dependency
 #include "globals/uvars.h"  // todo split write task
 #include "objtype.h"
@@ -107,11 +108,6 @@ void PolConfig::read_pol_config( bool initial_load )
       gamestate.write_account_task->set_secs( Plib::systemstate.config.account_save );
       gamestate.write_account_task->start();
     }
-
-    Plib::systemstate.config.default_visual_range =
-        static_cast<u8>( elem.remove_int( "DefaultVisualRange", 18 ) );
-    // default value needs to be reset as the object is created before config is loaded
-    Core::gamestate.initialize_range_from_config( Plib::systemstate.config.default_visual_range );
   }
   Plib::systemstate.config.verbose = elem.remove_bool( "Verbose", false );
   Plib::systemstate.config.watch_mapcache = elem.remove_bool( "WatchMapCache", false );

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -108,7 +108,8 @@ void PolConfig::read_pol_config( bool initial_load )
       gamestate.write_account_task->start();
     }
 
-    Plib::systemstate.config.default_visual_range = static_cast<u8>( elem.remove_int( "DefaultVisualRange", 18 ) );
+    Plib::systemstate.config.default_visual_range =
+        static_cast<u8>( elem.remove_int( "DefaultVisualRange", 18 ) );
     // default value needs to be reset as the object is created before config is loaded
     Core::gamestate.initialize_range_from_config( Plib::systemstate.config.default_visual_range );
   }

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -124,7 +124,7 @@ struct PolConfig
      Simple rectangular distance is used - if the x's differ by <= 18, and the y's differ
      by <= 18, you're in range.  If either is out of range, you're out.
      */
-  std::uint8_t visual_range;
+  std::uint8_t default_visual_range;
 
   bool enable_colored_output;
 

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -116,6 +116,16 @@ struct PolConfig
 
   std::vector<std::string> allowed_environmentvariables_access;
 
+  /* how to validate these values (and how range checking works on the client):
+     tell the client about a character.  Take your character to the spot that
+     character is standing on.  Walk straight, 18 steps in any direction.  Run back
+     to the spot.  The character will still be there.  If you walk 19 steps, the
+     client automatically removes the object - the server doesn't need to tell it to.
+     Simple rectangular distance is used - if the x's differ by <= 18, and the y's differ
+     by <= 18, you're in range.  If either is out of range, you're out.
+     */
+  std::uint8_t visual_range;
+
   bool enable_colored_output;
 
   static void read_pol_config( bool initial_load );

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -116,16 +116,6 @@ struct PolConfig
 
   std::vector<std::string> allowed_environmentvariables_access;
 
-  /* how to validate these values (and how range checking works on the client):
-     tell the client about a character.  Take your character to the spot that
-     character is standing on.  Walk straight, 18 steps in any direction.  Run back
-     to the spot.  The character will still be there.  If you walk 19 steps, the
-     client automatically removes the object - the server doesn't need to tell it to.
-     Simple rectangular distance is used - if the x's differ by <= 18, and the y's differ
-     by <= 18, you're in range.  If either is out of range, you're out.
-     */
-  std::uint8_t default_visual_range;
-
   bool enable_colored_output;
 
   static void read_pol_config( bool initial_load );

--- a/pol-core/pol/ssopt.cpp
+++ b/pol-core/pol/ssopt.cpp
@@ -36,6 +36,7 @@
 #include "../clib/logfacility.h"
 #include "../clib/stlutil.h"
 #include "globals/settings.h"
+#include "globals/uvars.h"
 #include "network/pktdef.h"
 
 namespace Pol
@@ -101,6 +102,8 @@ void ServSpecOpt::read_servspecopt()
   settingsManager.ssopt.core_ignores_defence_caps =
       elem.remove_bool( "CoreIgnoresDefenceCaps", false );
   settingsManager.ssopt.send_stat_locks = elem.remove_bool( "SendStatLocks", false );
+  settingsManager.ssopt.default_visual_range =
+      static_cast<u8>( elem.remove_int( "DefaultVisualRange", 18 ) );
   settingsManager.ssopt.speech_range = elem.remove_ushort( "SpeechRange", 12 );
   settingsManager.ssopt.whisper_range = elem.remove_ushort( "WhisperRange", 2 );
   settingsManager.ssopt.yell_range = elem.remove_ushort( "YellRange", 25 );
@@ -149,6 +152,9 @@ void ServSpecOpt::read_servspecopt()
       elem.remove_ushort( "NpcMinimumMovementDelay", 250 );
 
   ssopt_parse_totalstats( elem );
+
+  // default value needs to be reset as the object is created before config is loaded
+  gamestate.initialize_range_from_config( settingsManager.ssopt.default_visual_range );
 
   // Turley 2009/11/06 u8 range...
   // if ( ssopt.default_max_slots > 255 )

--- a/pol-core/pol/ssopt.h
+++ b/pol-core/pol/ssopt.h
@@ -84,6 +84,15 @@ struct ServSpecOpt
   bool core_ignores_defence_caps;
   bool send_stat_locks;
 
+  /* how to validate these values (and how range checking works on the client):
+   tell the client about a character.  Take your character to the spot that
+   character is standing on.  Walk straight, 18 steps in any direction.  Run back
+   to the spot.  The character will still be there.  If you walk 19 steps, the
+   client automatically removes the object - the server doesn't need to tell it to.
+   Simple rectangular distance is used - if the x's differ by <= 18, and the y's differ
+   by <= 18, you're in range.  If either is out of range, you're out.
+   */
+  std::uint8_t default_visual_range;
   unsigned short speech_range;
   unsigned short whisper_range;
   unsigned short yell_range;

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -508,13 +508,13 @@ MaxAnimID=0x800
 #AllowedEnvironmentVariablesAccess=
 
 #
-# VisualRange: distance at which player can see information around his surroundings. Keep in mind
+# DefaultVisualRange: distance at which player can see information around his surroundings. Keep in mind
 # this value needs to be same as client as there are assumptions made based on it whether client
 # can still see an object or not as client will automatically remove objects out of its configured
 # range.
 # Default is 18 (1-255 allowed)
 #
-#VisualRange=18
+#DefaultVisualRange=18
 
 #############################################################################
 ## Experimental Options - Modify at your own risk

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -507,14 +507,6 @@ MaxAnimID=0x800
 #
 #AllowedEnvironmentVariablesAccess=
 
-#
-# DefaultVisualRange: distance at which player can see information around his surroundings. Keep in mind
-# this value needs to be same as client as there are assumptions made based on it whether client
-# can still see an object or not as client will automatically remove objects out of its configured
-# range.
-# Default is 18 (1-255 allowed)
-#
-#DefaultVisualRange=18
 
 #############################################################################
 ## Experimental Options - Modify at your own risk

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -507,6 +507,15 @@ MaxAnimID=0x800
 #
 #AllowedEnvironmentVariablesAccess=
 
+#
+# VisualRange: distance at which player can see information around his surroundings. Keep in mind
+# this value needs to be same as client as there are assumptions made based on it whether client
+# can still see an object or not as client will automatically remove objects out of its configured
+# range.
+# Default is 18 (1-255 allowed)
+#
+#VisualRange=18
+
 #############################################################################
 ## Experimental Options - Modify at your own risk
 #############################################################################


### PR DESCRIPTION
This PR adds new setting to pol.cfg "VisualRange". This is a constant converted to configurable value which changes the distance at which client can see its surroundings. Changing the value requires changing the client as well. Default value is kept at 18 (=unchanged). Do note that this PR doesn't touch on the "client reported visual range" at all which seems to be present in an unfinished state.

The bad thing is I'm not sure how to properly test this as misconfiguration can have weird consequences and this PR heavily depends on the fact the constant is being used everywhere it needs to.

The good thing is keeping the configured value at 18 should keep the current behavior.

Fixes: https://github.com/polserver/polserver/issues/545