### PR TITLE
Fix `funcref.new()`; Correctly error on accessing class name as identifier

### DIFF
--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -1003,10 +1003,7 @@ void SemanticAnalyzer::visit_identifier( Identifier& node )
     }
   }
 
-  // Do not error if accessing a class name that does not define a constructor,
-  // as that is handled by visit_function_call.
-  if ( !node.variable &&
-       workspace.all_class_locations.find( name ) == workspace.all_class_locations.end() )
+  if ( !node.variable )
   {
     report.error( node, "Unknown identifier '{}'.", name );
     return;

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -2663,17 +2663,12 @@ void Executor::ins_call_method_id( const Instruction& ins )
 
       if ( add_new_classinst )
       {
-        if ( funcr->class_index() >= prog_->class_descriptors.size() )
+        if ( funcr->constructor() )
         {
-          POLLOG_ERRORLN( "Class index out of bounds: {} >= {} ({},PC={})", funcr->class_index(),
-                          prog_->class_descriptors.size(), prog_->name, PC );
-          seterror( true );
-          return;
+          fparams.insert( fparams.begin(),
+                          BObjectRef( new BConstObject( new BClassInstanceRef(
+                              new BClassInstance( prog_, funcr->class_index(), Globals2 ) ) ) ) );
         }
-
-        fparams.insert( fparams.begin(),
-                        BObjectRef( new BConstObject( new BClassInstanceRef(
-                            new BClassInstance( prog_, funcr->class_index(), Globals2 ) ) ) ) );
       }
 
       if ( funcr->validCall( continuation ? MTH_CALL : ins.token.lval, *this, &jmp ) )

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2418,6 +2418,9 @@ bool BFunctionRef::validCall( const int id, Executor& ex, Instruction* inst ) co
   if ( id != MTH_CALL && id != MTH_NEW && id != MTH_CALL_METHOD )
     return false;
 
+  if ( id == MTH_NEW && !constructor() )
+    return false;
+
   if ( passed_args < expected_min_args || ( passed_args > expected_max_args && !variadic() ) )
     return false;
 

--- a/testsuite/escript/classes/fail-class-as-identifier.err
+++ b/testsuite/escript/classes/fail-class-as-identifier.err
@@ -1,0 +1,1 @@
+fail-class-as-identifier.src:4:8: error: Unknown identifier 'A'.

--- a/testsuite/escript/classes/fail-class-as-identifier.src
+++ b/testsuite/escript/classes/fail-class-as-identifier.src
@@ -1,0 +1,4 @@
+class A()
+endclass
+
+print( A );

--- a/testsuite/escript/classes/method-new.out
+++ b/testsuite/escript/classes/method-new.out
@@ -1,2 +1,12 @@
+error{ errortext = "Invalid argument count: expected 1, got 0" }
 <class ClassA>
+error{ errortext = "Invalid argument count: expected 1, got 2" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
+error{ errortext = "Function is not a constructor" }
 error{ errortext = "Function is not a constructor" }

--- a/testsuite/escript/classes/method-new.src
+++ b/testsuite/escript/classes/method-new.src
@@ -1,4 +1,4 @@
-// Test MTH_NEW call on a funcref that is not a ctor
+// Test MTH_NEW call on a funcref that is not a ctor for both class and non-class methods
 
 class ClassA()
   function ClassA( this, arg0 )
@@ -8,7 +8,29 @@ class ClassA()
   function stringify( this )
     return $"ClassA::stringify this={this} this.arg0={this.arg0}";
   endfunction
+
+  function staticfunc()
+  endfunction
 endclass
 
+function GlobalFunction()
+endfunction
+
+print( @ClassA.new() );
 print( @ClassA.new( "a0" ) );
-print( @ClassA::stringify.new( "a0 ") );
+print( @ClassA.new( "a0", "a1" ) );
+
+// (a) class method
+print( @ClassA::stringify.new() );
+print( @ClassA::stringify.new( "a0" ) );
+print( @ClassA::stringify.new( "a0", "a1" ) );
+
+// (b) global function
+print( @GlobalFunction.new() );
+print( @GlobalFunction.new( "a0" ) );
+print( @GlobalFunction.new( "a0", "a1" ) );
+
+// (c) class static function
+print( @ClassA::staticfunc.new() );
+print( @ClassA::staticfunc.new( "a0" ) );
+print( @ClassA::staticfunc.new( "a0", "a1" ) );


### PR DESCRIPTION
- Fix `funcref.new()` on non-constructor function references.
- Fix runtime error on accessing class name as identifier.