### PR TITLE
Removed PolLock when handling nonallowed pkts

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -13,7 +13,7 @@
       <list>elipsis ... : repeat entries are allowed.</list>
       <bottom>This means the punctuation in these cases should NOT be in the actual config files used by POL, they only appear here for information purposes. Exception: curly braces { } are used to define an element in a config file. These must be present in the actual file.</bottom>
     </desc>
-    <datemodified>08/31/2024</datemodified>
+    <datemodified>10/14/2024</datemodified>
 </fileheader>
 
 
@@ -951,6 +951,7 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [InactivityDisconnectTimeout=(int minutes {default 5})]
 [MinCmdlevelToLogin=(int level {default 0})]
 [MinCmdLvlToIgnoreInactivity=(int level {default 1})]
+[LoginServerDisconnectUnknownPkts=(1/0 {default 0})]
 [MaxCallDepth=(int depth {default 100})]
 [ThreadStacktracesWhenStuck=(1/0 {default 0})]
 [DumpStackOnAssertionFailure=(1/0 {default 0})]

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>10-09-2024</datemodified>
+		<datemodified>10-14-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>10-14-2024</date>
+			<author>Turley:</author>
+			<change type="Added">pol.cfg LoginServerDisconnectUnknownPkts<br/>
+during login process disconnect connection if unknown/non-allowed pkt is received</change>
+			<change type="Fixed">improved performance when non allowed pkts arrive</change>
+		</entry>
 		<entry>
 			<date>10-09-2024</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 -- POL100.2.0 --
+10-14-2024 Turley:
+    Added: pol.cfg LoginServerDisconnectUnknownPkts
+           during login process disconnect connection if unknown/non-allowed pkt is received
+    Fixed: improved performance when non allowed pkts arrive
 10-09-2024 Kevin:
     Added: Escript now supports classes! Classes are a way to bundle attributes (members) and functionality (methods) together:
 

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -320,7 +320,21 @@ bool process_data( Network::ThreadedClient* session )
     if ( !Network::PacketRegistry::is_defined( msgtype ) )
     {
       handle_undefined_packet( session );
+      if ( !session->myClient.chr && Plib::systemstate.config.loginserver_disconnect_unknown_pkts )
+        session->forceDisconnect();
       return false;  // remain in RECV_STATE_MSGTYPE_WAIT
+    }
+    // during login if it should disconnect no need to receive the data before killing the
+    // connection
+    if ( !session->myClient.chr && Plib::systemstate.config.loginserver_disconnect_unknown_pkts &&
+         !session->msgtype_filter->msgtype_allowed[msgtype] )
+    {
+      POLLOG_ERRORLN( "Client#{} ({}, Acct {}) sent non-allowed message type {:#x}.",
+                      session->myClient.instance_, session->ipaddrAsString(),
+                      ( session->myClient.acct ? session->myClient.acct->name() : "unknown" ),
+                      (int)msgtype );
+      session->forceDisconnect();
+      return false;
     }
 
     Network::MSG_HANDLER packetHandler =

--- a/pol-core/pol/polcfg.cpp
+++ b/pol-core/pol/polcfg.cpp
@@ -248,6 +248,8 @@ void PolConfig::read_pol_config( bool initial_load )
       elem.remove_bool( "TimestampEveryLine", false );  // clib/logfacility.h bool
   Plib::systemstate.config.use_single_thread_login =
       elem.remove_bool( "UseSingleThreadLogin", false );
+  Plib::systemstate.config.loginserver_disconnect_unknown_pkts =
+      elem.remove_bool( "LoginServerDisconnectUnknownPkts", false );
   Plib::systemstate.config.disable_nagle = elem.remove_bool( "DisableNagle", false );
   Plib::systemstate.config.show_realm_info = elem.remove_bool( "ShowRealmInfo", false );
 

--- a/pol-core/pol/polcfg.h
+++ b/pol-core/pol/polcfg.h
@@ -91,6 +91,7 @@ struct PolConfig
 
   int account_save;
   bool use_single_thread_login;
+  bool loginserver_disconnect_unknown_pkts;
 
   bool disable_nagle;
   bool show_realm_info;

--- a/pol-core/pol/polsem.h
+++ b/pol-core/pol/polsem.h
@@ -7,6 +7,9 @@
 #ifndef POLSEM_H
 #define POLSEM_H
 
+// define to debug PolLocks, log each lock entry
+// #define POLLOCK_TRACE
+
 // TODO: encapsulate the "locker" variable to remove those includes from here. Would a size_t work?
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -14,6 +17,9 @@
 #else
 #include <pthread.h>
 #include <unistd.h>
+#endif
+#ifdef POLLOCK_TRACE
+#include "clib/logfacility.h"
 #endif
 #include <atomic>
 
@@ -40,6 +46,19 @@ extern pthread_mutex_t polsem;
 void polsem_lock();
 void polsem_unlock();
 
+#ifdef POLLOCK_TRACE
+class PolLockD
+{
+public:
+  PolLockD() { polsem_lock(); }
+  ~PolLockD() { polsem_unlock(); }
+};
+inline void noop(){};
+#define PolLock                                     \
+  noop();                                           \
+  INFO_PRINTLN( "lock {} {}", __FILE__, __LINE__ ); \
+  Core::PolLockD
+#endif
 class PolLock
 {
 public:
@@ -72,6 +91,6 @@ public:
 private:
   bool locked_;
 };
-}
-}
+}  // namespace Core
+}  // namespace Pol
 #endif  // POLSEM_H

--- a/pol-core/pol/polsem.h
+++ b/pol-core/pol/polsem.h
@@ -58,13 +58,14 @@ inline void noop(){};
   noop();                                           \
   INFO_PRINTLN( "lock {} {}", __FILE__, __LINE__ ); \
   Core::PolLockD
-#endif
+#else
 class PolLock
 {
 public:
   PolLock() { polsem_lock(); }
   ~PolLock() { polsem_unlock(); }
 };
+#endif
 
 class PolLock2
 {

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -102,6 +102,13 @@ InactivityDisconnectTimeout=20
 #
 #AllowMultiClientsPerAccount=0
 
+#
+# LoginServerDisconnectUnknownPkts:
+#   during login process disconnect connection if unknown/non-allowed pkt is received
+# default 0
+#
+#LoginServerDisconnectUnknownPkts=0
+
 #############################################################################
 ## System Profiling and Performance
 #############################################################################

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -500,11 +500,11 @@ MaxAnimID=0x800
 
 
 #############################################################################
-## Treading Settings - Do not modify unless necessary.
+## Threading Settings - Do not modify unless necessary.
 #############################################################################
 
 #
-# SelectTimeout: I/O sleep time
+# SelectTimeout: I/O sleep time in usec, minimum timeout is 1ms (1000usec)
 #   Set to 0 for a dedicated server.
 #   Set to 10 for a non-dedicated server.
 # Default 10

--- a/testsuite/pol/pol.cfg
+++ b/testsuite/pol/pol.cfg
@@ -111,6 +111,13 @@ InactivityDisconnectTimeout=20
 #
 #AllowMultiClientsPerAccount=0
 
+#
+# LoginServerDisconnectUnknownPkts:
+#   during login process disconnect connection if unknown/non-allowed pkt is received
+# default 0
+#
+LoginServerDisconnectUnknownPkts=1
+
 #############################################################################
 ## System Profiling and Performance
 #############################################################################


### PR DESCRIPTION
Currently when a undefined pkt got send the login/client thread does not take PolLock, but if it's a defined one it always takes the lock. For non-allowed pkts this is not needed.

For debugging locks added a define in polsem.h to log each usage.