### PR TITLE
Fix too-early fail on using scoped variable as a function callee

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>10-19-2024</datemodified>
+		<datemodified>10-20-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>10-20-2024</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Correct behavior with classes when using a class-scoped variable as a function callee.</change>
+		</entry>
 		<entry>
 			<date>10-19-2024</date>
 			<author>Kukkino:</author>

--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -425,7 +425,8 @@ void SemanticAnalyzer::visit_function_call( FunctionCall& fc )
         //
         // If that is the case, there will be a global named
         // `class_name::class_name`. We will not error in this case.
-        if ( !globals.find( ScopableName( class_name, class_name ).string() ) )
+        if ( Clib::caseInsensitiveEqual( fc.scoped_name->name, class_name ) &&
+             !globals.find( ScopableName( class_name, class_name ).string() ) )
         {
           auto msg = fmt::format( "In function call: Class '{}' does not define a constructor.",
                                   class_name );

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+10-20-2024 Kevin:
+    Fixed: Correct behavior with classes when using a class-scoped variable as a function callee.
 10-19-2024 Kukkino:
     Added: DefaultVisualRange setting to servspecopt.cfg. This setting declares how far clients can see by default.
            Note that the same value needs to be set on both server and in client (usually 18 or 21).

--- a/testsuite/escript/classes/scopes-var-as-method-call.out
+++ b/testsuite/escript/classes/scopes-var-as-method-call.out
@@ -1,0 +1,2 @@
+arg0=parExpression
+arg0=functionCallSuffix

--- a/testsuite/escript/classes/scopes-var-as-method-call.src
+++ b/testsuite/escript/classes/scopes-var-as-method-call.src
@@ -1,0 +1,9 @@
+// A class can have a variable the same as the classname. We should not error on
+// a call, but we should error when used as a base-class
+
+class Animal()
+  var speak := @( arg0 ) { print( $"arg0={arg0}" ); };
+endclass
+
+( ANIMAL::speak)( "parExpression" );
+ANIMAL::SPEAK( "functionCallSuffix" );


### PR DESCRIPTION
Corrects this erroneous behavior:
```
class Animal()
  var speak := @( arg0 ) { print( $"arg0={arg0}" ); };
endclass

// error: In function call: Class 'ANIMAL' does not define a constructor.
ANIMAL::SPEAK( "functionCallSuffix" ); 
```