### PR TITLE
Add moved_at and position_changed_at members to characters

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -7,6 +7,12 @@
 	<version name="POL100.2.0">
 		<entry>
 			<date>10-20-2024</date>
+			<author>Kukkino:</author>
+			<change type="Added">Added moved_at and position_changed_at members to characters. Values signify when was the last time character<br/>
+walked or changed position (for example with walking or MoveObjectToLocation)</change>
+		</entry>
+		<entry>
+			<date>10-20-2024</date>
 			<author>Kevin:</author>
 			<change type="Fixed">Correct behavior with classes when using a class-scoped variable as a function callee.</change>
 		</entry>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -309,8 +309,8 @@
 <member mname="luck_mod" type="Integer" access="r/w">Modifier for property, added to base property.</member>
 <member mname="swing_speed_increase_mod" type="Integer" access="r/w">Modifier for property, added to base property.</member>
 <member mname="buffs" type="dictionary" access="r/o">Returns the current active buffs added via addBuff as dictionary. Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}.</member>
-<member mname="position_changed_at" type="Integer" access="r/o">PolClock when character last changed position for any reason</member>
-<member mname="moved_at" type="Integer" access="r/o">PolClock when character last moved due to walking/running</member>
+<member mname="position_changed_at" type="Double" access="r/o">MilliSecondClock when character last changed position for any reason</member>
+<member mname="moved_at" type="Double" access="r/o">MilliSecondClock when character last moved due to walking/running</member>
 
 <method proto="setpoisoned(bool)" returns="true/error">sets the character poisoned, controller of calling script is flagged as in repsystem</method>
 <method proto="setparalyzed(bool)" returns="true/error">sets the character paralyzed, controller of calling script is flagged as in repsystem</method>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -309,6 +309,8 @@
 <member mname="luck_mod" type="Integer" access="r/w">Modifier for property, added to base property.</member>
 <member mname="swing_speed_increase_mod" type="Integer" access="r/w">Modifier for property, added to base property.</member>
 <member mname="buffs" type="dictionary" access="r/o">Returns the current active buffs added via addBuff as dictionary. Key is the iconid and value a struct struct{name_cliloc, desc_cliloc, end_time, name_args, desc_args}.</member>
+<member mname="position_changed_at" type="Integer" access="r/o">PolClock when character last changed position for any reason</member>
+<member mname="moved_at" type="Integer" access="r/o">PolClock when character last moved due to walking/running</member>
 
 <method proto="setpoisoned(bool)" returns="true/error">sets the character poisoned, controller of calling script is flagged as in repsystem</method>
 <method proto="setparalyzed(bool)" returns="true/error">sets the character paralyzed, controller of calling script is flagged as in repsystem</method>

--- a/pol-core/bscript/objaccess.cpp
+++ b/pol-core/bscript/objaccess.cpp
@@ -277,6 +277,8 @@ ObjMember object_members[] = {
     { MBR_WEIGHT_MULTIPLIER_MOD, "weight_multiplier_mod" },
     { MBR_HELD_WEIGHT_MULTIPLIER, "held_weight_multiplier" },
     { MBR_FUNCTION, "function" },
+    { MBR_POSITION_CHANGED_AT, "position_changed_at" },
+    { MBR_MOVED_AT, "moved_at" },
 };
 int n_objmembers = sizeof object_members / sizeof object_members[0];
 ObjMember* getKnownObjMember( const char* token )

--- a/pol-core/bscript/objmembers.h
+++ b/pol-core/bscript/objmembers.h
@@ -302,6 +302,8 @@ enum MemberID
   MBR_WEIGHT_MULTIPLIER_MOD,
   MBR_HELD_WEIGHT_MULTIPLIER, // 260
   MBR_FUNCTION,
+  MBR_POSITION_CHANGED_AT,
+  MBR_MOVED_AT,
 };
 
 inline auto format_as( MemberID id )

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.2.0 --
+10-20-2024 Kukkino:
+    Added: Added moved_at and position_changed_at members to characters. Values signify when was the last time character
+           walked or changed position (for example with walking or MoveObjectToLocation)
 10-20-2024 Kevin:
     Fixed: Correct behavior with classes when using a class-scoped variable as a function callee.
 10-19-2024 Kukkino:

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -328,7 +328,9 @@ Character::Character( u32 objtype, Core::UOBJ_CLASS uobj_class )
       // Note, Item uses the named constructor idiom, but here, it is not used.
       // this is probably okay, but something to keep in mind.
       gender( Plib::GENDER_MALE ),
-      race( Plib::RACE_HUMAN )
+      race( Plib::RACE_HUMAN ),
+      position_changed_at_( 0 ),
+      moved_at_( 0 )
 {
   logged_in( true );  // so initialization scripts etc can see
 
@@ -3654,6 +3656,7 @@ void Character::check_region_changes()
 void Character::position_changed()
 {
   wornitems->setposition( pos() );
+  position_changed_at_ = Core::polclock();
 }
 
 void Character::unhide()
@@ -3906,6 +3909,7 @@ bool Character::move( unsigned char i_dir )
 
     Core::Pos4d oldpos = pos();
     setposition( new_pos );
+    moved_at_ = Core::polclock();
 
     if ( on_mount() && !script_isa( Core::POLCLASS_NPC ) )
     {

--- a/pol-core/pol/mobile/charactr.h
+++ b/pol-core/pol/mobile/charactr.h
@@ -863,6 +863,11 @@ public:
   Plib::UGENDER gender;
   Plib::URACE race;
 
+protected:
+  Core::polclock_t position_changed_at_;
+  Core::polclock_t moved_at_;
+
+public:
   DYN_PROPERTY( dblclick_wait, u32, Core::PROP_DOUBLECLICK_WAIT, 0 );
 
   DYN_PROPERTY( title_prefix, std::string, Core::PROP_TITLE_PREFIX, "" );

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -1953,6 +1953,12 @@ BObjectImp* Character::get_script_member_id( const int id ) const
   case MBR_TRUECOLOR:
     return new BLong( truecolor );
     break;
+  case MBR_POSITION_CHANGED_AT:
+    return new Double( static_cast<double>( Core::polclock_t_to_ms( position_changed_at_ ) ) );
+    break;
+  case MBR_MOVED_AT:
+    return new Double( static_cast<double>( Core::polclock_t_to_ms( moved_at_ ) ) );
+    break;
   case MBR_AR_MOD:
     return new BLong( ar_mod() );
     break;

--- a/testsuite/pol/testpkgs/npc/ai_movement.src
+++ b/testsuite/pol/testpkgs/npc/ai_movement.src
@@ -4,6 +4,20 @@ use os;
 program ai()
   var me := Self();
 
+  var original_moved_at := me.moved_at;
+  var original_position_changed_at := me.position_changed_at;
+
+  if ( original_moved_at != 0 )
+    me.setprop( "testerror", $"wrong moved_at, expected 0, got {original_moved_at}" );
+    return;
+  endif
+  if ( original_position_changed_at <= 0 )
+    me.setprop( "testerror", $"wrong position_changed_at, expected > 0, got {original_position_changed_at}" );
+    return;
+  endif
+
+  SleepMs(10);
+
   var x := 100;
   var y := 100;
   if ( me.x != x || me.y != y )
@@ -13,6 +27,15 @@ program ai()
   var res := Move( "N" );
   if ( !res || me.x != 100 || me.y != 99 )
     me.setprop( "testerror", "Failed to move N: {}: {},{}".format( res, me.x, me.y ) );
+    return;
+  endif
+
+  if ( me.moved_at <= original_moved_at )
+    me.setprop( "testerror", $"wrong moved_at after move, expected > {original_moved_at}, got {me.moved_at}" );
+    return;
+  endif
+  if ( me.position_changed_at <= original_position_changed_at )
+    me.setprop( "testerror", $"wrong position_changed_at after move, expected > {original_position_changed_at}, got {me.position_changed_at}" );
     return;
   endif
 


### PR DESCRIPTION
This PR adds new read-only character members:

- `moved_at` - last time at which movement was made (meaning character actually moved due to move function)
- `position_chaged_at` - last time at which character changed position (this includes things like teleports or `MoveObjectToLocation` atc.)

This is needed for mechanics that depend on "can't use while moving" with various accuracy (ex. some may require player to stand still for a second, some just for half etc.).