### PR TITLE
Add realm decay setting

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>11-02-2024</datemodified>
+		<datemodified>11-09-2024</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>10-20-2024</date>
+			<author>Kukkino:</author>
+			<change type="Added">Added GetRealmDecay(realm) and SetRealmDecay(realm, has_decay) allowing to manipulate whether items decay on the ground in given realms.</change>
+		</entry>
 		<entry>
 			<date>11-02-2024</date>
 			<author>DevGIB:</author>

--- a/docs/docs.polserver.com/pol100/polsysem.xml
+++ b/docs/docs.polserver.com/pol100/polsysem.xml
@@ -197,6 +197,23 @@ const MSGLEN_VARIABLE := -1;</code></explain>
     <error>"Items in Realm."</error>
   </function>
   
+  <function name="GetRealmDecay">
+    <prototype>GetRealmDecay(realm_name)</prototype>
+    <parameter name="realm_name" value="String - case-sensitive name of the realm" />
+    <explain>Returns whether realm has decay or enabled or not.</explain>
+    <return>Boolean</return> 
+    <error>"Realm not found."</error>
+  </function>
+
+  <function name="SetRealmDecay">
+    <prototype>SetRealmDecay(realm_name, has_decay)</prototype>
+    <parameter name="realm_name" value="String - case-sensitive name of the realm" />
+    <parameter name="has_decay" value="Boolean - whether decay should be enabled or not" />
+    <explain>Enables or disables decay for realm.</explain>
+    <return>1</return> 
+    <error>"Realm not found."</error>
+  </function>
+
   <function name="MD5Encrypt">
     <prototype>MD5Encrypt(str)</prototype>
     <parameter name="str" value="String" />

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+10-20-2024 Kukkino:
+    Added: Added GetRealmDecay(realm) and SetRealmDecay(realm, has_decay) allowing to manipulate whether items decay on the ground in given realms.
 11-02-2024 DevGIB:
     Added: MinAttackRangeIncrease(min_attack_range_increase) and MinAttackRangeIncreaseMod(min_attack_range_increase_mod) to Mobiles and Items allowing people to have a dynamic modifier to the adjust a mobiles minimum attack range.<br/>
            Min Attack Range Increase is used as a numeric modifier to the minimum range of a weapon, e.g. Base min Weapon range of 1 + attack range increase of 1 would make the minimum attack range 2.

--- a/pol-core/pol/decay.cpp
+++ b/pol-core/pol/decay.cpp
@@ -118,7 +118,10 @@ bool Decay::should_switch_realm() const
 {
   if ( realm_index >= gamestate.Realms.size() )
     return true;
-  if ( gamestate.Realms[realm_index] == nullptr )
+  const Realms::Realm* realm = gamestate.Realms[realm_index];
+  if ( realm == nullptr )
+    return true;
+  if ( !realm->has_decay )
     return true;
   if ( area_itr == area.end() )
     return true;
@@ -152,10 +155,15 @@ void Decay::switch_realm()
 
 void Decay::step()
 {
-  ++area_itr;
   if ( should_switch_realm() )
+  {
     switch_realm();
-  decay_worldzone();
+  }
+  else
+  {
+    decay_worldzone();
+    ++area_itr;
+  }
 }
 
 
@@ -171,7 +179,7 @@ void Decay::on_delete_realm( Realms::Realm* realm )
   // due to the ++itr in step the realm will be switched
   --realm_index;
   area = gamestate.Realms[realm_index]->gridarea();
-  area_itr = --area.end();
+  area_itr = area.end();
 }
 
 void Decay::after_realms_size_changed()
@@ -185,6 +193,11 @@ void Decay::calculate_sleeptime()
   unsigned total_grid_count = 0;
   for ( const auto& realm : gamestate.Realms )
   {
+    if ( !realm->has_decay )
+    {
+      continue;
+    }
+
     total_grid_count += ( realm->grid_width() * realm->grid_height() );
   }
   if ( !total_grid_count )

--- a/pol-core/pol/module/polsystemmod.cpp
+++ b/pol-core/pol/module/polsystemmod.cpp
@@ -407,6 +407,37 @@ BObjectImp* PolSystemExecutorModule::mf_DeleteRealm( /*name*/ )
   return new BLong( 1 );
 }
 
+BObjectImp* PolSystemExecutorModule::mf_GetRealmDecay( /*name*/ )
+{
+  const String* realm_name;
+  if ( !getStringParam( 0, realm_name ) )
+  {
+    return new BError( "Invalid parameter" );
+  }
+  Realms::Realm* realm = Core::find_realm( realm_name->value() );
+  if ( !realm )
+    return new BError( "Realm not found." );
+
+  return new BBoolean( realm->has_decay );
+}
+
+BObjectImp* PolSystemExecutorModule::mf_SetRealmDecay( /*name,has_decay*/ )
+{
+  const String* realm_name;
+  bool has_deacy;
+  if ( !( getStringParam( 0, realm_name ) && getParam( 1, has_deacy ) ) )
+  {
+    return new BError( "Invalid parameter" );
+  }
+  Realms::Realm* realm = Core::find_realm( realm_name->value() );
+  if ( !realm )
+    return new BError( "Realm not found." );
+
+  realm->has_decay = has_deacy;
+
+  return new BLong( 1 );
+}
+
 BObjectImp* PolSystemExecutorModule::mf_MD5Encrypt( /*string*/ )
 {
   const String* string;

--- a/pol-core/pol/module/polsystemmod.cpp
+++ b/pol-core/pol/module/polsystemmod.cpp
@@ -434,6 +434,7 @@ BObjectImp* PolSystemExecutorModule::mf_SetRealmDecay( /*name,has_decay*/ )
     return new BError( "Realm not found." );
 
   realm->has_decay = has_deacy;
+  Core::gamestate.decay.after_realms_size_changed();
 
   return new BLong( 1 );
 }

--- a/pol-core/pol/module/polsystemmod.h
+++ b/pol-core/pol/module/polsystemmod.h
@@ -75,6 +75,8 @@ public:
   [[nodiscard]] Bscript::BObjectImp* mf_CreatePacket();
   [[nodiscard]] Bscript::BObjectImp* mf_AddRealm( /*name,base*/ );
   [[nodiscard]] Bscript::BObjectImp* mf_DeleteRealm( /*name*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_GetRealmDecay( /*name*/ );
+  [[nodiscard]] Bscript::BObjectImp* mf_SetRealmDecay( /*name,has_deacy*/ );
   [[nodiscard]] Bscript::BObjectImp* mf_MD5Encrypt( /*string*/ );
   [[nodiscard]] Bscript::BObjectImp* mf_FormatItemDescription( /*string,amount,suffix*/ );
   [[nodiscard]] Bscript::BObjectImp* mf_LogCPropProfile();

--- a/pol-core/pol/realms/realm.cpp
+++ b/pol-core/pol/realms/realm.cpp
@@ -28,6 +28,7 @@ namespace Realms
 Realm::Realm( const std::string& realm_name, const std::string& realm_path )
     : is_shadowrealm( false ),
       baserealm( nullptr ),
+      has_decay( true ),
       _descriptor( Plib::RealmDescriptor::Load( realm_name, realm_path ) ),
       _mobile_count( 0 ),
       _offline_count( 0 ),
@@ -55,6 +56,7 @@ Realm::Realm( const std::string& realm_name, Realm* realm )
     : is_shadowrealm( true ),
       baserealm( realm ),
       shadowname( realm_name ),
+      has_decay( true ),
       _descriptor( realm->_descriptor ),
       _mobile_count( 0 ),
       _offline_count( 0 ),

--- a/pol-core/pol/realms/realm.h
+++ b/pol-core/pol/realms/realm.h
@@ -67,6 +67,7 @@ public:
   bool is_shadowrealm;
   Realm* baserealm;
   const std::string shadowname;
+  bool has_decay;
 
   unsigned short width() const;
   unsigned short height() const;

--- a/pol-core/pol/realms/realms.cpp
+++ b/pol-core/pol/realms/realms.cpp
@@ -78,11 +78,15 @@ bool defined_realm( const std::string& name )
   return false;
 }
 
-void add_realm( const std::string& name, Realms::Realm* base )
+void add_realm( const std::string& name, Realms::Realm* base, bool has_decay )
 {
   Realms::Realm* r = new Realms::Realm( name, base );
+  r->has_decay = has_decay;
   gamestate.Realms.push_back( r );
-  gamestate.decay.after_realms_size_changed();
+  if ( r->has_decay )
+  {
+    gamestate.decay.after_realms_size_changed();
+  }
 }
 
 void remove_realm( const std::string& name )

--- a/pol-core/pol/realms/realms.h
+++ b/pol-core/pol/realms/realms.h
@@ -23,7 +23,7 @@ class Realm;
 namespace Core
 {
 Realms::Realm* find_realm( const std::string& name );
-void add_realm( const std::string& name, Realms::Realm* base );
+void add_realm( const std::string& name, Realms::Realm* base, bool has_decay = true );
 bool defined_realm( const std::string& name );
 void remove_realm( const std::string& name );
 

--- a/pol-core/pol/savedata.cpp
+++ b/pol-core/pol/savedata.cpp
@@ -209,13 +209,18 @@ void write_shadow_realms( Clib::StreamWriter& sw )
 {
   for ( const auto& realm : gamestate.Realms )
   {
-    if ( realm->is_shadowrealm )
+    sw.begin( "Realm" );
+    if (!realm->is_shadowrealm)
     {
-      sw.begin( "Realm" );
+      sw.add( "Name", realm->name() );
+    }
+    else
+    {
       sw.add( "Name", realm->shadowname );
       sw.add( "BaseRealm", realm->baserealm->name() );
-      sw.end();
     }
+    sw.add( "HasDecay", realm->has_decay );
+    sw.end();
   }
 }
 

--- a/pol-core/pol/savedata.cpp
+++ b/pol-core/pol/savedata.cpp
@@ -205,7 +205,7 @@ void write_global_properties( Clib::StreamWriter& sw )
   sw.end();
 }
 
-void write_shadow_realms( Clib::StreamWriter& sw )
+void write_realms( Clib::StreamWriter& sw )
 {
   for ( const auto& realm : gamestate.Realms )
   {
@@ -436,7 +436,7 @@ int write_data( unsigned int& dirty_writes, unsigned int& clean_writes, long lon
 
                   write_system_data( sc.pol );
                   write_global_properties( sc.pol );
-                  write_shadow_realms( sc.pol );
+                  write_realms( sc.pol );
                 }
                 catch ( ... )
                 {

--- a/pol-core/pol/uimport.cpp
+++ b/pol-core/pol/uimport.cpp
@@ -301,7 +301,11 @@ void read_realms( Clib::ConfigElem& elem )
   {
     // these are dynamic settings for base realm
     Realms::Realm* realm = find_realm( name );
-    realm->has_decay = has_decay;
+
+    if ( !realm )
+      elem.warn_with_line( "Realm not found." );
+    else
+      realm->has_decay = has_decay;
   }
 }
 

--- a/pol-core/pol/uimport.cpp
+++ b/pol-core/pol/uimport.cpp
@@ -279,18 +279,29 @@ void read_system_vars( Clib::ConfigElem& elem )
       elem.remove_ulong( "LastCharSerialNumber", UINT_MAX );  // dave 3/9/3
 }
 
-void read_shadow_realms( Clib::ConfigElem& elem )
+void read_realms( Clib::ConfigElem& elem )
 {
   std::string name = elem.remove_string( "Name" );
-  Realms::Realm* baserealm = find_realm( elem.remove_string( "BaseRealm" ) );
-  if ( !baserealm )
-    elem.warn_with_line( "BaseRealm not found." );
-  else if ( defined_realm( name ) )
-    elem.warn_with_line( "Realmname already defined" );
+  bool has_decay = elem.remove_bool( "HasDecay", true );
+  if ( elem.has_prop( "BaseRealm" ) )
+  {
+    // this is shadow realm
+    Realms::Realm* baserealm = find_realm( elem.remove_string( "BaseRealm" ) );
+    if ( !baserealm )
+      elem.warn_with_line( "BaseRealm not found." );
+    else if ( defined_realm( name ) )
+      elem.warn_with_line( "Realmname already defined" );
+    else
+    {
+      add_realm( name, baserealm, has_decay );
+      INFO_PRINTLN( "\nShadowrealm {}", name );
+    }
+  }
   else
   {
-    add_realm( name, baserealm );
-    INFO_PRINTLN( "\nShadowrealm {}", name );
+    // these are dynamic settings for base realm
+    Realms::Realm* realm = find_realm( name );
+    realm->has_decay = has_decay;
   }
 }
 
@@ -377,7 +388,7 @@ void slurp( const char* filename, const char* tags, int sysfind_flags )
           storage_area->load_item( elem );
         }
         else if ( elem.type_is( "REALM" ) )
-          read_shadow_realms( elem );
+          read_realms( elem );
       }
       catch ( std::exception& )
       {

--- a/pol-core/support/scripts/polsys.em
+++ b/pol-core/support/scripts/polsys.em
@@ -20,3 +20,5 @@ Realms( realm := "" );
 ReloadConfiguration(); // reloads pol.cfg and npcdesc.cfg
 SetSysTrayPopupText( text );
 LogCPropProfile();
+GetRealmDecay( realm );
+SetRealmDecay( realm, has_decay );


### PR DESCRIPTION
As discussed on discord, this PR allows opting out of decay for a whole realm.

The PR is still missing documentation, however code is ready for review.

New script methods:
```
GetRealmDecay( realm );
SetRealmDecay( realm, has_decay );
```

The changes include slight modification on how decay is handled - before each step would always clear an area, however now a step can be just moving onto next realm by itself. This was changed because I wanted to avoid possible infinite loop when all realms have decay disabled as well as allow for bit more comfortable unit testing.