### PR TITLE
Typing: Add support to print AST node

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -1040,6 +1040,7 @@ PackageRoot (path to package root)
 [GenerateListing (0/1 {default 0})]
 [GenerateDebugInfo  (0/1 {default 0})]
 [GenerateDebugTextInfo (0/1 {default 0})]
+[GenerateStringTree (0/1 {default 0})]
 [DisplayWarnings (0/1 {default 0})]           //same as -w flag
 [CompileAspPages (0/1 {default 0})]           //same as -a flag
 [OnlyCompileUpdatedScripts (0/1 {default 0})] //same as -u flag

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -238,6 +238,8 @@ set (bscript_sources    # sorted !
   compiler/codegen/InstructionGenerator.h
   compiler/codegen/ModuleDeclarationRegistrar.cpp
   compiler/codegen/ModuleDeclarationRegistrar.h
+  compiler/codegen/StringTreeGenerator.cpp
+  compiler/codegen/StringTreeGenerator.h
   compiler/file/ConformingCharStream.cpp
   compiler/file/ConformingCharStream.h
   compiler/file/ErrorListener.cpp

--- a/pol-core/bscript/compiler/Compiler.cpp
+++ b/pol-core/bscript/compiler/Compiler.cpp
@@ -6,6 +6,7 @@
 #include "bscript/compiler/analyzer/SemanticAnalyzer.h"
 #include "bscript/compiler/astbuilder/CompilerWorkspaceBuilder.h"
 #include "bscript/compiler/codegen/CodeGenerator.h"
+#include "bscript/compiler/codegen/StringTreeGenerator.h"
 #include "bscript/compiler/file/PrettifyBuilder.h"
 #include "bscript/compiler/file/SourceFileCache.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
@@ -49,6 +50,12 @@ void Compiler::write_listing( const std::string& pathname )
     std::ofstream ofs( pathname );
     ListingWriter( *output ).write( ofs );
   }
+}
+
+void Compiler::write_string_tree( const std::string& pathname )
+{
+  std::ofstream ofs( pathname );
+  ofs << tree;
 }
 
 void Compiler::write_dbg( const std::string& pathname, bool include_debug_text )
@@ -125,6 +132,13 @@ void Compiler::compile_file_steps( const std::string& pathname, Report& report )
   analyze( *workspace, report );
   if ( report.error_count() )
     return;
+
+  if ( compilercfg.GenerateStringTree )
+  {
+    StringTreeGenerator generator;
+    workspace->accept( generator );
+    tree = generator.tree();
+  }
 
   output = generate( std::move( workspace ), report );
 }

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -47,7 +47,6 @@ private:
   SourceFileCache& inc_cache;
   Profile& profile;
   std::unique_ptr<CompiledScript> output;
-  std::string tree;
   UserFunctionInclusion user_function_inclusion = UserFunctionInclusion::ReferencedOnly;
 };
 

--- a/pol-core/bscript/compiler/Compiler.h
+++ b/pol-core/bscript/compiler/Compiler.h
@@ -25,6 +25,7 @@ public:
   bool compile_file( const std::string& filename );
   bool write_ecl( const std::string& pathname );
   void write_listing( const std::string& pathname );
+  void write_string_tree( const std::string& pathname );
   void write_dbg( const std::string& pathname, bool include_debug_text );
   void write_included_filenames( const std::string& pathname );
   void set_include_compile_mode();
@@ -46,6 +47,7 @@ private:
   SourceFileCache& inc_cache;
   Profile& profile;
   std::unique_ptr<CompiledScript> output;
+  std::string tree;
   UserFunctionInclusion user_function_inclusion = UserFunctionInclusion::ReferencedOnly;
 };
 

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -14,6 +14,7 @@
 #include "bscript/compiler/codegen/InstructionEmitter.h"
 #include "bscript/compiler/codegen/InstructionGenerator.h"
 #include "bscript/compiler/codegen/ModuleDeclarationRegistrar.h"
+#include "bscript/compiler/codegen/StringTreeGenerator.h"
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/FlowControlLabel.h"
@@ -27,7 +28,7 @@
 namespace Pol::Bscript::Compiler
 {
 std::unique_ptr<CompiledScript> CodeGenerator::generate(
-    std::unique_ptr<CompilerWorkspace> workspace, Report& report )
+    std::unique_ptr<CompilerWorkspace> workspace, Report& report, bool with_string_tree )
 {
   auto program_info =
       workspace->program
@@ -73,11 +74,20 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
 
   std::vector<ClassDescriptor> class_descriptors = class_declaration_registrar.take_descriptors();
 
+  std::string tree;
+
+  if ( with_string_tree )
+  {
+    StringTreeGenerator generator;
+    workspace->accept( generator );
+    tree = generator.tree();
+  }
+
   return std::make_unique<CompiledScript>(
       std::move( code ), std::move( data ), std::move( debug ), std::move( exported_functions ),
       std::move( workspace->global_variable_names ), std::move( module_descriptors ),
       std::move( function_references ), std::move( class_descriptors ), std::move( program_info ),
-      std::move( workspace->referenced_source_file_identifiers ) );
+      std::move( workspace->referenced_source_file_identifiers ), std::move( tree ) );
 }
 
 CodeGenerator::CodeGenerator( InstructionEmitter& emitter,

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.h
@@ -16,7 +16,7 @@ class CodeGenerator
 {
 public:
   static std::unique_ptr<CompiledScript> generate( std::unique_ptr<CompilerWorkspace>,
-                                                   Report& report );
+                                                   Report& report, bool with_string_tree );
 
 private:
   CodeGenerator( InstructionEmitter&, ModuleDeclarationRegistrar& );

--- a/pol-core/bscript/compiler/codegen/StringTreeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/StringTreeGenerator.cpp
@@ -1,0 +1,15 @@
+#include "StringTreeGenerator.h"
+
+#include "bscript/compiler/ast/Node.h"
+#include "bscript/compiler/file/SourceFileIdentifier.h"
+
+namespace Pol::Bscript::Compiler
+{
+StringTreeGenerator::StringTreeGenerator() {}
+
+void StringTreeGenerator::visit_children( Node& parent )
+{
+  if ( parent.source_location.source_file_identifier->index == 0 )
+    _tree += parent.to_string_tree();
+}
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/codegen/StringTreeGenerator.h
+++ b/pol-core/bscript/compiler/codegen/StringTreeGenerator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "bscript/compiler/ast/NodeVisitor.h"
+
+#include <string>
+
+namespace Pol::Bscript::Compiler
+{
+class StringTreeGenerator : public NodeVisitor
+{
+public:
+  StringTreeGenerator();
+
+  void visit_children( Node& parent ) override;
+
+  const std::string& tree() const { return _tree; }
+
+private:
+  std::string _tree;
+};
+
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/representation/CompiledScript.cpp
+++ b/pol-core/bscript/compiler/representation/CompiledScript.cpp
@@ -12,11 +12,14 @@
 
 namespace Pol::Bscript::Compiler
 {
-CompiledScript::CompiledScript(
-    CodeSection code, DataSection data, DebugStore debug, ExportedFunctions exported_functions,
-    std::vector<std::string> global_variable_names, ModuleDescriptors module_descriptors,
-    FunctionReferences function_references, ClassDescriptors class_descriptors,
-    std::unique_ptr<ProgramInfo> program_info, SourceFileIdentifiers source_file_identifiers )
+CompiledScript::CompiledScript( CodeSection code, DataSection data, DebugStore debug,
+                                ExportedFunctions exported_functions,
+                                std::vector<std::string> global_variable_names,
+                                ModuleDescriptors module_descriptors,
+                                FunctionReferences function_references,
+                                ClassDescriptors class_descriptors,
+                                std::unique_ptr<ProgramInfo> program_info,
+                                SourceFileIdentifiers source_file_identifiers, std::string tree )
     : code( std::move( code ) ),
       data( std::move( data ) ),
       debug( std::move( debug ) ),
@@ -26,7 +29,8 @@ CompiledScript::CompiledScript(
       function_references( std::move( function_references ) ),
       class_descriptors( std::move( class_descriptors ) ),
       program_info( std::move( program_info ) ),
-      source_file_identifiers( std::move( source_file_identifiers ) )
+      source_file_identifiers( std::move( source_file_identifiers ) ),
+      tree( std::move( tree ) )
 {
 }
 

--- a/pol-core/bscript/compiler/representation/CompiledScript.h
+++ b/pol-core/bscript/compiler/representation/CompiledScript.h
@@ -41,7 +41,7 @@ public:
                   ExportedFunctions exported_functions,
                   std::vector<std::string> global_variable_names, ModuleDescriptors modules,
                   FunctionReferences function_references, ClassDescriptors class_descriptors,
-                  std::unique_ptr<ProgramInfo>, SourceFileIdentifiers );
+                  std::unique_ptr<ProgramInfo>, SourceFileIdentifiers, std::string tree );
   ~CompiledScript();
   CompiledScript( const CompiledScript& ) = delete;
   CompiledScript& operator=( const CompiledScript& ) = delete;
@@ -56,6 +56,7 @@ public:
   const ClassDescriptors class_descriptors;
   const std::unique_ptr<ProgramInfo> program_info;
   const SourceFileIdentifiers source_file_identifiers;
+  const std::string tree;
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compilercfg.cpp
+++ b/pol-core/bscript/compilercfg.cpp
@@ -46,6 +46,7 @@ void CompilerConfig::Read( const std::string& path )
   GenerateListing = elem.remove_bool( "GenerateListing", false );
   GenerateDebugInfo = elem.remove_bool( "GenerateDebugInfo", false );
   GenerateDebugTextInfo = elem.remove_bool( "GenerateDebugTextInfo", false );
+  GenerateStringTree = elem.remove_bool( "GenerateStringTree", false );
 
   VerbosityLevel = elem.remove_int( "VerbosityLevel", 0 );
   DisplayWarnings = elem.remove_bool( "DisplayWarnings", false );

--- a/pol-core/bscript/compilercfg.h
+++ b/pol-core/bscript/compilercfg.h
@@ -23,6 +23,7 @@ struct CompilerConfig
   bool GenerateListing;
   bool GenerateDebugInfo;
   bool GenerateDebugTextInfo;
+  bool GenerateStringTree;
   int VerbosityLevel;
   bool DisplayWarnings;
   bool DisplayDebugs;

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -67,6 +67,7 @@ void ECompileMain::showHelp()
       "   Options: \n"
       "       -F           format filespec (print result)\n"
       "       -Fi          format filespec (inplace)\n"
+      "       -Z           print abstract syntax tree (AST) as string tree\n"
       "       -a           compile *.asp pages also\n"
       "       -A           automatically compile scripts in main and enabled packages\n"
       "       -Au          (as '-A' but only compile updated files)\n"
@@ -362,6 +363,7 @@ bool compile_file( const std::string& path )
   std::string fname = path;
   std::string filename_ecl = fname.replace( pos, 4, ".ecl" );
   std::string filename_lst = fname.replace( pos, 4, ".lst" );
+  std::string filename_ast = fname.replace( pos, 4, ".ast" );
   std::string filename_dep = fname.replace( pos, 4, ".dep" );
   std::string filename_dbg = fname.replace( pos, 4, ".dbg" );
 
@@ -458,6 +460,19 @@ bool compile_file( const std::string& path )
       if ( !quiet )
         INFO_PRINTLN( "Deleting:  {}", filename_lst );
       Clib::RemoveFile( filename_lst );
+    }
+
+    if ( compilercfg.GenerateStringTree )
+    {
+      if ( !quiet )
+        INFO_PRINTLN( "Writing:   {}", filename_ast );
+      compiler->write_string_tree( filename_ast );
+    }
+    else if ( Clib::FileExists( filename_ast.c_str() ) )
+    {
+      if ( !quiet )
+        INFO_PRINTLN( "Deleting:  {}", filename_ast );
+      Clib::RemoveFile( filename_ast );
     }
 
     if ( compilercfg.GenerateDebugInfo )
@@ -702,6 +717,10 @@ int readargs( int argc, char** argv )
       case 'x':
         compilercfg.GenerateDebugInfo = setting_value( arg );
         compilercfg.GenerateDebugTextInfo = ( argv[i][2] == 't' );
+        break;
+
+      case 'Z':
+        compilercfg.GenerateStringTree = setting_value( arg );
         break;
 
 #ifdef WIN32

--- a/testsuite/escript/.gitignore
+++ b/testsuite/escript/.gitignore
@@ -5,3 +5,4 @@
 *.txt
 *.dep
 *.tst
+*.ast

--- a/testsuite/escript/ast/ast001.out
+++ b/testsuite/escript/ast/ast001.out
@@ -1,0 +1,11 @@
+- top-level-statements
+  - value-consumer
+    - function-call(foo)
+- user-function(foo)
+  - function-parameter-list
+  - user-function-body
+    - value-consumer
+      - function-call(print_astfile)
+        - string-value("ast001")
+    - return-statement
+      - integer-value(0)

--- a/testsuite/escript/ast/ast001.src
+++ b/testsuite/escript/ast/ast001.src
@@ -1,0 +1,8 @@
+include "astfile";
+
+function foo()
+  print_astfile( "ast001" );
+  return 0;
+endfunction
+
+foo();

--- a/testsuite/escript/ast/astfile.inc
+++ b/testsuite/escript/ast/astfile.inc
@@ -1,0 +1,9 @@
+use file;
+
+function print_astfile( test )
+  var lines := ReadFile( $"./ast/{test}.ast" );
+  if ( !lines )
+    return print( lines );
+  endif
+  print( "\n".join( lines ) );
+endfunction


### PR DESCRIPTION
This is a preliminary PR to typing support, in order to test AST building correctly.

This functionality can (should?) be removed prior to final merge into master, as there is no real benefit to printing an AST IMO.