### PR TITLE
Add Script object script method `stacktrace`

### DIFF
--- a/cmake/escripttest.cmake
+++ b/cmake/escripttest.cmake
@@ -17,7 +17,7 @@ endif()
 # set(keepfailedformats TRUE)
 
 function (cleanup scriptname)
-  foreach (ext .ecl .tst .lst .unformatted.src .formatted.src)
+  foreach (ext .ecl .tst .lst .unformatted.src .formatted.src .dbg)
     if(EXISTS "${scriptname}${ext}")
       if ("${ext}" STREQUAL ".formatted.src" AND DEFINED keepfailedformats)
         continue()

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>11-13-2024</datemodified>
+		<datemodified>01-04-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>01-04-2024</date>
+			<author>Kevin:</author>
+			<change type="Added">Script script method `stacktrace( options? )`</change>
+		</entry>
 		<entry>
 			<date>11-13-2024</date>
 			<author>Turley:</author>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,7 +8,7 @@
 		<entry>
 			<date>01-04-2024</date>
 			<author>Kevin:</author>
-			<change type="Added">Script script method `stacktrace( options? )`</change>
+			<change type="Added">Script object script method `stacktrace( options? )`</change>
 		</entry>
 		<entry>
 			<date>11-13-2024</date>

--- a/docs/docs.polserver.com/pol100/objref.xml
+++ b/docs/docs.polserver.com/pol100/objref.xml
@@ -631,6 +631,7 @@ Checks are made in the order above.</member>
 <method proto="kill()" returns="true">Kills this script</method>
 <method proto="loadsymbols()" returns="Boolean">Loads the .dbg file</method>
 <method proto="clear_event_queue()" returns="true">clears the event queue of the script</method>
+<method proto="stacktrace( options?: struct{ format?: 'string' | 'array' } | uninit )" returns="Array/String">Get information regarding the current execution stack of this script. The value is either a string containing a line for each stack frame, or an array of objects representing each stack frame. <code>options</code> is a struct specifying the format to return via setting a member <code>format</code> to the value <code>"string"</code> (default) or <code>"array"</code>. If <code>"array"</code>, then the result will be an array containing structs with members <code>pc</code> (program counter), <code>file</code> (script name), <code>name</code> (function name), and <code>line</code> (script line).<br/><br/>The script must been compiled with debugging information (using ecompile.cfg setting <code>GenerateDebugInfo</code> or ecompile <code>-x</code> flag) in order to get function name and line information. If debug information is not available, then only the script's program counter will be reported.</method>
 <method proto="get_member(string membername)" returns="object, value of member or error">Gets the value of the built-in member 'membername'. var objname := obj.get_member("name") is the same as var objname := obj.name</method>
 </class>
 

--- a/pol-core/bscript/eprog.h
+++ b/pol-core/bscript/eprog.h
@@ -160,7 +160,7 @@ public:
   void dump_casejmp( std::ostream& os, const Token& token );
   int write( const char* fname );
   int read( const char* fname );
-  int read_dbg_file();
+  int read_dbg_file( bool quiet = false );
   int read_progdef_hdr( FILE* fp );
   int read_module( FILE* fp );
   int read_globalvarnames( FILE* fp );

--- a/pol-core/bscript/eprog_read.cpp
+++ b/pol-core/bscript/eprog_read.cpp
@@ -495,7 +495,7 @@ int EScriptProgram::read_class_table( FILE* fp )
   return 0;
 }
 
-int EScriptProgram::read_dbg_file()
+int EScriptProgram::read_dbg_file( bool quiet )
 {
   if ( debug_loaded )
     return 0;
@@ -505,7 +505,8 @@ int EScriptProgram::read_dbg_file()
   FILE* fp = fopen( mname.c_str(), "rb" );
   if ( !fp )
   {
-    ERROR_PRINTLN( "Unable to open {}", mname );
+    if ( !quiet ) 
+      ERROR_PRINTLN( "Unable to open {}", mname );
     return -1;
   }
 

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -3040,7 +3040,7 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
 
 BObjectImp* Executor::get_stacktrace( bool as_array )
 {
-  bool has_symbols = prog_->read_dbg_file() == 0;
+  bool has_symbols = prog_->read_dbg_file( true ) == 0;
 
   auto with_dbginfo =
       [&]( const std::function<void( const std::string& /*file*/, unsigned int /*line*/,

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -3075,6 +3075,7 @@ BObjectImp* Executor::get_stacktrace( bool as_array )
             entry->addMember( "file", new String( filename ) );
             entry->addMember( "line", new BLong( line ) );
             entry->addMember( "name", new String( functionName ) );
+            entry->addMember( "pc", new BLong( PC ) );
             result->addElement( entry.release() );
           } );
     }

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -14,6 +14,7 @@
 
 
 #include "executor.h"
+#include "executor.inl.h"
 
 #include "../clib/clib.h"
 #include "../clib/logfacility.h"
@@ -3033,6 +3034,87 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
     }
     POLLOGLN( tmp );
     seterror( true );
+  }
+}
+
+
+BObjectImp* Executor::get_stacktrace( bool as_array )
+{
+  bool has_symbols = prog_->read_dbg_file() == 0;
+
+  auto with_dbginfo =
+      [&]( const std::function<void( const std::string& /*file*/, unsigned int /*line*/,
+                                     const std::string& /*functionName*/ )>& handler )
+  {
+    walkCallStack(
+        [&]( unsigned int pc )
+        {
+          auto filename = prog()->dbg_filenames[prog()->dbg_filenum[pc]];
+          auto line = prog()->dbg_linenum[pc];
+          auto dbgFunction =
+              std::find_if( prog()->dbg_functions.begin(), prog()->dbg_functions.end(),
+                            [&]( auto& i ) { return i.firstPC <= pc && pc <= i.lastPC; } );
+
+          std::string functionName =
+              dbgFunction != prog()->dbg_functions.end() ? dbgFunction->name : "<program>";
+
+          handler( filename, line, functionName );
+        } );
+  };
+
+  if ( as_array )
+  {
+    std::unique_ptr<ObjArray> result( new ObjArray );
+
+    if ( has_symbols )
+    {
+      with_dbginfo(
+          [&]( const std::string& filename, unsigned int line, const std::string& functionName )
+          {
+            std::unique_ptr<BStruct> entry( new BStruct );
+            entry->addMember( "file", new String( filename ) );
+            entry->addMember( "line", new BLong( line ) );
+            entry->addMember( "name", new String( functionName ) );
+            result->addElement( entry.release() );
+          } );
+    }
+    else
+    {
+      walkCallStack(
+          [&]( unsigned int PC )
+          {
+            std::unique_ptr<BStruct> entry( new BStruct );
+            entry->addMember( "file", new String( scriptname() ) );
+            entry->addMember( "pc", new BLong( PC ) );
+            result->addElement( entry.release() );
+          } );
+    }
+
+    return result.release();
+  }
+  else  // as string
+  {
+    std::string result;
+
+    if ( has_symbols )
+    {
+      with_dbginfo(
+          [&]( const std::string& filename, unsigned int line, const std::string& functionName )
+          {
+            result.append( fmt::format( "{}at {} ({}:{})", result.empty() ? "" : "\n", functionName,
+                                        filename, line ) );
+          } );
+    }
+    else
+    {
+      walkCallStack(
+          [&]( unsigned int PC ) {
+            result.append(
+                fmt::format( "{}at {}+{}", result.empty() ? "" : "\n", scriptname(), PC ) );
+          } );
+    }
+
+    return new String( std::move( result ) );
   }
 }
 

--- a/pol-core/bscript/executor.h
+++ b/pol-core/bscript/executor.h
@@ -241,6 +241,10 @@ public:
   // on `fparams` (as they are moved to `ValueStack` in `ins_call_method_id`).
   BContinuation* withContinuation( BContinuation* continuation, BObjectRefVec args = {} );
 
+  // Runs `callback( unsigned int PC )` for every frame in the call stack.
+  template <typename Callback>
+  void walkCallStack( Callback callback );
+
   int makeString( unsigned param );
   bool hasParams( unsigned howmany ) const { return ( fparams.size() >= howmany ); }
   size_t numParams() const { return fparams.size(); }
@@ -475,6 +479,14 @@ public:
   // sets up members (Globals2, nLines, prog_, execmodules) accordingly.
   void jump( int target_PC, BContinuation* continuation, BFunctionRef* funcref );
 
+  // Returns the current execution stack of this executor. The returned object
+  // is either a string containing a line for each stack frame, or an array of
+  // objects representing each stack frame.
+  //
+  // Will load the debug symbols for the current program. If debug symbols are
+  // not available, only program counter information will be available, and
+  // filename+line+function name will be empty.
+  BObjectImp* get_stacktrace( bool as_array );
 
   bool attach_debugger( std::weak_ptr<ExecutorDebugListener> listener = {},
                         bool set_attaching = true );

--- a/pol-core/bscript/executor.inl.h
+++ b/pol-core/bscript/executor.inl.h
@@ -1,6 +1,8 @@
 // Really for IDE integration
 #include "bobject.h"
 
+#include <boost/range/adaptor/reversed.hpp>
+
 namespace Pol::Bscript
 {
 template <typename Callback>
@@ -56,3 +58,15 @@ BObjectImp* Executor::makeContinuation( BObjectRef funcref, Callback callback, B
       details );
 }
 }  // namespace Pol::Bscript
+
+template <typename Callback>
+inline void Pol::Bscript::Executor::walkCallStack( Callback callback )
+{
+  callback( PC );
+  
+  for ( auto& call : boost::adaptors::reverse( ControlStack ) )
+  {
+    callback( call.PC );
+  }
+
+}

--- a/pol-core/bscript/objaccess.cpp
+++ b/pol-core/bscript/objaccess.cpp
@@ -479,6 +479,7 @@ ObjMethod object_methods[] = {
     { MTH_SET_MULTIID, "set_multiid", false },
     { MTH_NEW, "new", false },
     { MTH_CALL_METHOD, "call_method", false },  // internal, does not need objref.xml documentation
+    { MTH_STACKTRACE, "stacktrace", false },
 };
 int n_objmethods = sizeof object_methods / sizeof object_methods[0];
 ObjMethod* getKnownObjMethod( const char* token )

--- a/pol-core/bscript/objmethods.h
+++ b/pol-core/bscript/objmethods.h
@@ -193,6 +193,7 @@ enum MethodID
   MTH_SET_MULTIID,
   MTH_NEW,
   MTH_CALL_METHOD,
+  MTH_STACKTRACE,
 };
 
 inline auto format_as( MethodID id )

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+01-04-2024 Kevin:
+    Added: Script script method `stacktrace( options? )`
 11-13-2024 Turley:
     Added: regions.cfg ItemsDecay setting, if deactivated items will not decay in this area.
     Added: multi.items_decay r/w member, defaults to also added itemdesc.cfg entry ItemsDecay (1/0 default 0). If set to 1 items in this multi will decay.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,6 @@
 -- POL100.2.0 --
 01-04-2024 Kevin:
-    Added: Script script method `stacktrace( options? )`
+    Added: Script object script method `stacktrace( options? )`
 11-13-2024 Turley:
     Added: regions.cfg ItemsDecay setting, if deactivated items will not decay in this area.
     Added: multi.items_decay r/w member, defaults to also added itemdesc.cfg entry ItemsDecay (1/0 default 0). If set to 1 items in this multi will decay.

--- a/pol-core/pol/exscrobj.cpp
+++ b/pol-core/pol/exscrobj.cpp
@@ -130,6 +130,47 @@ BObjectImp* ScriptExObjImp::call_polmethod_id( const int id, UOExecutor& ex, boo
   case MTH_CLEAR_EVENT_QUEUE:  // DAVE added this 11/20
     return ( uoexec->clear_event_queue() );
 
+    /**
+     * .stacktrace(options?: struct{ format?: "array" | "string" } | uninit )
+     */
+  case MTH_STACKTRACE:
+  {
+    bool as_array = false;
+
+    if ( ex.numParams() > 0 && !ex.getParamImp( 0 )->isa( OTUninit ) )
+    {
+      BStruct* options =
+          static_cast<BStruct*>( ex.getParamImp( 0, Bscript::BObjectImp::OTStruct ) );
+
+      if ( options == nullptr )
+      {
+        return new BError( "Invalid parameter type" );
+      }
+
+      if ( auto format_member = options->FindMember( "format" ) )
+      {
+        if ( !format_member->isa( OTString ) )
+        {
+          return new BError( "Invalid parameter type" );
+        }
+
+        auto format_string = format_member->getStringRep();
+
+        // Explicitly case sensitive!
+        if ( format_string == "array" )
+        {
+          as_array = true;
+        }
+        else if ( format_string != "string" )
+        {
+          return new BError( "Invalid parameter value" );
+        }
+      }
+    }
+
+    return uoexec->get_stacktrace( as_array );
+  }
+
   default:
     return new BError( "undefined" );
   }

--- a/testsuite/escript/ecompile.cfg
+++ b/testsuite/escript/ecompile.cfg
@@ -3,7 +3,7 @@ IncludeDirectory 	.
 PolScriptRoot		.
 PackageRoot		.
 GenerateListing		0
-GenerateDebugInfo	0
+GenerateDebugInfo	1
 GenerateDebugTextInfo	0
 DisplayWarnings 1
 CompileAspPages 1

--- a/testsuite/pol/scripts/include/testutil.inc
+++ b/testsuite/pol/scripts/include/testutil.inc
@@ -1,4 +1,6 @@
+use file;
 use uo;
+use os;
 
 const IGNORE_TEST := 255; // only valid for setup or programs
 
@@ -80,6 +82,21 @@ class ResourceManager()
     return resource;
   endfunction
 
+  function Start_Script( this, script_name, byref param := 0 )
+    var resource := os::Start_Script( script_name, param );
+    if ( !resource )
+      return resource;
+    endif
+    this.resources.append( array{ resource, @DestroyScriptResource } );
+    return resource;
+  endfunction
+
+  function DestroyScriptResource( script )
+    dprint( $"cleanup script {script} {script.state} {script.pid}" );
+    // Swallow the "Script has been destroyed" error
+    return script.kill() ?: 1;
+  endfunction
+
   function DestroyItemResource( item )
     dprint( $"cleanup item 0x{item.serial:x}" );
     return DestroyItem( item );
@@ -115,3 +132,30 @@ class ResourceManager()
     return ret_error( $"Could not find corpse for NPC 0x{serial:x} at ({x}, {y}, {z}) (corpses: {corpses.size()})" );
   endfunction
 endclass
+
+function copy_file( source, destination )
+  var file_in := OpenBinaryFile( source, OPENMODE_IN );
+  if ( !file_in )
+    return file_in;
+  endif
+
+  var file_out := OpenBinaryFile( destination, OPENMODE_OUT | OPENMODE_TRUNC );
+  if ( !file_out )
+    return file_out;
+  endif
+
+  var byte, i := 0;
+
+  do
+    byte := file_in.getInt8();
+    if ( byte == error )
+      break;
+    endif
+    file_out.setInt8( byte );
+  dowhile ( 1 );
+
+  file_in.close();
+  file_out.close();
+
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/misc/test_stacktrace.src
+++ b/testsuite/pol/testpkgs/misc/test_stacktrace.src
@@ -1,16 +1,90 @@
-use os;
 include "testutil";
 
-program test_stacktrace()
-  return 1;
+// Don't start this with 'test_' ... ;D
+const CHILD_SCRIPTNAME := ":testmisc:stacktrace_child.ecl";
+const TIMEOUT_SEC := 1;
+var ARRAY_FORMAT := struct{ format := "array" };
+
+program test_stacktrace( parent_script )
+  // A setup run, via test orchestrator
+  if ( !parent_script )
+    var res := copy_file( "test_stacktrace.ecl", CHILD_SCRIPTNAME );
+
+    if ( !res )
+      return ret_error( $"Could not copy file: {res}" );
+    endif
+    return 1;
+  endif
+
+  // Child process, started by a test function
+  return waiting_for_event( parent_script );
 endprogram
 
-function outer_frame( format )
-  return inner_frame( format );
+function waiting_for_event( parent_script )
+  parent_script.SendEvent( 1 );
+
+  // Sent from parent script to tell child to exit.
+  if ( wait_for_event( TIMEOUT_SEC ) )
+    return 1;
+  endif
+
+  return ret_error( "No event received in child process" );
 endfunction
 
-function inner_frame( format )
-  return GetProcess().stacktrace( struct{ "format" := format } );
+// The child has no debug info
+exported function test_stacktrace_child( resources )
+  var res;
+  var stacktrace;
+  var child;
+
+  // Go critical, so we do not get interrupted by the script scheduler between
+  // starting a new script and collecting its stacktrace.
+
+
+  Set_Critical( 1 );
+
+  if ( !( child := resources.Start_Script( CHILD_SCRIPTNAME, GetProcess() ) ) )
+    return child;
+  endif
+
+  // Collect initial stacktrace
+  stacktrace := child.stacktrace( ARRAY_FORMAT );
+
+  Set_Critical( 0 );
+
+  // Since we were critical when we started the script and collected its
+  // stacktrace, (1) it should only have one element: the program entry.
+  if ( !( res := ret_error_not_equal( len( stacktrace ), 1,
+                                      "Incorrect child stack length, expected 1 got {len(stacktrace)}" ) ) )
+    return res;
+  endif
+
+  // ... at PC=0. It is a `pc` since we do not have the dbg information
+  if ( !( res := ret_error_not_equal( stacktrace[1].pc, 0,
+                                      "Incorrect initial PC value, expected 0 got {stacktrace[1].pc}" ) ) )
+    return res;
+  endif
+
+  // Sent from child to tell parent that it has entered the user function 
+  // where it will wait for an event.
+  if ( !( res := wait_for_event( TIMEOUT_SEC ) ) )
+    return ret_error( $"No event in {TIMEOUT_SEC} seconds" );
+  endif
+
+  // Get a new stacktrace.
+  stacktrace := child.stacktrace( ARRAY_FORMAT );
+
+  // Since we've stepped the script to the os::wait_for_event inside the
+  // waiting_for_event, we should have a new frame.
+  if ( !( res := ret_error_not_equal( len( stacktrace ), 2,
+                                      "Incorrect child stack length, expected 2 got {len(stacktrace)}" ) ) )
+    return res;
+  endif
+
+  // Tell the script to continue / exit
+  child.sendevent( 1 );
+
+  return 1;
 endfunction
 
 exported function test_error_stacktrace_as_string()
@@ -95,4 +169,12 @@ exported function test_stacktrace_options_parsing()
   endif
 
   return 1;
+endfunction
+
+function outer_frame( format )
+  return inner_frame( format );
+endfunction
+
+function inner_frame( format )
+  return GetProcess().stacktrace( struct{ "format" := format } );
 endfunction

--- a/testsuite/pol/testpkgs/misc/test_stacktrace.src
+++ b/testsuite/pol/testpkgs/misc/test_stacktrace.src
@@ -40,7 +40,6 @@ exported function test_stacktrace_child( resources )
   // Go critical, so we do not get interrupted by the script scheduler between
   // starting a new script and collecting its stacktrace.
 
-
   Set_Critical( 1 );
 
   if ( !( child := resources.Start_Script( CHILD_SCRIPTNAME, GetProcess() ) ) )
@@ -59,13 +58,19 @@ exported function test_stacktrace_child( resources )
     return res;
   endif
 
-  // ... at PC=0. It is a `pc` since we do not have the dbg information
-  if ( !( res := ret_error_not_equal( stacktrace[1].pc, 0,
-                                      "Incorrect initial PC value, expected 0 got {stacktrace[1].pc}" ) ) )
+  var st := stacktrace[1];
+
+  // ... at PC=0.
+  if ( !( res := ret_error_not_equal( st.pc, 0, "Incorrect initial PC value, expected 0 got {st.pc}" ) ) )
     return res;
   endif
 
-  // Sent from child to tell parent that it has entered the user function 
+  // Since we do not have debug information, there should be no `line`.
+  if ( !( res := ret_error_not_equal( st.?line, 0, "Stacktrace should not have 'line' member, stacktrace object {st}" ) ) )
+    return res;
+  endif
+
+  // Sent from child to tell parent that it has entered the user function
   // where it will wait for an event.
   if ( !( res := wait_for_event( TIMEOUT_SEC ) ) )
     return ret_error( $"No event in {TIMEOUT_SEC} seconds" );
@@ -87,7 +92,7 @@ exported function test_stacktrace_child( resources )
   return 1;
 endfunction
 
-exported function test_error_stacktrace_as_string()
+exported function test_stacktrace_as_string()
   var stacktrace := outer_frame( "string" );
   var inner_frame_pos := stacktrace.find( "inner_frame" );
   var outer_frame_pos := stacktrace.find( "outer_frame" );
@@ -99,12 +104,12 @@ exported function test_error_stacktrace_as_string()
   return 1;
 endfunction
 
-exported function test_error_stacktrace_as_array()
+exported function test_stacktrace_as_array()
   var stacktrace := outer_frame( "array" );
 
   // The (ordered) name of functions called when calling `outer_frame()` above.
-  var expected_names := array{ "inner_frame", "outer_frame", "test_error_stacktrace_as_array",
-                               "test_error_stacktrace_as_array" };
+  var expected_names := array{ "inner_frame", "outer_frame", "test_stacktrace_as_array",
+                               "test_stacktrace_as_array" };
 
   // Get the function names from the stacktrace
   var stacktrace_names := stacktrace.map( @( st ) {

--- a/testsuite/pol/testpkgs/misc/test_stacktrace.src
+++ b/testsuite/pol/testpkgs/misc/test_stacktrace.src
@@ -1,0 +1,98 @@
+use os;
+include "testutil";
+
+program test_stacktrace()
+  return 1;
+endprogram
+
+function outer_frame( format )
+  return inner_frame( format );
+endfunction
+
+function inner_frame( format )
+  return GetProcess().stacktrace( struct{ "format" := format } );
+endfunction
+
+exported function test_error_stacktrace_as_string()
+  var stacktrace := outer_frame( "string" );
+  var inner_frame_pos := stacktrace.find( "inner_frame" );
+  var outer_frame_pos := stacktrace.find( "outer_frame" );
+
+  if ( inner_frame_pos >= outer_frame_pos )
+    return ret_error( $"Incorrect frame order in stacktrace: expected inner_frame position {inner_frame_pos} < outer_frame position {outer_frame_pos}.\n\nStacktrace string: {stacktrace}" );
+  endif
+
+  return 1;
+endfunction
+
+exported function test_error_stacktrace_as_array()
+  var stacktrace := outer_frame( "array" );
+
+  // The (ordered) name of functions called when calling `outer_frame()` above.
+  var expected_names := array{ "inner_frame", "outer_frame", "test_error_stacktrace_as_array",
+                               "test_error_stacktrace_as_array" };
+
+  // Get the function names from the stacktrace
+  var stacktrace_names := stacktrace.map( @( st ) {
+    return st.name;
+  } );
+
+  return ret_error_not_equal( expected_names, stacktrace_names,
+                              $"Incorrect stacktrace object. Expected frame names of {expected_names}, got {stacktrace_names}\n\nStacktrace object: {stacktrace}"
+                              );
+endfunction
+
+exported function test_stacktrace_options_parsing()
+  var res;
+
+  var check_type := @( how, expected_type ) {
+    var return_type := TypeOfInt( how() );
+    return ret_error_not_equal( return_type, expected_type, $"Unexpected type: Expected {expected_type}, got {return_type} {GetProcess().stacktrace()}"
+                                );
+  };
+
+  // Can pass no arguments
+  if ( !( res := check_type( @() {
+    return GetProcess().stacktrace();
+  }, OT_STRING ) ) )
+    return res;
+
+  // Can pass uninit
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( uninit );
+  }, OT_STRING ) ) )
+    return res;
+
+  // Otherwise must be a struct
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( 123 );
+  }, OT_ERROR ) ) )
+    return res;
+
+  // And that struct can have no options
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( struct{} );
+  }, OT_STRING ) ) )
+    return res;
+
+  // But if a format is passed, it must be an accepted type of format
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( struct{ format := "invalid-format" } );
+  }, OT_ERROR ) ) )
+    return res;
+
+  // And those formats are "string", returning a string
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( struct{ format := "string" } );
+  }, OT_STRING ) ) )
+    return res;
+
+  // And "array", returning an array
+  elseif ( !( res := check_type( @() {
+    return GetProcess().stacktrace( struct{ format := "array" } );
+  }, OT_ARRAY ) ) )
+    return res;
+  endif
+
+  return 1;
+endfunction


### PR DESCRIPTION
Add `stacktrace` method to the `Script` object to get information regarding the script's execution stack.

Can be returned as either a user-friendly string, or an array containing objects for in-depth functionality.