### PR TITLE
Add hidden flag to invisible items

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-30-2025</datemodified>
+		<datemodified>02-01-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-01-2025</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Invisible items will now send the "hidden" flag if the character can see invisible items.</change>
+		</entry>
 		<entry>
 			<date>01-30-2025</date>
 			<author>AsYlum:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+02-01-2025 Kevin:
+    Fixed: Invisible items will now send the "hidden" flag if the character can see invisible items.
 01-30-2025 AsYlum:
     Fixed: Missing attack range properties defaults in itemdesc.
            

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -619,6 +619,8 @@ void send_item( Client* client, const Item* item )
   u8 flags = 0;
   if ( client->chr->can_move( item ) )
     flags |= ITEM_FLAG_FORCE_MOVABLE;
+  if ( item->invisible() )
+    flags |= ITEM_FLAG_HIDDEN;
 
   auto pkt = SendWorldItem( item->serial, item->graphic, item->get_senditem_amount(), item->pos3d(),
                             item->facing, item->color, flags );
@@ -660,6 +662,8 @@ void send_item_to_inrange( const Item* item )
         u8 flags = 0;
         if ( zonechr->can_move( item ) )
           flags |= ITEM_FLAG_FORCE_MOVABLE;
+        if ( item->invisible() )
+          flags |= ITEM_FLAG_HIDDEN;
         pkt.updateFlags( flags );
         pkt.Send( zonechr->client );
 

--- a/testsuite/pol/testpkgs/client/test_client_seeinvisitems.src
+++ b/testsuite/pol/testpkgs/client/test_client_seeinvisitems.src
@@ -1,0 +1,85 @@
+include "communication";
+include "testutil";
+
+use uo;
+
+const ITEM_FLAG_HIDDEN := 0x80;
+
+var char;
+var charX := 100;
+var charY := 50;
+var clientcon := getClientConnection();
+
+program test_item_move()
+  var a := FindAccount( "testclient0" );
+  char := a.getcharacter( 1 );
+  if ( !char )
+    return ret_error( "Could not find char at slot 1" );
+  endif
+
+  // Move character somewhere nice.
+  var res := MoveObjectToLocation( char, charX, charY, 0 );
+  if ( !res )
+    return ret_error( $"Could not move character: ${res}" );
+  endif
+
+  grantprivilege( char, "seeinvisitems" );
+  char.disable( "seeinvisitems" );
+
+  return 1;
+endprogram
+
+exported function see_invis_items( resources )
+  var ev;
+
+  var item := resources.CreateItemAtLocation( char.x, char.y, char.z, 0x1F03 );
+  if ( !item )
+    return ret_error( $"Could not create item: {item}" );
+  endif
+
+  // Receive NEW_ITEM with flags = 0
+  while ( 1 )
+    ev := waitForClient( 0, { EVT_NEW_ITEM } );
+    if ( !ev )
+      return ev;
+    elseif ( ev.serial == item.serial )
+      break;
+    endif
+  endwhile
+  if ( ev.status != 0 )
+    return ret_error( $"Expected status 0, got {ev.status}" );
+  endif
+
+  // Set item invisible, receive EVT_REMOVED_OBJ
+  item.invisible := 1;
+  while ( 1 )
+    ev := waitForClient( 0, { EVT_REMOVED_OBJ } );
+    if ( !ev )
+      return ev;
+    elseif ( ev.serial == item.serial )
+      break;
+    endif
+  endwhile
+
+
+  // Enable privilege, and receive NEW_ITEM with flags = HIDDEN
+  char.enable( "seeinvisitems" );
+
+  while ( 1 )
+    ev := waitForClient( 0, { EVT_NEW_ITEM } );
+    if ( !ev )
+      char.disable( "seeinvisitems" );
+      return ev;
+    elseif ( ev.serial == item.serial )
+      break;
+    endif
+  endwhile
+
+  if ( ev.status != ITEM_FLAG_HIDDEN )
+    return ret_error( $"Expected status {ITEM_FLAG_HIDDEN}, got {ev.status}" );
+  endif
+
+  char.disable( "seeinvisitems" );
+
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_seeinvisitems.src
+++ b/testsuite/pol/testpkgs/client/test_client_seeinvisitems.src
@@ -30,56 +30,58 @@ program test_item_move()
 endprogram
 
 exported function see_invis_items( resources )
-  var ev;
+  var ret := @() {
+    var ev;
 
-  var item := resources.CreateItemAtLocation( char.x, char.y, char.z, 0x1F03 );
-  if ( !item )
-    return ret_error( $"Could not create item: {item}" );
-  endif
-
-  // Receive NEW_ITEM with flags = 0
-  while ( 1 )
-    ev := waitForClient( 0, { EVT_NEW_ITEM } );
-    if ( !ev )
-      return ev;
-    elseif ( ev.serial == item.serial )
-      break;
+    var item := resources.CreateItemAtLocation( char.x, char.y, char.z, 0x1F03 );
+    if ( !item )
+      return ret_error( $"Could not create item: {item}" );
     endif
-  endwhile
-  if ( ev.status != 0 )
-    return ret_error( $"Expected status 0, got {ev.status}" );
-  endif
 
-  // Set item invisible, receive EVT_REMOVED_OBJ
-  item.invisible := 1;
-  while ( 1 )
-    ev := waitForClient( 0, { EVT_REMOVED_OBJ } );
-    if ( !ev )
-      return ev;
-    elseif ( ev.serial == item.serial )
-      break;
+    // Receive NEW_ITEM with flags = 0
+    while ( 1 )
+      ev := waitForClient( 0, { EVT_NEW_ITEM } );
+      if ( !ev )
+        return ev;
+      elseif ( ev.serial == item.serial )
+        break;
+      endif
+    endwhile
+    if ( ev.status != 0 )
+      return ret_error( $"Expected status 0, got {ev.status}" );
     endif
-  endwhile
 
+    // Set item invisible, receive EVT_REMOVED_OBJ
+    item.invisible := 1;
+    while ( 1 )
+      ev := waitForClient( 0, { EVT_REMOVED_OBJ } );
+      if ( !ev )
+        return ev;
+      elseif ( ev.serial == item.serial )
+        break;
+      endif
+    endwhile
 
-  // Enable privilege, and receive NEW_ITEM with flags = HIDDEN
-  char.enable( "seeinvisitems" );
+    // Enable privilege, and receive NEW_ITEM with flags = HIDDEN
+    char.enable( "seeinvisitems" );
 
-  while ( 1 )
-    ev := waitForClient( 0, { EVT_NEW_ITEM } );
-    if ( !ev )
-      char.disable( "seeinvisitems" );
-      return ev;
-    elseif ( ev.serial == item.serial )
-      break;
+    while ( 1 )
+      ev := waitForClient( 0, { EVT_NEW_ITEM } );
+      if ( !ev )
+        return ev;
+      elseif ( ev.serial == item.serial )
+        break;
+      endif
+    endwhile
+
+    if ( !( ev.status & ITEM_FLAG_HIDDEN ) )
+      return ret_error( $"Expected status {ITEM_FLAG_HIDDEN}, got {ev.status}" );
     endif
-  endwhile
 
-  if ( ev.status != ITEM_FLAG_HIDDEN )
-    return ret_error( $"Expected status {ITEM_FLAG_HIDDEN}, got {ev.status}" );
-  endif
+    return 1;
+  }();
 
   char.disable( "seeinvisitems" );
 
-  return 1;
+  return ret;
 endfunction

--- a/testsuite/testclient/pyuo/testclient.py
+++ b/testsuite/testclient/pyuo/testclient.py
@@ -275,6 +275,7 @@ class PolServer:
       res["serial"]=obj.serial
       res["pos"]=ev.pos
       res["graphic"]=obj.graphic
+      res["status"]=obj.status
     elif ev.type==Event.EVT_REMOVED_OBJ:
       res["serial"]=ev.serial
       res["oldpos"]=ev.oldpos


### PR DESCRIPTION
Adds the `HIDDEN` flag to items, so clients will show them as hidden, eg:
![image](https://github.com/user-attachments/assets/1548361c-8e12-4f55-9446-6dd0c01f5782)

Fixes: #749 