### PR TITLE
Worldsave further improvements

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-04-2025</datemodified>
+		<datemodified>02-06-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-06-2025</date>
+			<author>Turley:</author>
+			<change type="Improved">world save performance</change>
+		</entry>
 		<entry>
 			<date>02-04-2025</date>
 			<author>Turley:</author>

--- a/pol-core/clib/streamsaver.h
+++ b/pol-core/clib/streamsaver.h
@@ -2,10 +2,12 @@
 
 #include <fmt/compile.h>
 #include <fmt/format.h>
+#include <fmt/os.h>
 #include <fmt/ostream.h>
 #include <fstream>
 #include <iosfwd>
 #include <iterator>
+#include <stdio.h>
 #include <string>
 #include <type_traits>
 
@@ -14,7 +16,7 @@ namespace Pol::Clib
 class StreamWriter
 {
 public:
-  StreamWriter( std::ostream& stream );
+  StreamWriter( const std::string& path );
   ~StreamWriter() noexcept( false );
   StreamWriter( const StreamWriter& ) = delete;
   StreamWriter& operator=( const StreamWriter& ) = delete;
@@ -22,19 +24,10 @@ public:
   template <typename T>
   void add( const std::string_view& key, T&& value )
   {
-    fmt::format_to( std::back_inserter( _mbuff ), FMT_COMPILE( "\t{}\t" ), key );
     if constexpr ( !std::is_same<std::decay_t<T>, bool>::value )
-    {
-      // shortcut for strings
-      if constexpr ( std::is_same<std::decay_t<T>, std::string>::value ||
-                     std::is_same<std::decay_t<T>, std::string_view>::value )
-        _mbuff.append( value );
-      else
-        fmt::format_to( std::back_inserter( _mbuff ), FMT_COMPILE( "{}" ), value );
-    }
+      fmt::format_to( std::back_inserter( _mbuff ), FMT_COMPILE( "\t{}\t{}\n" ), key, value );
     else  // force bool to write as 0/1
-      fmt::format_to( std::back_inserter( _mbuff ), FMT_COMPILE( "{:d}" ), value );
-    _mbuff.push_back( '\n' );
+      fmt::format_to( std::back_inserter( _mbuff ), FMT_COMPILE( "\t{}\t{:d}\n" ), key, value );
   }
   template <typename... Args>
   void comment( const std::string_view& formatstr, Args&&... args )
@@ -61,21 +54,19 @@ public:
   {
     using namespace std::literals;
     _mbuff.append( "}\n\n"sv );
-    if ( _mbuff.size() > 10'000 )
+    if ( _mbuff.size() > 0x8000 )
     {
-      _stream << std::string_view{ _mbuff.data(), _mbuff.size() };
+      fwrite( _mbuff.data(), sizeof( char ), _mbuff.size(), _file );
       _mbuff.clear();
     }
   }
-  void open_fstream( const std::string& filepath, std::ofstream& s );
-  void flush();
+  void flush_close();
 
 protected:
-  std::ostream& _stream;
+  FILE* _file;
   // formatting creates a temp buffer
   // to prevent this format into this buffer and when full write to disk, clear of the buffer keeps
   // the capacity
-  fmt::basic_memory_buffer<char, 10'000> _mbuff;
+  fmt::basic_memory_buffer<char, 0x8000> _mbuff;
 };
-
 }  // namespace Pol::Clib

--- a/pol-core/clib/streamsaver.h
+++ b/pol-core/clib/streamsaver.h
@@ -56,7 +56,9 @@ public:
     _mbuff.append( "}\n\n"sv );
     if ( _mbuff.size() > 0x8000 )
     {
-      fwrite( _mbuff.data(), sizeof( char ), _mbuff.size(), _file );
+      auto size = fwrite( _mbuff.data(), sizeof( char ), _mbuff.size(), _file );
+      if ( size < _mbuff.size() )
+        throw std::runtime_error{ "failed to write" };
       _mbuff.clear();
     }
   }

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+02-06-2025 Turley:
+ Improved: world save performance
 02-04-2025 Turley:
     Added: ssopt.cfg DefaultExpansion defines the default expansion for accounts. Supported values are T2A (default),LBR,AOS,SE,ML,KR,SA,HSA,TOL
     Fixed: HSA (and TOL) expansion did not activate gothic and rustic tiles for customhouses

--- a/pol-core/pol/accounts/accounts.cpp
+++ b/pol-core/pol/accounts/accounts.cpp
@@ -84,8 +84,7 @@ void write_account_data()
   bool result( true );
   try
   {
-    std::ofstream ofs( accountsndtfile_c, std::ios::trunc | std::ios::out );
-    Clib::StreamWriter sw( ofs );
+    Clib::StreamWriter sw( accountsndtfile_c );
     for ( const auto& account : Core::gamestate.accounts )
     {
       Account* acct = account.get();

--- a/pol-core/pol/module/datastore.cpp
+++ b/pol-core/pol/module/datastore.cpp
@@ -650,9 +650,7 @@ std::string DataStoreFile::filename() const
 
 void DataStoreFile::save() const
 {
-  std::string fname = filename();
-  std::ofstream ofs( fname.c_str(), std::ios::out );
-  Clib::StreamWriter sw( ofs );
+  Clib::StreamWriter sw( filename() );
   dfcontents->save( sw );
 }
 
@@ -721,7 +719,6 @@ void write_datastore( Clib::StreamWriter& sw )
     }
 
     dsf->printOn( sw );
-    // sw.flush();
   }
 }
 

--- a/pol-core/pol/savedata.cpp
+++ b/pol-core/pol/savedata.cpp
@@ -61,47 +61,20 @@ std::shared_future<void> SaveContext::finished;
 std::atomic<gameclock_t> SaveContext::last_worldsave_success = 0;
 
 SaveContext::SaveContext()
-    : _pol(),
-      _objects(),
-      _pcs(),
-      _pcequip(),
-      _npcs(),
-      _npcequip(),
-      _items(),
-      _multis(),
-      _storage(),
-      _resource(),
-      _guilds(),
-      _datastore(),
-      _party(),
-      pol( _pol ),
-      objects( _objects ),
-      pcs( _pcs ),
-      pcequip( _pcequip ),
-      npcs( _npcs ),
-      npcequip( _npcequip ),
-      items( _items ),
-      multis( _multis ),
-      storage( _storage ),
-      resource( _resource ),
-      guilds( _guilds ),
-      datastore( _datastore ),
-      party( _party )
+    : pol( Plib::systemstate.config.world_data_path + "pol.ndt" ),
+      objects( Plib::systemstate.config.world_data_path + "objects.ndt" ),
+      pcs( Plib::systemstate.config.world_data_path + "pcs.ndt" ),
+      pcequip( Plib::systemstate.config.world_data_path + "pcequip.ndt" ),
+      npcs( Plib::systemstate.config.world_data_path + "npcs.ndt" ),
+      npcequip( Plib::systemstate.config.world_data_path + "npcequip.ndt" ),
+      items( Plib::systemstate.config.world_data_path + "items.ndt" ),
+      multis( Plib::systemstate.config.world_data_path + "multis.ndt" ),
+      storage( Plib::systemstate.config.world_data_path + "storage.ndt" ),
+      resource( Plib::systemstate.config.world_data_path + "resource.ndt" ),
+      guilds( Plib::systemstate.config.world_data_path + "guilds.ndt" ),
+      datastore( Plib::systemstate.config.world_data_path + "datastore.ndt" ),
+      party( Plib::systemstate.config.world_data_path + "parties.ndt" )
 {
-  pol.open_fstream( Plib::systemstate.config.world_data_path + "pol.ndt", _pol );
-  objects.open_fstream( Plib::systemstate.config.world_data_path + "objects.ndt", _objects );
-  pcs.open_fstream( Plib::systemstate.config.world_data_path + "pcs.ndt", _pcs );
-  pcequip.open_fstream( Plib::systemstate.config.world_data_path + "pcequip.ndt", _pcequip );
-  npcs.open_fstream( Plib::systemstate.config.world_data_path + "npcs.ndt", _npcs );
-  npcequip.open_fstream( Plib::systemstate.config.world_data_path + "npcequip.ndt", _npcequip );
-  items.open_fstream( Plib::systemstate.config.world_data_path + "items.ndt", _items );
-  multis.open_fstream( Plib::systemstate.config.world_data_path + "multis.ndt", _multis );
-  storage.open_fstream( Plib::systemstate.config.world_data_path + "storage.ndt", _storage );
-  resource.open_fstream( Plib::systemstate.config.world_data_path + "resource.ndt", _resource );
-  guilds.open_fstream( Plib::systemstate.config.world_data_path + "guilds.ndt", _guilds );
-  datastore.open_fstream( Plib::systemstate.config.world_data_path + "datastore.ndt", _datastore );
-  party.open_fstream( Plib::systemstate.config.world_data_path + "parties.ndt", _party );
-
   pcs.comment( "" );
   pcs.comment( " PCS.TXT: Player-Character Data" );
   pcs.comment( "" );
@@ -172,19 +145,19 @@ SaveContext::~SaveContext() noexcept( false )
   auto stack_unwinding = std::uncaught_exceptions();
   try
   {
-    pol.flush();
-    objects.flush();
-    pcs.flush();
-    pcequip.flush();
-    npcs.flush();
-    npcequip.flush();
-    items.flush();
-    multis.flush();
-    storage.flush();
-    resource.flush();
-    guilds.flush();
-    datastore.flush();
-    party.flush();
+    pol.flush_close();
+    objects.flush_close();
+    pcs.flush_close();
+    pcequip.flush_close();
+    npcs.flush_close();
+    npcequip.flush_close();
+    items.flush_close();
+    multis.flush_close();
+    storage.flush_close();
+    resource.flush_close();
+    guilds.flush_close();
+    datastore.flush_close();
+    party.flush_close();
   }
   catch ( ... )
   {

--- a/pol-core/pol/savedata.h
+++ b/pol-core/pol/savedata.h
@@ -21,21 +21,6 @@ class SaveContext
 {
   typedef Clib::StreamWriter SaveStrategy;
 
-private:
-  std::ofstream _pol;
-  std::ofstream _objects;
-  std::ofstream _pcs;
-  std::ofstream _pcequip;
-  std::ofstream _npcs;
-  std::ofstream _npcequip;
-  std::ofstream _items;
-  std::ofstream _multis;
-  std::ofstream _storage;
-  std::ofstream _resource;
-  std::ofstream _guilds;
-  std::ofstream _datastore;
-  std::ofstream _party;
-
 public:
   SaveContext();
   // allow exception without direct terminate, performs fileoperations which can fail eg diskfull

--- a/pol-core/pol/uobject.cpp
+++ b/pol-core/pol/uobject.cpp
@@ -42,30 +42,18 @@ namespace Pol
 namespace Core
 {
 std::set<UObject*> unreaped_orphan_instances;
-std::ofstream orphans_txt( "orphans.txt", std::ios::out | std::ios::trunc );
 
-int display_orphan( UObject* o )
-{
-  std::ostringstream stream;
-  {
-    Clib::StreamWriter sw( stream );
-    Clib::StreamWriter sw_orphan( orphans_txt );
-    sw.comment( "{}, {}", o->name(), o->ref_counted_count() );
-    o->printOn( sw );
-    o->printOnDebug( sw_orphan );
-  }
-  INFO_PRINT( stream.str() );
-  return 0;
-}
 void display_unreaped_orphan_instances()
 {
-  //    orphans_txt.open( "orphans.txt", ios::out|ios::trunc );
+  Clib::StreamWriter sw{ "orphans.txt" };
 
   for ( auto& obj : unreaped_orphan_instances )
   {
-    display_orphan( obj );
+    sw.comment( "{}, {}", obj->name(), obj->ref_counted_count() );
+    obj->printOnDebug( sw );
   }
-  // for( std::set<UObject*>::iterator itr = unreaped_orphan_instances.begin();
+  if ( !unreaped_orphan_instances.empty() )
+    INFO_PRINT( "orphans detected, check orphans.txt" );
 }
 
 

--- a/testsuite/pol/testpkgs/restart/test_item.src
+++ b/testsuite/pol/testpkgs/restart/test_item.src
@@ -120,7 +120,7 @@ exported function load_save_item()
                  },
                  {
                    "NameSuffix",
-                   { "name_suffix", "my_suffix" }
+                   { "name_suffix", "☠my_suffix☠" /* unicode test */ }
                  },
                  {
                    "NoDrop",


### PR DESCRIPTION
Directly use the c API for writing savefiles to get rid of unneeded overhead.
Increased local buffer to 32kb per file and write without extra buffer to the files.

Seems to give us 20% faster write times.