### PR TITLE
Socket race condition on mac with dapdugger 

### DIFF
--- a/.github/workflows/buildmacos.yml
+++ b/.github/workflows/buildmacos.yml
@@ -12,11 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: "macos-13"
-            cxx-compiler: clang++
-            c-compiler: clang
-            compiler-version: default
-            build-type: Release
           - os: "macos-14"
             cxx-compiler: clang++
             c-compiler: clang

--- a/.github/workflows/buildmacos.yml
+++ b/.github/workflows/buildmacos.yml
@@ -17,12 +17,12 @@ jobs:
             c-compiler: clang
             compiler-version: default
             build-type: Release
+          - os: "macos-14"
+            cxx-compiler: clang++
+            c-compiler: clang
+            compiler-version: default
+            build-type: Release
 
-              #- os: "macos-latest"
-              #cxx-compiler: g++
-              #c-compiler: gcc
-              #compiler-version: 11
-              #build-type: RelWithDebInfo
 
     runs-on: ${{ matrix.config.os }}
 

--- a/pol-core/pol/dap/clientthread.cpp
+++ b/pol-core/pol/dap/clientthread.cpp
@@ -912,11 +912,19 @@ void DebugClientThread::run()
   // Error handler
   _session->onError( [this]( const char* msg ) { on_error( msg ); } );
 
+  std::atomic_bool socket_closed{ false };
   // Attach the SocketReaderWriter to the Session and begin processing events.
+  // expects that the close handler is called everytime the socket gets closed
   _session->bind( _rw,
-                  [&]() { POLLOG_INFOLN( "Debugger#{} session endpoint closed.", _instance ); } );
+                  [&]()
+                  {
+                    socket_closed = true;
+                    POLLOG_INFOLN( "Debugger#{} session endpoint closed.", _instance );
+                  } );
 
-  while ( !Clib::exit_signalled && !_exit_sent && _rw->isOpen() )
+  // MacOS implementation has a race between isOpen and close.
+  // never call isOpen from non-dap threads
+  while ( !Clib::exit_signalled && !_exit_sent && !socket_closed )
   {
     pol_sleep_ms( 1000 );
   }
@@ -940,10 +948,7 @@ void DebugClientThread::run()
   _session.reset();
 
   // Close the socket endpoint if necessary.
-  if ( _rw->isOpen() )
-  {
-    _rw->close();
-  }
+  _rw->close();
 
   POLLOG_INFOLN( "Debugger#{} client thread closing.", _instance );
 }

--- a/pol-core/pol/dap/clientthread.cpp
+++ b/pol-core/pol/dap/clientthread.cpp
@@ -945,10 +945,8 @@ void DebugClientThread::run()
     }
   }
 
+  _rw.reset();
   _session.reset();
-
-  // Close the socket endpoint if necessary.
-  _rw->close();
 
   POLLOG_INFOLN( "Debugger#{} client thread closing.", _instance );
 }


### PR DESCRIPTION
Dap ports are freed but via eg `isOpen` still can perform operations on the socket.
Switched to newer os version.