### PR TITLE
Fix saving banned state of an account

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-07-2025</datemodified>
+		<datemodified>02-17-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-17-2025</date>
+			<author>AsYlum:</author>
+			<change type="Fixed">Saving banned state of an account</change>
+		</entry>
 		<entry>
 			<date>02-07-2025</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+02-17-2025 AsYlum:
+    Fixed: Saving banned state of an account
 02-07-2025 Turley:
     Fixed: B9 feature flag was used from ssopt DefaultExpansion instead of the account expansion. Bug added with 02-04 changes
 02-06-2025 Turley:

--- a/pol-core/pol/accounts/account.cpp
+++ b/pol-core/pol/accounts/account.cpp
@@ -93,6 +93,8 @@ void Account::writeto( Clib::StreamWriter& sw ) const
 
   sw.add( "Enabled", enabled_ );
 
+  sw.add( "Banned", banned_ );
+
   if ( !default_privs_.empty() )
   {
     sw.add( "DefaultPrivs", default_privs_.extract() );

--- a/testsuite/pol/testpkgs/restart/test_account.src
+++ b/testsuite/pol/testpkgs/restart/test_account.src
@@ -43,6 +43,7 @@ exported function load_save_account()
     acc.set_uo_expansion( "SE" );
     acc.addcharacter( 1 );
     acc.setprop( "test", 1 );
+    acc.ban();
   else
 
     var acc := FindAccount( "restart_account" );

--- a/testsuite/pol/testpkgs/restart/test_account.src
+++ b/testsuite/pol/testpkgs/restart/test_account.src
@@ -20,6 +20,10 @@ exported function load_save_account()
                  {
                    "Enabled",
                    { "enabled", 0 }
+                 },
+                 {
+                   "Banned",
+                   { "banned", 1 }
                  }, //          {"DefaultPrivs", {"",1}},
                  {
                    "DefaultCmdLevel",


### PR DESCRIPTION
Saving of `Banned` property was missing since PR #601 .

Find and replace probably failed because both properties Enabled and Banned were on same line.

https://github.com/polserver/polserver/pull/601/files#diff-ba5f5f1e5175d6c06ea6ea60cbb4b8a035462fb26a177467975b67ae76d7afefR95