### PR TITLE
Windows backtrace fix with pdb files

### DIFF
--- a/cmake/compile_defs.cmake
+++ b/cmake/compile_defs.cmake
@@ -143,6 +143,13 @@ function(set_compile_flags target is_executable)
         -OPT:REF # remove unused blocks
       )
     endif()
+    if (${is_executable})
+      # by default the absolute path during linking is stored in the executable
+      # use just the targetname so that the pdbs get found when copied next to the executable
+      # for eg CI purpose check clib ExceptionParser
+      # this adds current binary dir also as search path (which is different for CI)
+      set_target_properties(${target} PROPERTIES LINK_FLAGS "/PDBALTPATH:${target}.pdb")
+    endif()
   endif()
 
   if(${linux})

--- a/pol-core/clib/CMakeLists.txt
+++ b/pol-core/clib/CMakeLists.txt
@@ -46,6 +46,7 @@ elseif(${windows})
     ws2_32
     Psapi
     DbgHelp
+    Shlwapi
   )
 endif()
 

--- a/pol-core/clib/Debugging/ExceptionParser.cpp
+++ b/pol-core/clib/Debugging/ExceptionParser.cpp
@@ -25,6 +25,7 @@
 #define SOCKET int
 #else
 #include "../Header_Windows.h"
+#include "shlwapi.h"
 #endif
 
 #include <boost/stacktrace.hpp>
@@ -540,11 +541,21 @@ void ExceptionParser::initGlobalExceptionCatching()
     std::exit( 1 );
   }
 }
-#else   // _WIN32 || Apple
+#else  // _WIN32 || Apple
 
 void ExceptionParser::logAllStackTraces() {}
 
-void ExceptionParser::initGlobalExceptionCatching() {}
+void ExceptionParser::initGlobalExceptionCatching()
+{
+#if defined( _WIN32 )
+  // see compile_defs.cmake
+  // in addition add the executable path as searchpath
+  wchar_t path[MAX_PATH];
+  GetModuleFileNameW( nullptr, path, MAX_PATH );
+  PathRemoveFileSpecW( path );
+  SetEnvironmentVariableW( L"_NT_ALT_SYMBOL_PATH", path );
+#endif
+}
 #endif  // _WIN32 || Apple
 
 string ExceptionParser::getTrace()

--- a/pol-core/pol/savedata.cpp
+++ b/pol-core/pol/savedata.cpp
@@ -407,6 +407,12 @@ std::optional<bool> write_data( std::function<void( bool, u32, u32, s64 )> callb
                   {
                     func();
                   }
+                  catch ( const std::exception& error )
+                  {
+                    POLLOG_ERRORLN( "failed to store {} datafile! {}\n{}", name, error.what(),
+                                    Clib::ExceptionParser::getTrace() );
+                    result = false;
+                  }
                   catch ( ... )
                   {
                     POLLOG_ERRORLN( "failed to store {} datafile!\n{}", name,


### PR DESCRIPTION
pdb location is stored as absolute path in the executable 

overwritten this default behaviour to find pdbs in the workdirectory
in addition add during runtime pdb searchpath to the directory where the
executable is located (CI case)