### PR TITLE
Add fPIC to boost build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: lib/boost_1_87_0
-          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-boost-1.87.0
+          key: ${{ runner.os }}-${{ matrix.config.cxx-compiler }}-${{ matrix.config.compiler-version }}-boost-1.87.0-pic
       - name: Cache cppdap
         uses: actions/cache@v4
         with:

--- a/cmake/Boost.cmake
+++ b/cmake/Boost.cmake
@@ -49,6 +49,8 @@ else()
     set (BOOST_ARC "architecture=arm+x86")
     set (BOOST_STACKTRACE_LIB "${BOOST_STAGE_LIB_DIR}/libboost_stacktrace_basic.a")
     set (BOOST_STACKTRACE_LIB2 "")
+  else()
+    set (BOOST_CXX_FLAGS "${BOOST_CXX_FLAGS} -fPIC")
   endif()
 endif()
 


### PR DESCRIPTION
The boost backtrace library needs PIC when compiling bscript as a static library (eg. vscode-escript).