### PR TITLE
Datafile save fixes

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-19-2025</datemodified>
+		<datemodified>02-20-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-20-2025</date>
+			<author>Turley:</author>
+			<change type="Fixed">saving datafiles if the folderstructure is no longer existing</change>
+			<change type="Changed">start of the core now fails if the datastore.txt contains a datafile which no longer exists.<br/>
+This can happen if datafiles where manually removed without updating the datastore.txt</change>
+		</entry>
 		<entry>
 			<date>02-19-2025</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -1,6 +1,9 @@
 # This is a short summary of breaking changes.
 # Please consult core-changes.txt for more information.
 -- POL100.2.0 [work-in-progress] --
+02-20-2025:
+    Start of the core now fails if the datastore.txt contains a datafile which no longer exists.
+    This can happen if datafiles where manually removed without updating the datastore.txt
 10-09-2024:
     The words `class` and `endclass` are now special keywords in the Escript language, and any identifiers (variable or function names)
     will need to be refactored and renamed.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 -- POL100.2.0 --
+02-20-2025 Turley:
+    Fixed: saving datafiles if the folderstructure is no longer existing
+  Changed: start of the core now fails if the datastore.txt contains a datafile which no longer exists.
+           This can happen if datafiles where manually removed without updating the datastore.txt
 02-19-2025 Kevin:
     Added: Support for spread operator in dictionary and struct initializers. For example:
 

--- a/pol-core/pol/module/datastore.cpp
+++ b/pol-core/pol/module/datastore.cpp
@@ -10,6 +10,7 @@
 
 #include "datastore.h"
 #include <exception>
+#include <filesystem>
 #include <fstream>
 #include <stddef.h>
 
@@ -650,6 +651,11 @@ std::string DataStoreFile::filename() const
 
 void DataStoreFile::save() const
 {
+  auto path = std::filesystem::path( filename() );
+  path.remove_filename();
+  if ( !std::filesystem::exists( path ) )
+    std::filesystem::create_directories( path );
+
   Clib::StreamWriter sw( filename() );
   dfcontents->save( sw );
 }

--- a/pol-core/pol/module/datastore.cpp
+++ b/pol-core/pol/module/datastore.cpp
@@ -700,6 +700,11 @@ void read_datastore_dat()
   while ( cf.read( elem ) )
   {
     DataStoreFile* dsf = new DataStoreFile( elem );
+    auto path = std::filesystem::path( dsf->filename() );
+    if ( !std::filesystem::exists( path ) )
+      throw std::runtime_error(
+          fmt::format( "datafile '{}' does not exist, but should due to 'datastore.txt' entry '{}'",
+                       dsf->filename(), dsf->descriptor ) );
     Core::configurationbuffer.datastore[dsf->descriptor] = dsf;
   }
 }

--- a/testsuite/pol/testpkgs/restart/test_datafile.src
+++ b/testsuite/pol/testpkgs/restart/test_datafile.src
@@ -82,3 +82,18 @@ exported function load_save_datafile_intkey()
   endif
   return 1;
 endfunction
+
+exported function load_save_datafile_empty()
+  if ( testrun == 1 )
+    var df := CreateDataFile( ":TestRestart:empty", DF_KEYTYPE_STRING );
+    if ( !df )
+      return ret_error( $"failed to create {df}" );
+    endif
+  else
+    var df := OpenDataFile( ":TestRestart:dfstring" );
+    if ( !df )
+      return ret_error( $"failed to open {df}" );
+    endif
+  endif
+  return 1;
+endfunction


### PR DESCRIPTION
If the pkg folder of a datafile does not exists the WorldSave fails, create the folder in this case

During loading the linked datafile gets checked, if it does not exist stop the core.