### PR TITLE
Fix display of corpse body items (hair, face, beard) on human death

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-23-2025</datemodified>
+		<datemodified>02-26-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>02-26-2025</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Hair and beard layers no longer appear on ground of human corpses at death</change>
+		</entry>
 		<entry>
 			<date>02-23-2025</date>
 			<author>Turley:</author>

--- a/pol-core/clib/logfacility.h
+++ b/pol-core/clib/logfacility.h
@@ -6,6 +6,7 @@ Remove the include in all StdAfx.h files or live with the consequences :)
 
 #pragma once
 
+#include <chrono>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fstream>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+02-26-2025 Kevin:
+    Fixed: Hair and beard layers no longer appear on ground of human corpses at death
 02-23-2025 Turley:
     Added: Modulus (% and %=) for doubles. Meaning that eg 4%1.5==1.0 or 3.3%1.1==0
 02-20-2025 Turley:

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -585,8 +585,11 @@ void send_corpse_contents( Client* client, const UCorpse* corpse )
 void send_corpse( Client* client, const Item* item )
 {
   const UCorpse* corpse = static_cast<const UCorpse*>( item );
-  send_corpse_equip( client, corpse );
+  // Send the contents _first_, so the client is aware of the copied items (eg.
+  // hair). Then send the corpse equipment, as client knows about the copied
+  // items.
   send_corpse_contents( client, corpse );
+  send_corpse_equip( client, corpse );
 }
 
 // This function sends every item in the corpse, not only the equipped items. It's mainly

--- a/testsuite/pol/scripts/tests.src
+++ b/testsuite/pol/scripts/tests.src
@@ -33,13 +33,16 @@ program tests()
     testpkgs.append( restartpkg );
   endif
 
-  var filter := GetEnvironmentVariable( "POLCORE_TEST_FILTER" );
-  if ( filter )
-    syslog( "## using testfilter \"" + filter + "\"\n", 0, CONSOLE_COLOR_CYAN );
+  // Add some colons to ensure array size is always >=3
+  var filter := ( GetEnvironmentVariable( "POLCORE_TEST_FILTER" ) ?: "" ) + ":::";
+  var [ filter_pkg, filter_file, filter_func ] := SplitWords( filter, ":" );
+  if ( filter_pkg || filter_file || filter_func )
+    syslog( $"## using testfilter filter_pkg=\"{filter_pkg}\", filter_file=\"{filter_file}\", filter_func=\"{filter_func}\", \n",
+            0, CONSOLE_COLOR_CYAN );
   endif
 
   foreach pkg in testpkgs
-    if ( filter and !pkg[1].find( filter ) )
+    if ( filter_pkg and !pkg[1].find( filter_pkg ) )
       continue;
     endif
 
@@ -67,6 +70,8 @@ program tests()
     foreach file in scripts
       if ( file.find( "test" ) != 1 )
         continue;
+      elseif ( filter_file and !file.find( filter_file ) )
+        continue;
       endif
       var scriptstartms := ReadMillisecondClock();
       syslog( "  Calling {}..".format( file ), 0, CONSOLE_COLOR_GREEN );
@@ -82,6 +87,9 @@ program tests()
 
       var resources := ResourceManager();
       foreach func in ( script[1].exported_functions )
+        if ( filter_func && !func.find( filter_func ) )
+          continue;
+        endif
         var startms := ReadMillisecondClock();
         syslog( "    Calling {}..".format( func ), 0, CONSOLE_COLOR_GREEN );
         var res := script[1].call( func, { resources } );

--- a/testsuite/pol/testpkgs/client/test_client_corpse_view.src
+++ b/testsuite/pol/testpkgs/client/test_client_corpse_view.src
@@ -33,6 +33,9 @@ program test_corpse_view()
   return 1;
 endprogram
 
+// After killing an NPC, client should not received a NEW_ITEM corresponding to
+// the items copied to corpse (items in the beard, face, or hair layer). A
+// previous bug would show these items on the ground.
 exported function test_corpse_body_items( resources )
   var npc := resources.CreateNPCFromTemplate( ":testnpc:probe_npc", char.x, char.y, char.z );
   if ( !npc )

--- a/testsuite/pol/testpkgs/client/test_client_corpse_view.src
+++ b/testsuite/pol/testpkgs/client/test_client_corpse_view.src
@@ -1,0 +1,60 @@
+include "communication";
+include "testutil";
+
+use os;
+use uo;
+use boat;
+use file;
+use polsys;
+
+var char;
+var charX := 100;
+var charY := 50;
+var clientcon := getClientConnection();
+
+program test_corpse_view()
+  var a := FindAccount( "testclient0" );
+  char := a.getcharacter( 1 );
+  if ( !char )
+    return ret_error( "Could not find char at slot 1" );
+  endif
+
+  // Move character somewhere nice.
+  var res := MoveObjectToLocation( char, charX, charY, 0 );
+  if ( !res )
+    return ret_error( $"Could not move character: ${res}" );
+  endif
+
+  clientcon.sendevent( struct{ todo := EVT_DISABLE_ITEM_LOGGING, arg := 0, id := 0 } );
+  if ( !( res := waitForClient( 0, { EVT_DISABLE_ITEM_LOGGING } ) ) )
+    return res;
+  endif
+
+  return 1;
+endprogram
+
+exported function test_corpse_body_items( resources )
+  var npc := resources.CreateNPCFromTemplate( ":testnpc:probe_npc", char.x, char.y, char.z );
+  if ( !npc )
+    return npc;
+  endif
+
+  var beard := resources.CreateItemAtLocation( 0, 0, 0, 0x203b );
+  if ( !beard )
+    return beard;
+  endif
+
+  var res;
+  if ( !( res := EquipItem( npc, beard ) ) )
+    return ret_error( $"Could not equip beard: {res}" );
+  endif
+
+  ResourceManager::DestroyNpcResource( npc );
+
+  if ( !( res := waitForClient( 0, { EVT_NEW_ITEM, EVT_REMOVED_OBJ } ) ) )
+    return res;
+  endif
+
+  return ret_error_not_equal( res.type, EVT_REMOVED_OBJ,
+                              $"Incorrect event after corpse death, expected {EVT_REMOVED_OBJ} got {res.type}" );
+endfunction


### PR DESCRIPTION
Fix body items by:
- postponing `item->movable( false )` to _after_ corpse display
- sending corpse contents _first_ (so client is aware of items), then corpse equipment

Corpse death on osi client:

https://github.com/user-attachments/assets/096e11b4-7bba-486e-ad6f-f21657a55e64

