### PR TITLE
Update multi elements graphic checks

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-26-2025</datemodified>
+		<datemodified>03-05-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>03-05-2025</date>
+			<author>AsYlum:</author>
+			<change type="Changed">Multi elements will check raw graphic instead of using itemdesc graphic definition</change>
+		</entry>
 		<entry>
 			<date>02-26-2025</date>
 			<author>Kevin:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+03-05-2025 AsYlum:
+  Changed: Multi elements will check raw graphic instead of using itemdesc graphic definition
 02-26-2025 Kevin:
     Fixed: Hair and beard layers no longer appear on ground of human corpses at death
 02-23-2025 Turley:

--- a/pol-core/pol/multi/multidef2.cpp
+++ b/pol-core/pol/multi/multidef2.cpp
@@ -65,6 +65,7 @@ bool MultiDef::readshapes( Plib::MapShapeList& vec, const Core::Vec2d& rxy, shor
   for ( ; itr != end; ++itr )
   {
     const MULTI_ELEM* elem = ( *itr ).second;
+    // use raw objtype instead of itemdesc.graphic to ensure correct Line of Sight checks
     unsigned short graphic = elem->objtype;
     if ( Plib::tile_flags( graphic ) & anyflags )
     {

--- a/pol-core/pol/multi/multidef2.cpp
+++ b/pol-core/pol/multi/multidef2.cpp
@@ -65,7 +65,7 @@ bool MultiDef::readshapes( Plib::MapShapeList& vec, const Core::Vec2d& rxy, shor
   for ( ; itr != end; ++itr )
   {
     const MULTI_ELEM* elem = ( *itr ).second;
-    unsigned short graphic = Items::getgraphic( elem->objtype );
+    unsigned short graphic = elem->objtype;
     if ( Plib::tile_flags( graphic ) & anyflags )
     {
       if ( elem->is_static )


### PR DESCRIPTION
For multis it was possible to create itemdesc entry for multi element and redirect it to different graphic so line of sight checks were done against graphic from itemdesc instead of actual graphic of the multi element.