### PR TITLE
fixed order of pkts when changing client view range

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-28-2025</datemodified>
+		<datemodified>08-02-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>08-02-2025</date>
+			<author>Turley:</author>
+			<change type="Fixed">when the client view range is changed the client gets first informed about the new range before potentially sending new objects</change>
+		</entry>
 		<entry>
 			<date>07-28-2025</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+08-02-2025 Turley:
+    Fixed:  when the client view range is changed the client gets first informed about the new range before potentially sending new objects
 07-28-2025 Turley:
     Added: ecompile.cfg setting ShortCircuitEvaluation (0/1) default 0 and ShortCircuitEvaluationWarning (0/1) default 1
            if activated: in || and && expressions the second argument get only evaluated if the first operand is false for || and true for &&

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -750,15 +750,17 @@ void Client::set_update_range_by_script( u8 range )
 void Client::set_update_range( u8 range )
 {
   auto old_range = update_range();
+  // first signal the client about the change before we potentially send new objects otherwise the
+  // client could directly drop them
+  PktHelper::PacketOut<PktOut_C8> outMsg;
+  outMsg->Write<u8>( range );
+  outMsg.Send( this );
+
   // delete/send all objects, but not if its the first pkt
   if ( old_range != range && gd->original_client_update_range != 0 )
     chr->update_objects_on_range_change( range );
 
   gd->update_range = range;
-
-  PktHelper::PacketOut<PktOut_C8> outMsg;
-  outMsg->Write<u8>( range );
-  outMsg.Send( this );
 
   if ( old_range != range )
   {


### PR DESCRIPTION
the client should be first informed about the new range, otherwise the client could drop the newly send objects