### PR TITLE
Fix issue with unresolved base class static methods

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-19-2025</datemodified>
+		<datemodified>08-24-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>08-24-2025</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Under certain situations, the compiler would not find a parent class' static (ie. non-member) when used inside a child class.</change>
+		</entry>
 		<entry>
 			<date>08-19-2025</date>
 			<author>Kevin:</author>

--- a/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
+++ b/pol-core/bscript/compiler/astbuilder/FunctionResolver.cpp
@@ -314,6 +314,11 @@ bool FunctionResolver::resolve(
     }
   }
 
+  // If any class link was resolved, we need to trigger
+  // `CompilerWorkspaceBuilder::build_referenced_user_functions` to run the
+  // resolution loop again.
+  bool any_classes_linked = false;
+
   for ( auto unresolved_itr = unresolved_classes.begin();
         unresolved_itr != unresolved_classes.end(); )
   {
@@ -331,6 +336,7 @@ bool FunctionResolver::resolve(
       {
         // Remove this function link from the list of links.
         class_link_itr = ( *unresolved_itr ).second.erase( class_link_itr );
+        any_classes_linked = true;
       }
       else if ( build_if_available( to_build_ast, scope ) )
       {
@@ -354,7 +360,7 @@ bool FunctionResolver::resolve(
     }
   }
 
-  return !to_build_ast.empty();
+  return any_classes_linked || !to_build_ast.empty();
 }
 
 std::string FunctionResolver::function_expression_name( const SourceLocation& source_location )

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+08-24-2025 Kevin:
+    Fixed: Under certain situations, the compiler would not find a parent class' static (ie. non-member) when used inside a child class.
 08-19-2025 Kevin:
     Fixed: Enum class constants can be used unscoped within their own enum class.
     Fixed: Enum class constants can be used in case statement labels.

--- a/testsuite/escript/classes/inherited-func-1.out
+++ b/testsuite/escript/classes/inherited-func-1.out
@@ -1,0 +1,2 @@
+Base
+Child

--- a/testsuite/escript/classes/inherited-func-1.src
+++ b/testsuite/escript/classes/inherited-func-1.src
@@ -1,0 +1,14 @@
+class Base()
+  function base_func()
+    print( "Base" );
+  endfunction
+endclass
+
+class Child( Base )
+  function child_func()
+    base_func(); // Previously would error that `base_func` is undefined.
+    print( "Child" );
+  endfunction
+endclass
+
+Child::child_func();

--- a/testsuite/escript/classes/inherited-func-2.out
+++ b/testsuite/escript/classes/inherited-func-2.out
@@ -1,0 +1,2 @@
+Base
+Child

--- a/testsuite/escript/classes/inherited-func-2.src
+++ b/testsuite/escript/classes/inherited-func-2.src
@@ -1,0 +1,15 @@
+// Same as inherited-func-1 but classes are ordered differently
+class Child( Base )
+  function child_func()
+    base_func();
+    print( "Child" );
+  endfunction
+endclass
+
+class Base()
+  function base_func()
+    print( "Base" );
+  endfunction
+endclass
+
+Child::child_func();

--- a/testsuite/escript/classes/inherited-func-3.out
+++ b/testsuite/escript/classes/inherited-func-3.out
@@ -1,0 +1,2 @@
+Base
+Child

--- a/testsuite/escript/classes/inherited-func-3.src
+++ b/testsuite/escript/classes/inherited-func-3.src
@@ -1,0 +1,15 @@
+// Same as inherited-func-1 but uses super
+class Base()
+  function base_func()
+    print( "Base" );
+  endfunction
+endclass
+
+class Child( Base )
+  function child_func()
+    super::base_func();
+    print( "Child" );
+  endfunction
+endclass
+
+Child::child_func();


### PR DESCRIPTION
The function resolver needs to run an additional iteration if there were any class links resolved in order to link any remaining (unscoped) function links.


```
class Base()
  function base_func()
    print( "Base" );
  endfunction
endclass

class Child( Base )
  function child_func()
    base_func(); // Previously would error that `base_func` is undefined.
    print( "Child" );
  endfunction
endclass

Child::child_func();
```

In the bugged behavior, the `FunctionResolver::resolve` would resolve/link the `Base` class link but not add anything to second-pass build (ie. nothing added to `to_build_ast`). Since `to_build_ast` would be empty, the function resolver loop would stop.