### PR TITLE
Fix flaky client_item_move tests

### DIFF
--- a/testsuite/pol/testpkgs/client/test_client_item_move.src
+++ b/testsuite/pol/testpkgs/client/test_client_item_move.src
@@ -808,7 +808,7 @@ exported function test_equip_npc_equipitem( resources )
     return res;
   endif
 
-  var evs := get_events();
+  var evs := get_events( { "equiptest", "equip" } );
   if ( !evs )
     return evs;
   endif
@@ -823,7 +823,7 @@ exported function test_equip_npc_equipitem( resources )
     return res;
   endif
 
-  evs := get_events();
+  evs := get_events( { "unequiptest", "unequip" } );
   if ( !evs )
     return evs;
   endif
@@ -878,7 +878,7 @@ exported function test_equip_npc_dragdrop( resources )
 
   var equipscript_testfunc := @() {
     // Get three events, and check for wear_item and equiptest & equip
-    var evs := get_events( 1, 3 );
+    var evs := get_events( { "wear_item", "equiptest", "equip" }, 1, 3 );
     if ( !evs )
       return evs;
     endif
@@ -1124,16 +1124,19 @@ function validate_events( evs, on_chr, by_chr, item, is_unequip )
   return 1;
 endfunction
 
-// Returns two events as an array, eg. equiptest & equip or unequiptest & unequip events
-function get_events( timeout := 0, count := 2 )
+// Returns `count` events as an array, accepting only events of a type that are
+// listed in `allowed_events`, eg. equiptest & equip or unequiptest & unequip
+// events.
+function get_events( allowed_events, timeout := 0, count := 2 )
   var evs := {};
 
-  while ( count-- > 0 )
+  while ( Len( evs ) < count )
     var res := wait_for_event( timeout );
     if ( !res )
       return ret_error( "No event received" );
+    elseif ( res.type in allowed_events )
+      evs.append( res );
     endif
-    evs.append( res );
   endwhile
   return evs;
 endfunction


### PR DESCRIPTION
The test checks the event order of [un]equiptest and then [un]equip, but it is possible the test script receives an event from the client.

Fix flaky client_item_move tests by filtering out unwanted events by type.