### PR TITLE
Skip internal errors for unlinked inherited base classes

### DIFF
--- a/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
+++ b/pol-core/bscript/compiler/analyzer/SemanticAnalyzer.cpp
@@ -256,10 +256,8 @@ void SemanticAnalyzer::visit_class_declaration( ClassDeclaration& node )
       {
         to_visit.push_back( base_cd );
       }
-      else
-      {
-        cd->internal_error( "no class linked for base class" );
-      }
+      // Do not error, as the the (middle) parent class which referenced the
+      // (top) parent class would have already errored in the previous for-loop.
     }
   }
 
@@ -399,6 +397,10 @@ void SemanticAnalyzer::analyze_class( ClassDeclaration* class_decl )
       }
       else
       {
+        // Should never happen, as a method function link is only created if
+        // there was a FunctionDeclarationContext to visit inside
+        // UserFunctionBuilder, and the function link is immediately registered
+        // with the FunctionResolver, guaranteeing it will be visited/built.
         cd->internal_error( fmt::format( "no user function linked for method {}::{}",
                                          class_decl->name, method_name ) );
       }
@@ -410,11 +412,8 @@ void SemanticAnalyzer::analyze_class( ClassDeclaration* class_decl )
       {
         to_visit.push_back( base_cd );
       }
-      else
-      {
-        cd->internal_error( fmt::format( "no class linked for {} baseclass {}", class_decl->name,
-                                         base_class_link->name ) );
-      }
+      // Do not error if no ClassDeclaration found, as it will be reported in
+      // visit_class_declaration.
     }
   }
 

--- a/testsuite/escript/classes/fail-unknown-inherited-base-class.err
+++ b/testsuite/escript/classes/fail-unknown-inherited-base-class.err
@@ -1,0 +1,1 @@
+:6:13: error: Class 'Base' references unknown base class 'UnknownBase'

--- a/testsuite/escript/classes/fail-unknown-inherited-base-class.src
+++ b/testsuite/escript/classes/fail-unknown-inherited-base-class.src
@@ -1,0 +1,18 @@
+// Previously, an internal error occurred when analyzing the inheritance tree in
+// visit_class_declaration for Child -> Base -> UnknownBase, because Base's
+// base_class_links had an unlinked class link. This error is still reported (as
+// a regular error, not internal error) in visit_class_declaration for Base.
+
+class Base( UnknownBase )
+  uninit function method( this );
+endclass
+
+class Child( Base )
+  function Child( this )
+  endfunction
+
+  function method( this )
+  endfunction
+endclass
+
+Child();


### PR DESCRIPTION
The SemanticAnalyzer was incorrectly reporting internal errors when a class parent inherited from an unlinked class. The error will already have been reported, when visiting the class parent.