### PR TITLE
Normalize TypeOf and TypeOfInt return value for ClassInstanceRef

### DIFF
--- a/docs/docs.polserver.com/pol100/basicem.xml
+++ b/docs/docs.polserver.com/pol100/basicem.xml
@@ -4,7 +4,7 @@
 <ESCRIPT>  
   <fileheader fname="Basic.em">
     <filedesc>Functions for converting and manipulating number, character, and string values.</filedesc>
-    <datemodified>08/20/2020</datemodified>
+    <datemodified>09/28/2025</datemodified>
 <constant>const TRIM_LEFT  := 0x1; // Trim whitespace from Left of string.</constant>
 <constant>const TRIM_RIGHT := 0x2; // Trim whitespace from Right of string.</constant>
 <constant>const TRIM_BOTH  := 0x3; // Trim whitespace from Left and Right of string.</constant>
@@ -52,6 +52,8 @@
 <constant>const OT_BOOLEAN          := 38;</constant>
 <constant>const OT_FUNCOBJECT       := 39;</constant>
 <constant>const OT_EXPORTEDSCRIPT   := 40;</constant>
+<constant>const OT_STORAGEAREA      := 41;</constant>
+<constant>const OT_CLASSINSTANCEREF := 42;</constant>
   </fileheader>
 
   <function name="CAsc"> 

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>09-06-2025</datemodified>
+		<datemodified>09-28-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>09-28-2025</date>
+			<author>Kevin:</author>
+			<change type="Changed">The `TypeOf()` and `TypeOfInt()` for a class instance has been changed from &quot;Class&quot; and 102 to &quot;ClassInstanceRef&quot; and 42.<br/>
+The basic.em constant for class instance references was missing, and has been added as:<br/>
+  const OT_CLASSINSTANCEREF := 42;</change>
+		</entry>
 		<entry>
 			<date>09-06-2025</date>
 			<author>Kevin:</author>

--- a/pol-core/bscript/bclassinstance.cpp
+++ b/pol-core/bscript/bclassinstance.cpp
@@ -134,13 +134,15 @@ size_t BClassInstanceRef::sizeEstimate() const
 {
   return sizeof( BClassInstanceRef ) + class_instance_->sizeEstimate();
 }
+
 const char* BClassInstanceRef::typeOf() const
 {
-  return class_instance_->typeOf();
+  return "ClassInstanceRef";
 }
+
 u8 BClassInstanceRef::typeOfInt() const
 {
-  return class_instance_->typeOfInt();
+  return OTClassInstanceRef;
 }
 
 BObjectImp* BClassInstanceRef::copy() const

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -1,6 +1,11 @@
 # This is a short summary of breaking changes.
 # Please consult core-changes.txt for more information.
 -- POL100.2.0 [work-in-progress] --
+09-28-2025:
+    The `TypeOf()` and `TypeOfInt()` for a class instance has been changed from "Class" and 102 to "ClassInstanceRef" and 42.
+    The basic.em constant for class instance references was missing, and has been added as:
+
+      const OT_CLASSINSTANCEREF := 42;
 02-20-2025:
     Start of the core now fails if the datastore.txt contains a datafile which no longer exists.
     This can happen if datafiles where manually removed without updating the datastore.txt

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 -- POL100.2.0 --
+09-28-2025 Kevin:
+  Changed: The `TypeOf()` and `TypeOfInt()` for a class instance has been changed from "Class" and 102 to "ClassInstanceRef" and 42.
+           The basic.em constant for class instance references was missing, and has been added as:
+
+             const OT_CLASSINSTANCEREF := 42;
 09-06-2025 Kevin:
     Fixed: Uninitialized functions now properly check for parameters for byref and rest parameters.
     Added: Uninitialized function parameters can be marked as `default`, requiring constructed descendant classes to provide

--- a/pol-core/support/scripts/basic.em
+++ b/pol-core/support/scripts/basic.em
@@ -46,6 +46,7 @@ const OT_BOOLEAN          := 38;
 const OT_FUNCOBJECT       := 39;
 const OT_EXPORTEDSCRIPT   := 40;
 const OT_STORAGEAREA      := 41;
+const OT_CLASSINSTANCEREF := 42;
 // format-on
 
 // returns the one-based index of Search within Str after position Start

--- a/testsuite/escript/classes/super-multiple-01.out
+++ b/testsuite/escript/classes/super-multiple-01.out
@@ -4,17 +4,6 @@ BaseClass2 arg0=unscoped-arg2
 ---
 ---
 ---
-base1=[
-  [
-    "unscoped-arg0",
-    "unscoped-arg1"
-  ]
-]
-
-base2=[
-  [
-    "unscoped-arg2"
-  ]
-]
-
-child="foo"
+base1={ { unscoped-arg0, unscoped-arg1 } }
+base2={ { unscoped-arg2 } }
+child=foo

--- a/testsuite/escript/classes/super-multiple-01.src
+++ b/testsuite/escript/classes/super-multiple-01.src
@@ -43,5 +43,5 @@ var obj := Foo( "foo" );
 // We'll see that obj.base1 always contains a value of *-arg0/1, and obj.base2
 // will have "unscoped-arg2" and scoped arg0s
 foreach key in obj
-  print( $"{_key_iter}={PackJSON( key, true )}" );
+  print( $"{_key_iter}={key}" );
 endforeach

--- a/testsuite/escript/classes/super-multiple-02.out
+++ b/testsuite/escript/classes/super-multiple-02.out
@@ -4,24 +4,6 @@ BaseClass2 arg0=unscoped-arg2
 BaseClass1 arg0=unscoped-arg0 arg1=unscoped-arg1
 BaseClass2 arg0=unscoped-arg2
 ---
-base1=[
-  [
-    "unscoped-arg0",
-    "unscoped-arg1"
-  ],
-  [
-    "unscoped-arg0",
-    "unscoped-arg1"
-  ]
-]
-
-base2=[
-  [
-    "unscoped-arg2"
-  ],
-  [
-    "unscoped-arg2"
-  ]
-]
-
-child="foo"
+base1={ { unscoped-arg0, unscoped-arg1 }, { unscoped-arg0, unscoped-arg1 } }
+base2={ { unscoped-arg2 }, { unscoped-arg2 } }
+child=foo

--- a/testsuite/escript/classes/super-multiple-02.src
+++ b/testsuite/escript/classes/super-multiple-02.src
@@ -30,5 +30,5 @@ var obj := Foo( "foo" );
 // We'll see that obj.base1 always contains a value of unscoped-arg0/1, and obj.base2
 // will have "unscoped-arg2"
 foreach key in obj
-  print( $"{_key_iter}={PackJSON( key, true )}" );
+  print( $"{_key_iter}={key}" );
 endforeach

--- a/testsuite/escript/classes/typeof.out
+++ b/testsuite/escript/classes/typeof.out
@@ -1,0 +1,2 @@
+42 == 42 => 1
+ClassInstanceRef

--- a/testsuite/escript/classes/typeof.src
+++ b/testsuite/escript/classes/typeof.src
@@ -1,0 +1,8 @@
+class MyClass()
+  function MyClass( unused this )
+  endfunction
+endclass
+
+var o := MyClass();
+print( $"{TypeOfInt( o )} == {OT_CLASSINSTANCEREF} => {TypeOfInt( o ) == OT_CLASSINSTANCEREF}" );
+print( TypeOf( o ) );


### PR DESCRIPTION
The `TypeOf()` and `TypeOfInt()` for a class instance has been changed from `"Class"` and `102` to `"ClassInstanceRef"` and `42`.

The basic.em constant for class instance references was missing, and has been added as:

```
const OT_CLASSINSTANCEREF := 42;
```
