### PR TITLE
DiscardedWaterTiles config for uoconvert (#830)

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -5,6 +5,18 @@
 		<datemodified>12-14-2025</datemodified>
 	</header>
 	<version name="POL100.2.0">
+      <entry>
+         <date>12-14-2025</date>
+         <author>Reloecc:</author>
+         <change type="Added">uoconvert.cfg element StaticOptions extended by DiscardedWaterTiles.<br/>
+Lists the tiles that will be discarded during the processing of solid statics,<br/>
+where the map is at or below the same Z level as the static, allowing boats to bump into shores.<br/>
+Defaults to tiles in the range from 0x1796 to 0x17B2 if not present in the config file.<br/>
+StaticOptions<br/>
+{<br/>
+    DiscardedWaterTiles 0x1796 0x1797 0x1798 ...<br/>
+}</change>
+      </entry>
 		<entry>
 			<date>12-14-2025</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,13 @@
 -- POL100.2.0 --
+12-14-2025 Reloecc:
+    Added: uoconvert.cfg element StaticOptions extended by DiscardedWaterTiles.
+           Lists the tiles that will be discarded during the processing of solid statics,
+           where the map is at or below the same Z level as the static, allowing boats to bump into shores.
+           Defaults to tiles in the range from 0x1796 to 0x17B2 if not present in the config file.
+                StaticOptions
+                {
+                    DiscardedWaterTiles 0x1796 0x1797 0x1798 ...
+                }
 12-14-2025 Turley:
     Fixed: With newer clients boat travellers and observers didnt get all objects send
 11-18-2025 Kevin:

--- a/pol-core/support/uoconvert.cfg
+++ b/pol-core/support/uoconvert.cfg
@@ -21,6 +21,11 @@ StaticOptions
 	MaxStaticsPerBlock 		1000
 	WarningStaticsPerBlock		1000
 	ShowIllegalGraphicWarning	1
+
+	// Tiles that will be discarded during the processing of solid statics,
+	// where the map is at or below the same Z level as the static, which is usually at -15 anyway.
+	// Discarding those tiles from solid statics allows boats to bump into shores.
+   DiscardedWaterTiles 0x1796 0x1797 0x1798 0x1799 0x179A 0x179B 0x179C 0x179D 0x179E 0x179F 0x17A0 0x17A1 0x17A2 0x17A3 0x17A4 0x17A5 0x17A6 0x17A7 0x17A8 0x17A9 0x17AA 0x17AB 0x17AC 0x17AD 0x17AE 0x17AF 0x17B0 0x17B1 0x17B2
 }
 
 TileOptions

--- a/pol-core/uoconvert/UoConvertMain.cpp
+++ b/pol-core/uoconvert/UoConvertMain.cpp
@@ -520,12 +520,11 @@ void UoConvertMain::ProcessSolidBlock( unsigned short x_base, unsigned short y_b
 
       for ( const auto& srec : statics )
       {
-        // Look for water tiles.  If there are any, discard the map (which is usually at -15 anyway)
+        // Look for water tiles. If there are any, discard the map (which is usually at -15 anyway)
         if ( z + lt_height <= srec.z &&
-             ( ( srec.z - ( z + lt_height ) ) <=
-               10 ) &&  // only where the map is below or same Z as the static
-             srec.graphic >= 0x1796 &&
-             srec.graphic <= 0x17B2 )  // FIXME hardcoded
+             // only where the map is below or same Z as the static
+             ( ( srec.z - ( z + lt_height ) ) <= 10 ) &&
+            DiscardedWaterTypes.count( srec.graphic ) )
         {
           // arr, there be water here
           addMap = false;
@@ -1378,6 +1377,12 @@ void UoConvertMain::load_uoconvert_cfg()
           else if ( UoConvert::cfg_warning_statics_per_block < 0 )
             UoConvert::cfg_warning_statics_per_block = 1000;
         }
+
+        if ( elem.has_prop( "DiscardedWaterTiles" ) )
+        {
+          parse_graphics_properties( elem, "DiscardedWaterTiles", DiscardedWaterTypes );
+        }
+        else for ( int i = 0x1796; i <= 0x17B2; ++i ) DiscardedWaterTypes.insert( i );
 
         if ( elem.has_prop( "ShowIllegalGraphicWarning" ) )
           UoConvert::cfg_show_illegal_graphic_warning =

--- a/pol-core/uoconvert/UoConvertMain.h
+++ b/pol-core/uoconvert/UoConvertMain.h
@@ -24,6 +24,7 @@ public:
 
   std::set<unsigned int> BoatTypes;
   std::set<unsigned int> MountTypes;
+  std::set<unsigned int> DiscardedWaterTypes;
 
   bool cfg_use_no_shoot;
   bool cfg_LOS_through_windows;


### PR DESCRIPTION
Added: uoconvert.cfg element StaticOptions extended by DiscardedWaterTiles.

Lists the tiles that will be discarded during the processing of solid statics,
where the map is at or below the same Z level as the static, allowing boats to bump into shores.
Defaults to tiles in the range from 0x1796 to 0x17B2 if not present in the config file.

Resolves https://github.com/polserver/polserver/issues/830