### PR TITLE
Fix a typo in ecompile.cfg.example

### DIFF
--- a/pol-core/support/scripts/ecompile.cfg.example
+++ b/pol-core/support/scripts/ecompile.cfg.example
@@ -180,7 +180,7 @@ ShortCircuitEvaluation=0
 # prints warnings if ShortCircuitEvaluation is active and second operand could have sideeffects
 # Default is 1
 #
-ShortCircuitEvaluation=1
+ShortCircuitEvaluationWarning=1
 
 #
 # EmParseTreeCacheSize


### PR DESCRIPTION
ecompile.cfg.example mentions `ShortCircuitEvaluation` twice instead of `ShortCircuitEvaluation` and then `ShortCircuitEvaluationWarning`.