### PR TITLE
Add https to docs links

### DIFF
--- a/docs/docs.polserver.com/pol100/include/index.html
+++ b/docs/docs.polserver.com/pol100/include/index.html
@@ -2,7 +2,7 @@
 <head>
 	<title>POL Scripting Reference</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-	<meta http-equiv="refresh" content="0; URL=http://docs.polserver.com/index.php">
+	<meta http-equiv="refresh" content="0; URL=https://docs.polserver.com/index.php">
 </head>
 
 <body>

--- a/docs/docs.polserver.com/pol100/index.php
+++ b/docs/docs.polserver.com/pol100/index.php
@@ -32,14 +32,14 @@
 <?php if( ! $offline && $official ) { ?>
 				<hr>
 				Downloadable Version (100):
-				<a href="http://docs.polserver.com/pol100/archives/<?=$archivefile?>">
+				<a href="https://docs.polserver.com/pol100/archives/<?=$archivefile?>">
 					100 Offline Documentation <?=$archivetime?>
 				</a>
 				<hr>
 <?php } else { ?>
 				<hr>
 				The Official POL Documentaion site is found at
-				<a href="http://docs.polserver.com">http://docs.polserver.com</a>
+				<a href="https://docs.polserver.com">https://docs.polserver.com</a>
 				<hr>
 <?php } ?>
 		</div>


### PR DESCRIPTION
Newer browsers rejects downloads when the protocol is http