### PR TITLE
do not include full program in funcref memory estimate

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>01-10-2026</datemodified>
+		<datemodified>01-17-2026</datemodified>
 	</header>
 	<version name="POL100.2.0">
+		<entry>
+			<date>01-17-2026</date>
+			<author>Kukkino:</author>
+			<change type="Changed">FunctionReference no longer includes full program in its memory estimate.</change>
+		</entry>
 		<entry>
 			<date>01-10-2026</date>
 			<author>Turley:</author>

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2334,7 +2334,7 @@ BObjectImp* BFunctionRef::copy() const
 
 size_t BFunctionRef::sizeEstimate() const
 {
-  return sizeof( BFunctionRef ) + Clib::memsize( captures ) + prog_->sizeEstimate();
+  return sizeof( BFunctionRef ) + Clib::memsize( captures );
 }
 
 bool BFunctionRef::isTrue() const

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.2.0 --
+01-17-2026 Kukkino:
+  Changed: FunctionReference no longer includes full program in its memory estimate.
 01-10-2026 Turley:
     Fixed: class method calls which have a known name, name of an existing obj method, now work
     Fixed: now also if the method has parameters


### PR DESCRIPTION
While trying to diagnose memory usage we've noticed some crazy numbers in `PolCore().internal(2);` and `PolCore().internal(5);`. I've tracked it down to `FunctionReference` including the program memory estimate in its own which kind of makes sense, but it makes global memory estimates quite useless. For instance our server consumes 9.9 GB in memory, but estimates bloomed up to over 30 GB due to this. After this change the breakdown in `memoryusage.log` sums to 7.92 GB out of 9.91 GB process size, which seems much more reasonable and useful.