### PR TITLE
Uoconvert the wrong coordinates where shown when a block contains more then the allowed number of items

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>02-16-2026</datemodified>
+		<datemodified>02-22-2026</datemodified>
 	</header>
-	<version name="POL100.3.0"/>
+	<version name="POL100.3.0">
+		<entry>
+			<date>02-22-2026</date>
+			<author>Turley:</author>
+			<change type="Fixed">uoconvert showed wrong coordinates in the error msgs when too many static items exist in a block</change>
+		</entry>
+	</version>
 	<version name="POL100.2.0">
 		<entry>
 			<date>02-16-2026</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,7 +1,9 @@
 -- POL100.3.0 --
+02-22-2026 Turley:
+    Fixed: uoconvert showed wrong coordinates in the error msgs when too many static items exist in a block
 -- POL100.2.0 --
 02-16-2026 Turley:
-    Note: Pol 100.2.0 is now officially released
+     Note: Pol 100.2.0 is now officially released
 01-18-2026 Turley:
     Fixed: ClassInstance memory estimate
 01-17-2026 Kukkino:

--- a/pol-core/plib/staticblock.h
+++ b/pol-core/plib/staticblock.h
@@ -45,11 +45,11 @@ constexpr size_t staticblock_from_coords( u16 x, u16 y, u16 map_height )
 
 constexpr std::pair<u16, u16> staticblock_to_coords( size_t block, u16 map_height )
 {
-  return { block / ( map_height / STATICBLOCK_CHUNK ) * STATICBLOCK_CHUNK,
-           ( block % ( map_height / STATICBLOCK_CHUNK ) ) * STATICBLOCK_CHUNK };
+  return { static_cast<u16>( block / ( map_height / STATICBLOCK_CHUNK ) * STATICBLOCK_CHUNK ),
+           static_cast<u16>( ( block % ( map_height / STATICBLOCK_CHUNK ) ) * STATICBLOCK_CHUNK ) };
 }
-static_assert( staticblock_to_coords( staticblock_from_coords( 96, 200, 4096 ), 4096 ) ==
-               std::make_pair( 96_u16, 200_u16 ) );
+static_assert( staticblock_to_coords( staticblock_from_coords( 3288, 4000, 4096 ), 4096 ) ==
+               std::make_pair( 3288_u16, 4000_u16 ) );
 
 }  // namespace Pol::Plib
 

--- a/pol-core/plib/staticblock.h
+++ b/pol-core/plib/staticblock.h
@@ -11,6 +11,7 @@
 
 #include "../clib/rawtypes.h"
 
+#include <utility>
 #include <vector>
 
 
@@ -36,6 +37,20 @@ class StaticEntryList : public std::vector<STATIC_ENTRY>
 const unsigned STATICBLOCK_CHUNK = 8;
 const unsigned STATICBLOCK_SHIFT = 3;
 const unsigned STATICCELL_MASK = 0x7;
+
+constexpr size_t staticblock_from_coords( u16 x, u16 y, u16 map_height )
+{
+  return ( x / STATICBLOCK_CHUNK ) * ( map_height / STATICBLOCK_CHUNK ) + ( y / STATICBLOCK_CHUNK );
+}
+
+constexpr std::pair<u16, u16> staticblock_to_coords( size_t block, u16 map_height )
+{
+  return { block / ( map_height / STATICBLOCK_CHUNK ) * STATICBLOCK_CHUNK,
+           ( block % ( map_height / STATICBLOCK_CHUNK ) ) * STATICBLOCK_CHUNK };
+}
+static_assert( staticblock_to_coords( staticblock_from_coords( 96, 200, 4096 ), 4096 ) ==
+               std::make_pair( 96, 200 ) );
+
 }  // namespace Pol::Plib
 
 #endif

--- a/pol-core/plib/staticblock.h
+++ b/pol-core/plib/staticblock.h
@@ -49,7 +49,7 @@ constexpr std::pair<u16, u16> staticblock_to_coords( size_t block, u16 map_heigh
            ( block % ( map_height / STATICBLOCK_CHUNK ) ) * STATICBLOCK_CHUNK };
 }
 static_assert( staticblock_to_coords( staticblock_from_coords( 96, 200, 4096 ), 4096 ) ==
-               std::make_pair( 96, 200 ) );
+               std::make_pair( 96u, 200u ) );
 
 }  // namespace Pol::Plib
 

--- a/pol-core/plib/staticblock.h
+++ b/pol-core/plib/staticblock.h
@@ -49,7 +49,7 @@ constexpr std::pair<u16, u16> staticblock_to_coords( size_t block, u16 map_heigh
            ( block % ( map_height / STATICBLOCK_CHUNK ) ) * STATICBLOCK_CHUNK };
 }
 static_assert( staticblock_to_coords( staticblock_from_coords( 96, 200, 4096 ), 4096 ) ==
-               std::make_pair( 96u, 200u ) );
+               std::make_pair( 96_u16, 200_u16 ) );
 
 }  // namespace Pol::Plib
 

--- a/pol-core/plib/uofile02.cpp
+++ b/pol-core/plib/uofile02.cpp
@@ -98,7 +98,7 @@ void rawstaticfullread()
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
             fmt::format(
-                "to many static items in area {},{} - {},{} - maybe double items... you've "
+                "too many static items in area {},{} - {},{} - maybe double items... you've "
                 "to reduce amount of {} items below {} items ",
                 x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 
@@ -150,7 +150,7 @@ void rawstaticfullread()
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
             fmt::format(
-                "to many static items in area {},{} - {},{} - maybe double items... you've "
+                "too many static items in area {},{} - {},{} - maybe double items... you've "
                 "to reduce amount of {} items below {} items ",
                 x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 

--- a/pol-core/plib/uofile02.cpp
+++ b/pol-core/plib/uofile02.cpp
@@ -8,6 +8,7 @@
 
 
 #include <cstdio>
+#include <fmt/format.h>
 
 #include "../clib/logfacility.h"
 #include "../clib/passert.h"
@@ -96,7 +97,7 @@ void rawstaticfullread()
         auto [x, y] = staticblock_to_coords( block, uo_map_height );
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
-            std::format( "to many static items in area {} {} {} {} - maybe double items... you've "
+            fmt::format( "to many static items in area {} {} {} {} - maybe double items... you've "
                          "to reduce amount of {} items below {} items ",
                          x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 
@@ -147,7 +148,7 @@ void rawstaticfullread()
         auto [x, y] = staticblock_to_coords( block, uo_map_height );
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
-            std::format( "to many static items in area {} {} {} {} - maybe double items... you've "
+            fmt::format( "to many static items in area {} {} {} {} - maybe double items... you've "
                          "to reduce amount of {} items below {} items ",
                          x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 

--- a/pol-core/plib/uofile02.cpp
+++ b/pol-core/plib/uofile02.cpp
@@ -97,9 +97,10 @@ void rawstaticfullread()
         auto [x, y] = staticblock_to_coords( block, uo_map_height );
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
-            fmt::format( "to many static items in area {} {} {} {} - maybe double items... you've "
-                         "to reduce amount of {} items below {} items ",
-                         x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
+            fmt::format(
+                "to many static items in area {},{} - {},{} - maybe double items... you've "
+                "to reduce amount of {} items below {} items ",
+                x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 
         // dave 9/8/3, Austin's statics had a normal offset but a length of 0. badly written tool?
         if ( idx.length != 0 && fread( srecs, idx.length, 1, statfile ) != 1 )
@@ -110,8 +111,8 @@ void rawstaticfullread()
 
 
         if ( srec_count > cfg_warning_statics_per_block )
-          INFO_PRINTLN( " Warning: {} items found in area {} {} {} {}", srec_count, x, y, ( x + 7 ),
-                        ( y + 7 ) );
+          INFO_PRINTLN( " Warning: {} items found in area {},{} - {},{}", srec_count, x, y,
+                        ( x + 7 ), ( y + 7 ) );
 
         buf.count = srec_count;
       }
@@ -148,9 +149,10 @@ void rawstaticfullread()
         auto [x, y] = staticblock_to_coords( block, uo_map_height );
         passert_always_r(
             srec_count <= cfg_max_statics_per_block,
-            fmt::format( "to many static items in area {} {} {} {} - maybe double items... you've "
-                         "to reduce amount of {} items below {} items ",
-                         x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
+            fmt::format(
+                "to many static items in area {},{} - {},{} - maybe double items... you've "
+                "to reduce amount of {} items below {} items ",
+                x, y, x + 7, y + 7, srec_count, cfg_max_statics_per_block ) );
 
         if ( fread( srecs, idx.length, 1, stadif_file ) != 1 )
         {
@@ -158,7 +160,7 @@ void rawstaticfullread()
         }
 
         if ( srec_count > cfg_warning_statics_per_block )
-          INFO_PRINTLN( " Warning: {} items found in dif-area {} {} {} {}", srec_count, x, y,
+          INFO_PRINTLN( " Warning: {} items found in dif-area {},{} - {},{}", srec_count, x, y,
                         ( x + 7 ), ( y + 7 ) );
 
         buf.count = srec_count;


### PR DESCRIPTION
Due to wrong calculation to get from Blockindex to coordinates

Can be reproduced with our test map when setting in uoconvert the MaxStaticsPerBlock to eg 40.
The multi is at ~150,150
Without this PR it complains about 2,8 - 9,15
Now it prints 144,144 - 151,151