### PR TITLE
use unique_ptr to store BSpecialUserFuncJump 

### DIFF
--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -1006,6 +1006,7 @@ class BSpecialUserFuncJump final : public BObjectImp
 {
 public:
   static BSpecialUserFuncJump* get();
+  static void ReleaseSharedInstance();
 
 public:  // needed minimal imp
   size_t sizeEstimate() const override;
@@ -1015,7 +1016,9 @@ public:  // needed minimal imp
 private:
   BSpecialUserFuncJump();
   ~BSpecialUserFuncJump() override = default;
-  static BSpecialUserFuncJump imp_special_userjmp;
+  static std::unique_ptr<BSpecialUserFuncJump> imp_special_userjmp;
+  friend std::unique_ptr<BSpecialUserFuncJump> std::make_unique<BSpecialUserFuncJump>();
+  friend std::unique_ptr<BSpecialUserFuncJump>::deleter_type;
 };
 
 class BApplicObjType

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2520,23 +2520,34 @@ std::string BSpread::getStringRep() const
   return "Spread";
 }
 
-BSpecialUserFuncJump BSpecialUserFuncJump::imp_special_userjmp{};
+std::unique_ptr<BSpecialUserFuncJump> BSpecialUserFuncJump::imp_special_userjmp =
+    std::make_unique<BSpecialUserFuncJump>();
+
 BSpecialUserFuncJump::BSpecialUserFuncJump() : BObjectImp( OTSpecialUserFuncJump ) {}
+
 size_t BSpecialUserFuncJump::sizeEstimate() const
 {
   return sizeof( BSpecialUserFuncJump );
 };
+
 std::string BSpecialUserFuncJump::getStringRep() const
 {
   return "BSpecialUserFuncJump";
 };
+
 BObjectImp* BSpecialUserFuncJump::copy() const
 {
   return get();
 };
+
 BSpecialUserFuncJump* BSpecialUserFuncJump::get()
 {
-  return &imp_special_userjmp;
+  return imp_special_userjmp.get();
+}
+
+void BSpecialUserFuncJump::ReleaseSharedInstance()
+{
+  imp_special_userjmp.reset();
 }
 
 }  // namespace Pol::Bscript

--- a/pol-core/pol/globals/uvars.cpp
+++ b/pol-core/pol/globals/uvars.cpp
@@ -276,6 +276,7 @@ void GameState::deinitialize()
                            // 2012-08-27: moved before objecthash due to npc-method_script cleanup
 
   Bscript::UninitObject::ReleaseSharedInstance();
+  Bscript::BSpecialUserFuncJump::ReleaseSharedInstance();
   objStorageManager.deinitialize();
   display_leftover_objects();
 


### PR DESCRIPTION
to be able to delete instance before leftover imps are displayed.

its not an actual problem aka leak, but confusing since it gets reported