### PR TITLE
Fix handling of AlternateMultiID in boat item descriptor structs

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>03-07-2026</datemodified>
+		<datemodified>03-09-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>03-09-2026</date>
+			<author>Kevin:</author>
+			<change type="Fixed">Passing a boat item descriptor struct which contains an `AlternateMultiID` member to<br/>
+`CreateMultiAtLocation` now works correctly.</change>
+		</entry>
 		<entry>
 			<date>03-07-2026</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.3.0 --
+03-09-2026 Kevin:
+    Fixed: Passing a boat item descriptor struct which contains an `AlternateMultiID` member to
+           `CreateMultiAtLocation` now works correctly.
 03-07-2026 Turley:
     Fixed: configuration file reading failed in very rare cases due to missing thread-safety
 02-22-2026 Turley:

--- a/pol-core/pol/item/itemdesc.cpp
+++ b/pol-core/pol/item/itemdesc.cpp
@@ -1229,6 +1229,22 @@ const ItemDesc* CreateItemDescriptor( Bscript::BStruct* itemdesc_struct )
                                   std::string( val_imp->typeOf() ) );
       }
     }
+    else if ( key == "AlternateMultiID" )
+    {
+      if ( auto arr = impptrIf<Bscript::ObjArray>( val_imp ) )
+      {
+        for ( const auto& obj : arr->ref_arr )
+        {
+          elem.add_prop( "ALTERNATEMULTIID", obj->impptr()->getStringRep() );
+        }
+      }
+      else
+      {
+        throw std::runtime_error(
+            fmt::format( "CreateItemDescriptor: AlternateMultiID must be an array, but is: {}",
+                         val_imp->typeOf() ) );
+      }
+    }
     else if ( key == "StackingIgnoresCProps" )
     {
       if ( val_imp->isa( Bscript::BObjectImp::OTArray ) )

--- a/testsuite/pol/testpkgs/boat/test_boat.src
+++ b/testsuite/pol/testpkgs/boat/test_boat.src
@@ -62,6 +62,42 @@ exported function move()
   return 1;
 endfunction
 
+exported function create_alternate_multiid_filled( resources )
+  var itemdesc := GetItemDescriptor( 0x11000 );
+  itemdesc.AlternateMultiID := array{ 4, 8 };
+
+  var res := resources.CreateMultiAtLocation( 10, 50, -4, itemdesc, CRMULTI_FACING_EAST );
+  if ( !res )
+    return ret_error( "Failed to create boat " + res );
+  endif
+
+  return 1;
+endfunction
+
+exported function create_alternate_multiid_empty( resources )
+  var itemdesc := GetItemDescriptor( 0x11000 );
+  itemdesc.AlternateMultiID := {};
+
+  var res := resources.CreateMultiAtLocation( 10, 50, -4, itemdesc, CRMULTI_FACING_EAST );
+  if ( !res )
+    return ret_error( "Failed to create boat " + res );
+  endif
+
+  return 1;
+endfunction
+
+exported function create_alternate_multiid_missing( resources )
+  var itemdesc := GetItemDescriptor( 0x11000 );
+  itemdesc.-AlternateMultiID;
+
+  var res := resources.CreateMultiAtLocation( 10, 50, -4, itemdesc, CRMULTI_FACING_EAST );
+  if ( !res )
+    return ret_error( "Failed to create boat " + res );
+  endif
+
+  return 1;
+endfunction
+
 exported function test_script_method_syshook()
   var res := CreateMultiAtLocation( 10, 50, -4, 0x11000, CRMULTI_FACING_EAST );
   if ( !res )


### PR DESCRIPTION
Passing a boat item descriptor struct which contains an `AlternateMultiID` member to `CreateMultiAtLocation` now works correctly.