### PR TITLE
refptr: fixed assignment operators - changes done by llm after the fix

### DIFF
--- a/pol-core/clib/refptr.h
+++ b/pol-core/clib/refptr.h
@@ -38,6 +38,16 @@ private:
 };
 
 // **** ref_ptr class, assuming T implements ref_counted interface
+//
+// Thread-safety contract:
+//  - The pointee's refcount is atomic; two threads holding *distinct* ref_ptr<T>
+//    instances pointing at the same T are safe.
+//  - A single ref_ptr instance is NOT safe for concurrent mutation: the source-
+//    side load-then-incref window in copy-assign cannot be closed with a plain
+//    std::atomic<T*>. Callers needing to share the slot across threads must
+//    serialize externally.
+//  - get() / operator-> / operator* return raw T*/T& whose lifetime is bounded
+//    by the issuing ref_ptr; storing them past a reassignment is a UAF.
 template <class T>
 class ref_ptr
 {
@@ -218,11 +228,17 @@ bool ref_ptr<T>::operator>=( T* ptr ) const
 template <class T>
 ref_ptr<T>& ref_ptr<T>::operator=( const ref_ptr<T>& rptr )
 {
-  if ( *this != rptr )
+  // identity check, not value compare: the exchange-based body is correct for
+  // self-assignment-by-value, and a value compare would do two racy loads.
+  if ( this != &rptr )
   {
-    release();
-    _ptr = rptr.get();
-    add_ref();
+    // dont use add_ref/release here
+    T* new_p = rptr.get();
+    if ( new_p )
+      new_p->add_ref();
+    T* old_p = _ptr.exchange( new_p );
+    if ( old_p && old_p->release() == 0 )
+      delete old_p;
   }
   return *this;
 }
@@ -230,10 +246,14 @@ ref_ptr<T>& ref_ptr<T>::operator=( const ref_ptr<T>& rptr )
 template <class T>
 ref_ptr<T>& ref_ptr<T>::operator=( ref_ptr<T>&& rptr ) noexcept
 {
-  if ( *this != rptr )
+  // true self-move must be skipped: rptr._ptr.exchange(nullptr) would null self.
+  if ( this != &rptr )
   {
-    release();
-    _ptr = rptr._ptr.exchange( nullptr );
+    // dont use add_ref/release here
+    T* new_p = rptr._ptr.exchange( nullptr );
+    T* old_p = _ptr.exchange( new_p );
+    if ( old_p && old_p->release() == 0 )
+      delete old_p;
   }
   return *this;
 }
@@ -241,11 +261,14 @@ ref_ptr<T>& ref_ptr<T>::operator=( ref_ptr<T>&& rptr ) noexcept
 template <class T>
 void ref_ptr<T>::set( T* ptr )
 {
-  if ( *this == ptr )  // protection against self assignment
+  if ( *this == ptr )
     return;
-  release();
-  _ptr = ptr;
-  add_ref();
+  // dont use add_ref/release here
+  if ( ptr )
+    ptr->add_ref();
+  T* old_p = _ptr.exchange( ptr );
+  if ( old_p && old_p->release() == 0 )
+    delete old_p;
 }
 
 template <class T>

--- a/pol-core/pol/CMakeSources.cmake
+++ b/pol-core/pol/CMakeSources.cmake
@@ -399,6 +399,7 @@ set (pol_sources  # sorted !
   testing/testmisc.cpp
   testing/testpos.cpp
   testing/testrange.cpp
+  testing/testrefptr.cpp
   testing/testskill.cpp
   testing/testvector.cpp
   testing/testwalk.cpp

--- a/pol-core/pol/testing/poltest.cpp
+++ b/pol-core/pol/testing/poltest.cpp
@@ -56,6 +56,7 @@ bool run_pol_tests()
   RUNTEST( uoextension_test )
 
   RUNTEST( caseinsensitive_compare_test )
+  RUNTEST( refptr_test )
   //  RUNTEST( dummy )
 
   UnitTest::display_test_results();

--- a/pol-core/pol/testing/testenv.h
+++ b/pol-core/pol/testing/testenv.h
@@ -108,6 +108,7 @@ void decay_test();
 void clamp_test();
 void uoextension_test();
 void caseinsensitive_compare_test();
+void refptr_test();
 }  // namespace Testing
 }  // namespace Pol
 #endif

--- a/pol-core/pol/testing/testrefptr.cpp
+++ b/pol-core/pol/testing/testrefptr.cpp
@@ -1,0 +1,111 @@
+/** @file
+ *
+ * @par History
+ */
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "../../clib/logfacility.h"
+#include "../../clib/refptr.h"
+#include "testenv.h"
+
+namespace Pol::Testing
+{
+namespace
+{
+class RefCountedFoo final : public ref_counted
+{
+public:
+  RefCountedFoo() { ++live_count; }
+  ~RefCountedFoo() override { --live_count; }
+
+  static std::atomic<int> live_count;
+};
+
+std::atomic<int> RefCountedFoo::live_count{ 0 };
+
+constexpr int kPoolSize = 16;
+constexpr int kThreads = 8;
+constexpr int kIterations = 50000;
+
+// Each thread owns its own destination ref_ptr<>s and pulls source pointers
+// out of a shared pool of pre-existing ref_ptr<>s. This exercises the
+// destination-side race that the M1 fix targets without entering the
+// (documented as unsupported) territory of mutating the same ref_ptr instance
+// from multiple threads.
+void hammer( const std::vector<ref_ptr<RefCountedFoo>>& pool, int seed )
+{
+  ref_ptr<RefCountedFoo> a;
+  ref_ptr<RefCountedFoo> b;
+  unsigned x = static_cast<unsigned>( seed ) * 2654435761u;
+  for ( int i = 0; i < kIterations; ++i )
+  {
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    const auto& src = pool[x % pool.size()];
+    switch ( ( x >> 8 ) & 3u )
+    {
+    case 0:
+      a = src;  // copy-assign
+      break;
+    case 1:
+      b.set( src.get() );  // raw set
+      break;
+    case 2:
+    {
+      ref_ptr<RefCountedFoo> tmp( src );
+      a = std::move( tmp );  // move-assign
+      break;
+    }
+    default:
+      a.clear();
+      break;
+    }
+  }
+}
+}  // namespace
+
+void refptr_test()
+{
+  const int baseline = RefCountedFoo::live_count.load();
+
+  {
+    std::vector<ref_ptr<RefCountedFoo>> pool;
+    pool.reserve( kPoolSize );
+    for ( int i = 0; i < kPoolSize; ++i )
+      pool.emplace_back( new RefCountedFoo );
+
+    std::vector<std::thread> workers;
+    workers.reserve( kThreads );
+    for ( int t = 0; t < kThreads; ++t )
+      workers.emplace_back( [&pool, t]() { hammer( pool, t + 1 ); } );
+
+    for ( auto& w : workers )
+      w.join();
+
+    // Every Foo must still be alive: only the pool holds canonical refs.
+    if ( RefCountedFoo::live_count.load() == baseline + kPoolSize )
+      UnitTest::inc_successes();
+    else
+    {
+      INFO_PRINTLN( "refptr_test: live={} expected={} after hammer",
+                    RefCountedFoo::live_count.load(), baseline + kPoolSize );
+      UnitTest::inc_failures();
+    }
+  }
+
+  // Pool is destroyed; all Foos must be released.
+  if ( RefCountedFoo::live_count.load() == baseline )
+    UnitTest::inc_successes();
+  else
+  {
+    INFO_PRINTLN( "refptr_test: live={} expected={} after pool destruction",
+                  RefCountedFoo::live_count.load(), baseline );
+    UnitTest::inc_failures();
+  }
+}
+}  // namespace Pol::Testing


### PR DESCRIPTION
What LLM came up with after initial fix was done.