### PR TITLE
Restore NPC cold_resist_cap from its own orig value on refresh_ar

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,10 +8,8 @@
 		<entry>
 			<date>05-10-2026</date>
 			<author>AsYlum:</author>
-			<change type="Fixed">NPC::resetEquipablePropertiesNPC was restoring cold_resist_cap from<br/>
-orig_energy_resist_cap (copy-paste). On NPCs with intrinsic AR,<br/>
-refresh_ar() would clobber the cold resist cap with the energy<br/>
-cap's original value. Each cap is now restored from its own orig.</change>
+			<change type="Fixed">NPCs with intrinsic AR had their ColdResistCap silently overwritten<br/>
+with EnergyResistCap whenever any resist/damage/cap mod was changed.</change>
 		</entry>
 		<entry>
 			<date>04-22-2026</date>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,17 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>04-22-2026</datemodified>
+		<datemodified>05-10-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>05-10-2026</date>
+			<author>AsYlum:</author>
+			<change type="Fixed">NPC::resetEquipablePropertiesNPC was restoring cold_resist_cap from<br/>
+orig_energy_resist_cap (copy-paste). On NPCs with intrinsic AR,<br/>
+refresh_ar() would clobber the cold resist cap with the energy<br/>
+cap's original value. Each cap is now restored from its own orig.</change>
+		</entry>
 		<entry>
 			<date>04-22-2026</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,9 +1,7 @@
 -- POL100.3.0 --
 05-10-2026 AsYlum:
-    Fixed: NPC::resetEquipablePropertiesNPC was restoring cold_resist_cap from
-           orig_energy_resist_cap (copy-paste). On NPCs with intrinsic AR,
-           refresh_ar() would clobber the cold resist cap with the energy
-           cap's original value. Each cap is now restored from its own orig.
+    Fixed: NPCs with intrinsic AR had their ColdResistCap silently overwritten
+           with EnergyResistCap whenever any resist/damage/cap mod was changed.
 04-22-2026 Turley:
     Fixed: Statmsg pkt (0x11) was send way to often
     Fixed: In case of a load error print the starting line number of the element

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 -- POL100.3.0 --
+05-10-2026 AsYlum:
+    Fixed: NPC::resetEquipablePropertiesNPC was restoring cold_resist_cap from
+           orig_energy_resist_cap (copy-paste). On NPCs with intrinsic AR,
+           refresh_ar() would clobber the cold resist cap with the energy
+           cap's original value. Each cap is now restored from its own orig.
 04-22-2026 Turley:
     Fixed: Statmsg pkt (0x11) was send way to often
     Fixed: In case of a load error print the starting line number of the element

--- a/pol-core/pol/mobile/npc.cpp
+++ b/pol-core/pol/mobile/npc.cpp
@@ -1075,7 +1075,7 @@ void NPC::resetEquipablePropertiesNPC()
   if ( has_fire_resist_cap() || has_orig_fire_resist_cap() )
     fire_resist_cap( fire_resist_cap().setAsValue( orig_fire_resist_cap() ) );
   if ( has_cold_resist_cap() || has_orig_cold_resist_cap() )
-    cold_resist_cap( cold_resist_cap().setAsValue( orig_energy_resist_cap() ) );
+    cold_resist_cap( cold_resist_cap().setAsValue( orig_cold_resist_cap() ) );
   if ( has_energy_resist_cap() || has_orig_energy_resist_cap() )
     energy_resist_cap( energy_resist_cap().setAsValue( orig_energy_resist_cap() ) );
   if ( has_physical_resist_cap() || has_orig_physical_resist_cap() )

--- a/testsuite/pol/testpkgs/npc/test_npc.src
+++ b/testsuite/pol/testpkgs/npc/test_npc.src
@@ -268,18 +268,13 @@ exported function test_logged_in( resources )
   return ret_error_not_equal( npc.logged_in, 1, $"NPC should be logged_in, got {npc.logged_in} expected 1" );
 endfunction
 
-// Regression: resetEquipablePropertiesNPC restores 27 properties from their
-// orig_* values. A single copy-paste in that block silently swaps two
-// channels (the original bug had cold_resist_cap reading orig_energy_resist_cap).
-// Distinct values per property catch any such swap generically.
-exported function test_npc_resist_cap_refresh()
-  // Distinct non-zero value per property so any cross-wiring in
-  // resetEquipablePropertiesNPC produces a detectable mismatch.
-  // INVARIANT: each resist must be < its matching cap, and
-  // DefenceIncrease < DefenceIncreaseCap. Reads for those members go
-  // through EnforceCaps (= min(value, cap)); if a resist ever exceeds
-  // its cap the read silently clamps to the cap and a real swap regression
-  // would be masked. Keep caps strictly larger than the things they cap.
+exported function test_npc_resist_cap_refresh( resources )
+  // Refreshing an intrinsic-AR NPC must restore each property from its
+  // OWN orig_*; a copy-paste once wired cold_resist_cap to
+  // orig_energy_resist_cap. Distinct values 1..27 catch any such swap.
+  // Each cap must stay strictly greater than the resist/value it caps —
+  // resist_* and defence_increase reads clamp to min(value, cap), which
+  // would mask a swap if a value ever exceeded its cap.
   var override := struct{
     AR := 50,
     FireResist := 1,
@@ -341,25 +336,21 @@ exported function test_npc_resist_cap_refresh()
     { "max_attack_range_increase", override.MaxAttackRangeIncrease }
   };
 
-  var npc := CreateNPCFromTemplate( ":testnpc:load_npc", 100, 100, 0, override );
+  var npc := resources.CreateNPCFromTemplate( ":testnpc:load_npc", 100, 100, 0, override );
   if ( !npc )
     return ret_error( "Could not create NPC: " + npc );
   endif
 
-  // ar_mod calls refresh_ar(); with npc_ar_ != 0 (AR=50) this takes the
-  // intrinsic-armor path that re-applies orig values via
-  // resetEquipablePropertiesNPC. ar_mod is used (not one of the properties
-  // under test) so the trigger and the assertions stay independent.
+  // ar_mod triggers the refresh; it isn't one of the asserted members,
+  // so the trigger stays independent of what's being verified.
   npc.ar_mod := 0;
 
   foreach check in checks
     var got := npc.get_member( check[1] );
     if ( got != check[2] )
-      npc.kill();
       return ret_error( $"{check[1]} after refresh: got {got}, expected {check[2]}" );
     endif
   endforeach
 
-  npc.kill();
   return 1;
 endfunction

--- a/testsuite/pol/testpkgs/npc/test_npc.src
+++ b/testsuite/pol/testpkgs/npc/test_npc.src
@@ -267,3 +267,99 @@ exported function test_logged_in( resources )
   var npc := resources.CreateNPCFromTemplate( ":testnpc:load_npc", 100, 100, 0 );
   return ret_error_not_equal( npc.logged_in, 1, $"NPC should be logged_in, got {npc.logged_in} expected 1" );
 endfunction
+
+// Regression: resetEquipablePropertiesNPC restores 27 properties from their
+// orig_* values. A single copy-paste in that block silently swaps two
+// channels (the original bug had cold_resist_cap reading orig_energy_resist_cap).
+// Distinct values per property catch any such swap generically.
+exported function test_npc_resist_cap_refresh()
+  // Distinct non-zero value per property so any cross-wiring in
+  // resetEquipablePropertiesNPC produces a detectable mismatch.
+  // INVARIANT: each resist must be < its matching cap, and
+  // DefenceIncrease < DefenceIncreaseCap. Reads for those members go
+  // through EnforceCaps (= min(value, cap)); if a resist ever exceeds
+  // its cap the read silently clamps to the cap and a real swap regression
+  // would be masked. Keep caps strictly larger than the things they cap.
+  var override := struct{
+    AR := 50,
+    FireResist := 1,
+    ColdResist := 2,
+    EnergyResist := 3,
+    PoisonResist := 4,
+    PhysicalResist := 5,
+    FireDamage := 6,
+    ColdDamage := 7,
+    EnergyDamage := 8,
+    PoisonDamage := 9,
+    PhysicalDamage := 10,
+    LowerReagentCost := 11,
+    SpellDamageIncrease := 12,
+    FasterCasting := 13,
+    FasterCastRecovery := 14,
+    DefenceIncrease := 15,
+    DefenceIncreaseCap := 16,
+    LowerManaCost := 17,
+    HitChance := 18,
+    FireResistCap := 19,
+    ColdResistCap := 20,
+    EnergyResistCap := 21,
+    PhysicalResistCap := 22,
+    PoisonResistCap := 23,
+    Luck := 24,
+    SwingSpeedIncrease := 25,
+    MinAttackRangeIncrease := 26,
+    MaxAttackRangeIncrease := 27
+  };
+
+  var checks := {
+    { "resist_fire", override.FireResist },
+    { "resist_cold", override.ColdResist },
+    { "resist_energy", override.EnergyResist },
+    { "resist_poison", override.PoisonResist },
+    { "resist_physical", override.PhysicalResist },
+    { "damage_fire", override.FireDamage },
+    { "damage_cold", override.ColdDamage },
+    { "damage_energy", override.EnergyDamage },
+    { "damage_poison", override.PoisonDamage },
+    { "damage_physical", override.PhysicalDamage },
+    { "lower_reagent_cost", override.LowerReagentCost },
+    { "spell_damage_increase", override.SpellDamageIncrease },
+    { "faster_casting", override.FasterCasting },
+    { "faster_cast_recovery", override.FasterCastRecovery },
+    { "defence_increase", override.DefenceIncrease },
+    { "defence_increase_cap", override.DefenceIncreaseCap },
+    { "lower_mana_cost", override.LowerManaCost },
+    { "hit_chance", override.HitChance },
+    { "resist_fire_cap", override.FireResistCap },
+    { "resist_cold_cap", override.ColdResistCap },
+    { "resist_energy_cap", override.EnergyResistCap },
+    { "resist_physical_cap", override.PhysicalResistCap },
+    { "resist_poison_cap", override.PoisonResistCap },
+    { "luck", override.Luck },
+    { "swing_speed_increase", override.SwingSpeedIncrease },
+    { "min_attack_range_increase", override.MinAttackRangeIncrease },
+    { "max_attack_range_increase", override.MaxAttackRangeIncrease }
+  };
+
+  var npc := CreateNPCFromTemplate( ":testnpc:load_npc", 100, 100, 0, override );
+  if ( !npc )
+    return ret_error( "Could not create NPC: " + npc );
+  endif
+
+  // ar_mod calls refresh_ar(); with npc_ar_ != 0 (AR=50) this takes the
+  // intrinsic-armor path that re-applies orig values via
+  // resetEquipablePropertiesNPC. ar_mod is used (not one of the properties
+  // under test) so the trigger and the assertions stay independent.
+  npc.ar_mod := 0;
+
+  foreach check in checks
+    var got := npc.get_member( check[1] );
+    if ( got != check[2] )
+      npc.kill();
+      return ret_error( $"{check[1]} after refresh: got {got}, expected {check[2]}" );
+    endif
+  endforeach
+
+  npc.kill();
+  return 1;
+endfunction


### PR DESCRIPTION
## Summary
- `NPC::resetEquipablePropertiesNPC` was restoring `cold_resist_cap` from `orig_energy_resist_cap()` instead of `orig_cold_resist_cap()` — a copy-paste typo. On any NPC with intrinsic AR (`npc_ar_ != 0`), every `refresh_ar()` clobbered the cold resist cap with the energy cap's original value. Every other line in the same block correctly reads its own channel's orig.
- Added a regression test in `testsuite/pol/testpkgs/npc/test_npc.src` (`test_npc_resist_cap_refresh`) that creates an NPC with `AR=50` and 27 distinct override values, triggers a refresh via `ar_mod := 0`, and asserts each of the 27 properties restored by `resetEquipablePropertiesNPC` reads back its own orig. This catches not just the original swap but any single-line copy-paste of the same shape in that block.
- Changelog entry added to `pol-core/doc/core-changes.txt`; `corechanges.xml` regenerated.

## Files
- `pol-core/pol/mobile/npc.cpp` — one-line fix at line 1078.
- `testsuite/pol/testpkgs/npc/test_npc.src` — new exported function `test_npc_resist_cap_refresh`.
- `pol-core/doc/core-changes.txt`, `docs/docs.polserver.com/pol100/corechanges.xml` — changelog.

## Notes
- The trigger uses `ar_mod := 0` rather than one of the asserted properties, so the trigger and the verification surface stay disjoint.
- All resist values in the test are kept strictly below their matching caps — `resist_*` reads go through `EnforceCaps = min(value, cap)`, and a swap regression would silently clamp if that invariant ever broke. Comment in the test calls this out.