### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
-      - uses: compnerd/gha-setup-vsdevenv@v6
+      - uses: egor-tensin/vs-shell@v2
       - name: Cache curl
         uses: actions/cache@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,22 +260,22 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Nightly-Linux-g++
           path: Nightly-Linux-g++
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Nightly-Linux-clang++
           path: Nightly-Linux-clang++
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Nightly-Windows-cl
           path: Nightly-Windows-cl
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Nightly-macOS-clang++
           path: Nightly-macOS-clang++

--- a/.github/workflows/buildwinnopch.yml
+++ b/.github/workflows/buildwinnopch.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
-      - uses: compnerd/gha-setup-vsdevenv@v6
+      - uses: egor-tensin/vs-shell@v2
       - name: Cache curl
         uses: actions/cache@v5
         with:

--- a/.github/workflows/tidy.yml_
+++ b/.github/workflows/tidy.yml_
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - uses: compnerd/gha-setup-vsdevenv@v6
       - name: Cache curl
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Due to node20 deprecation warning:
Use a different action to activate the environ
Update download-artefact
