### PR TITLE
Fixed leak when a class/funcref is a global

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,17 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>05-23-2026</datemodified>
+		<datemodified>05-25-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>05-25-2026</date>
+			<author>Turley:</author>
+			<change type="Fixed">Memoryleak when storing classes or functionobjects as global variable</change>
+			<change type="Changed">When sending classes/functionobjects to another script its no longer valid to access global variables when the sending script is destroyed before the call.<br/>
+The calling script will stop with an error.<br/>
+Original feature description check 08-08-2024</change>
+		</entry>
 		<entry>
 			<date>05-23-2026</date>
 			<author>Kevin:</author>

--- a/pol-core/bscript/bclassinstance.cpp
+++ b/pol-core/bscript/bclassinstance.cpp
@@ -11,7 +11,7 @@
 namespace Pol::Bscript
 {
 BClassInstance::BClassInstance( ref_ptr<EScriptProgram> program, int index,
-                                std::shared_ptr<ValueStackCont> globals )
+                                std::weak_ptr<ValueStackCont> globals )
     : BStruct( OTClassInstance ),
       prog_( std::move( program ) ),
       index_( index ),
@@ -31,7 +31,7 @@ size_t BClassInstance::sizeEstimate() const
 {
   return base::sizeEstimate() + Clib::memsize( constructors_called ) +
          sizeof( ref_ptr<EScriptProgram> ) + sizeof( unsigned int ) +
-         sizeof( std::shared_ptr<ValueStackCont> );
+         sizeof( std::weak_ptr<ValueStackCont> );
 }
 
 ref_ptr<EScriptProgram> BClassInstance::prog() const

--- a/pol-core/bscript/bclassinstance.h
+++ b/pol-core/bscript/bclassinstance.h
@@ -48,7 +48,7 @@ private:
   unsigned int index_;
 
 public:
-  std::shared_ptr<ValueStackCont> globals;
+  std::weak_ptr<ValueStackCont> globals;
 };
 
 class BClassInstanceRef final : public BObjectImp

--- a/pol-core/bscript/bclassinstance.h
+++ b/pol-core/bscript/bclassinstance.h
@@ -15,7 +15,7 @@ class BClassInstance final : public BStruct
 
 public:
   BClassInstance( ref_ptr<EScriptProgram> program, int index,
-                  std::shared_ptr<ValueStackCont> globals );
+                  std::weak_ptr<ValueStackCont> globals );
   BClassInstance( const BClassInstance& B );
   ~BClassInstance() override = default;
 

--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -576,6 +576,7 @@ public:
 
   static UninitObject* SharedInstance;
   static ref_ptr<BObjectImp> SharedInstanceOwner;
+  static BObjectRef SharedInstanceRef;
 
   BObjectImp* copy() const override;
   size_t sizeEstimate() const override;

--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -930,7 +930,7 @@ class BFunctionRef final : public BObjectImp
 
 public:
   BFunctionRef( ref_ptr<EScriptProgram> program, unsigned function_reference_index,
-                std::shared_ptr<ValueStackCont> globals, ValueStackCont&& captures );
+                std::weak_ptr<ValueStackCont> globals, ValueStackCont&& captures );
   BFunctionRef( const BFunctionRef& B );
 
 private:
@@ -971,7 +971,7 @@ private:
   unsigned function_reference_index_;
 
 public:
-  std::shared_ptr<ValueStackCont> globals;
+  std::weak_ptr<ValueStackCont> globals;
   ValueStackCont captures;
 };
 

--- a/pol-core/bscript/dict.cpp
+++ b/pol-core/bscript/dict.cpp
@@ -141,18 +141,24 @@ BObjectRef BDictionary::set_member( const char* membername, BObjectImp* value, b
 {
   BObject key( new String( membername ) );
   BObjectImp* target = copy ? value->copy() : value;
-
-  auto itr = contents_.find( key );
-  if ( itr != contents_.end() )
+  auto [itr, inserted] = contents_.try_emplace( key, target );
+  if ( !inserted )
   {
-    BObjectRef& oref = ( *itr ).second;
+    BObjectRef& oref = itr->second;
     oref->setimp( target );
-    return oref;
   }
+  return itr->second;
+  /*  auto itr = contents_.find( key );
+    if ( itr != contents_.end() )
+    {
+      BObjectRef& oref = ( *itr ).second;
+      oref->setimp( target );
+      return oref;
+    }
 
-  BObjectRef ref( new BObject( target ) );
-  contents_[key] = ref;
-  return ref;
+    BObjectRef ref( new BObject( target ) );
+    contents_[key] = ref;
+    return ref;*/
 }
 
 BObjectRef BDictionary::get_member( const char* membername )

--- a/pol-core/bscript/dict.cpp
+++ b/pol-core/bscript/dict.cpp
@@ -141,24 +141,18 @@ BObjectRef BDictionary::set_member( const char* membername, BObjectImp* value, b
 {
   BObject key( new String( membername ) );
   BObjectImp* target = copy ? value->copy() : value;
-  auto [itr, inserted] = contents_.try_emplace( key, target );
-  if ( !inserted )
-  {
-    BObjectRef& oref = itr->second;
-    oref->setimp( target );
-  }
-  return itr->second;
-  /*  auto itr = contents_.find( key );
-    if ( itr != contents_.end() )
-    {
-      BObjectRef& oref = ( *itr ).second;
-      oref->setimp( target );
-      return oref;
-    }
 
-    BObjectRef ref( new BObject( target ) );
-    contents_[key] = ref;
-    return ref;*/
+  auto itr = contents_.find( key );
+  if ( itr != contents_.end() )
+  {
+    BObjectRef& oref = ( *itr ).second;
+    oref->setimp( target );
+    return oref;
+  }
+
+  BObjectRef ref( new BObject( target ) );
+  contents_[key] = ref;
+  return ref;
 }
 
 BObjectRef BDictionary::get_member( const char* membername )

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -2942,14 +2942,25 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
   // Only store our global context if the function is external to the current program.
   if ( funcref != nullptr && funcref->prog() != prog_ )
   {
-    // Store external context for the return path.
-    rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
+    POLLOG_INFOLN( "different prog {}", funcref->prog()->name );
+    if ( auto shared = funcref->globals.lock() )
+    {
+      // Store external context for the return path.
+      rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
+
+      Globals2 = shared;
+    }
+    else
+    {
+      POLLOG_INFOLN( "Function no longer valid" );
+      setFunctionResult( new BError( "Function no longer valid" ) );
+      return;
+    }
 
     // Set the prog and globals to the external function's, updating nLines and
     // execmodules.
     prog_ = funcref->prog();
 
-    Globals2 = funcref->globals;
 
     nLines = static_cast<unsigned int>( prog_->instr.size() );
 
@@ -3858,9 +3869,15 @@ void Executor::show_context( std::string& os, unsigned atPC )
 void Executor::call_function_reference( BFunctionRef* funcr, BContinuation* continuation,
                                         const Instruction& jmp )
 {
+  POLLOG_INFOLN( "CALL FUNC" );
   // params need to be on the stack, without current objectref
   ValueStack.pop_back();
-
+  if ( funcr->globals.expired() )
+  {
+    POLLOG_INFOLN( "expired" );
+    ValueStack.emplace_back( new BError( "expired" ) );
+    return;
+  }
   // Push captured parameters onto the stack prior to function parameters.
   for ( auto& p : funcr->captures )
     ValueStack.push_back( p );

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -1466,7 +1466,7 @@ void Executor::ins_globalvar( const Instruction& ins )
   {
     POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
     seterror( true );
-    ValueStack.push_back( BObjectRef( UninitObject::create() ) );
+    ValueStack.emplace_back( UninitObject::create() );
     return;
   }
   ValueStack.push_back( ( *Globals2 )[ins.token.lval] );

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -815,7 +815,7 @@ BObjectRef& Executor::LocalVar( unsigned int varnum )
 
 BObjectRef& Executor::GlobalVar( unsigned int varnum )
 {
-  if ( varnum < Globals2->size() )
+  if ( varnum >= Globals2->size() )
   {
     POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
     seterror( true );
@@ -1462,7 +1462,7 @@ void Executor::ins_localvar( const Instruction& ins )
 // case TOK_GLOBALVAR:
 void Executor::ins_globalvar( const Instruction& ins )
 {
-  if ( (unsigned)ins.token.lval < Globals2->size() )
+  if ( (unsigned)ins.token.lval >= Globals2->size() )
   {
     POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
     seterror( true );
@@ -1701,7 +1701,7 @@ void Executor::ins_assign_localvar( const Instruction& ins )
 }
 void Executor::ins_assign_globalvar( const Instruction& ins )
 {
-  if ( (unsigned)ins.token.lval < Globals2->size() )
+  if ( (unsigned)ins.token.lval >= Globals2->size() )
   {
     POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
     seterror( true );
@@ -2394,8 +2394,7 @@ void Executor::ins_take_global( const Instruction& ins )
 {
   passert( !ValueStack.empty() );
 
-  // Globals already have an entry in the globals vector, so just index into it.
-  if ( (unsigned)ins.token.lval < Globals2->size() )
+  if ( (unsigned)ins.token.lval >= Globals2->size() )
   {
     POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
     seterror( true );

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -1689,7 +1689,7 @@ void Executor::ins_assign_localvar( const Instruction& ins )
 }
 void Executor::ins_assign_globalvar( const Instruction& ins )
 {
-  passert_always_r( (unsigned)ine.token.lval < Globals2->size(), "Globals empty" );
+  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
   BObjectRef& gvar = ( *Globals2 )[ins.token.lval];
 
   BObjectRef& rightref = ValueStack.back();

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -815,7 +815,13 @@ BObjectRef& Executor::LocalVar( unsigned int varnum )
 
 BObjectRef& Executor::GlobalVar( unsigned int varnum )
 {
-  passert_always_r( varnum < Globals2->size(), "Globals empty" );
+  if ( varnum < Globals2->size() )
+  {
+    POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
+    seterror( true );
+    UninitObject::SharedInstanceRef.set( UninitObject::SharedInstance );
+    return UninitObject::SharedInstanceRef;
+  }
   return ( *Globals2 )[varnum];
 }
 
@@ -1456,7 +1462,13 @@ void Executor::ins_localvar( const Instruction& ins )
 // case TOK_GLOBALVAR:
 void Executor::ins_globalvar( const Instruction& ins )
 {
-  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
+  if ( (unsigned)ins.token.lval < Globals2->size() )
+  {
+    POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
+    seterror( true );
+    ValueStack.push_back( BObjectRef( UninitObject::create() ) );
+    return;
+  }
   ValueStack.push_back( ( *Globals2 )[ins.token.lval] );
 }
 
@@ -1689,7 +1701,13 @@ void Executor::ins_assign_localvar( const Instruction& ins )
 }
 void Executor::ins_assign_globalvar( const Instruction& ins )
 {
-  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
+  if ( (unsigned)ins.token.lval < Globals2->size() )
+  {
+    POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
+    seterror( true );
+    ValueStack.pop_back();
+    return;
+  }
   BObjectRef& gvar = ( *Globals2 )[ins.token.lval];
 
   BObjectRef& rightref = ValueStack.back();
@@ -2377,7 +2395,13 @@ void Executor::ins_take_global( const Instruction& ins )
   passert( !ValueStack.empty() );
 
   // Globals already have an entry in the globals vector, so just index into it.
-  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
+  if ( (unsigned)ins.token.lval < Globals2->size() )
+  {
+    POLLOG_ERRORLN( "Fatal error: Globals access out of range! ({},PC={})", prog_->name, PC );
+    seterror( true );
+    ValueStack.pop_back();
+    return;
+  }
   BObjectRef& gvar = ( *Globals2 )[ins.token.lval];
 
   BObjectRef& rightref = ValueStack.back();

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -15,6 +15,7 @@
 
 #include "executor.h"
 #include "bobject.h"
+#include "exectype.h"
 #include "executor.inl.h"
 
 #include "../clib/clib.h"
@@ -814,7 +815,7 @@ BObjectRef& Executor::LocalVar( unsigned int varnum )
 
 BObjectRef& Executor::GlobalVar( unsigned int varnum )
 {
-  passert( varnum < Globals2->size() );
+  passert_always_r( varnum < Globals2->size(), "Globals empty" );
   return ( *Globals2 )[varnum];
 }
 
@@ -1455,6 +1456,7 @@ void Executor::ins_localvar( const Instruction& ins )
 // case TOK_GLOBALVAR:
 void Executor::ins_globalvar( const Instruction& ins )
 {
+  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
   ValueStack.push_back( ( *Globals2 )[ins.token.lval] );
 }
 
@@ -1687,6 +1689,7 @@ void Executor::ins_assign_localvar( const Instruction& ins )
 }
 void Executor::ins_assign_globalvar( const Instruction& ins )
 {
+  passert_always_r( (unsigned)ine.token.lval < Globals2->size(), "Globals empty" );
   BObjectRef& gvar = ( *Globals2 )[ins.token.lval];
 
   BObjectRef& rightref = ValueStack.back();
@@ -2374,6 +2377,7 @@ void Executor::ins_take_global( const Instruction& ins )
   passert( !ValueStack.empty() );
 
   // Globals already have an entry in the globals vector, so just index into it.
+  passert_always_r( (unsigned)ins.token.lval < Globals2->size(), "Globals empty" );
   BObjectRef& gvar = ( *Globals2 )[ins.token.lval];
 
   BObjectRef& rightref = ValueStack.back();
@@ -2943,18 +2947,19 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
   if ( funcref != nullptr && funcref->prog() != prog_ )
   {
     POLLOG_INFOLN( "different prog {}", funcref->prog()->name );
+    // Store external context for the return path.
+    rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
+
     if ( auto shared = funcref->globals.lock() )
     {
-      // Store external context for the return path.
-      rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
-
       Globals2 = shared;
     }
     else
     {
-      POLLOG_INFOLN( "Function no longer valid" );
-      setFunctionResult( new BError( "Function no longer valid" ) );
-      return;
+      Globals2 = std::make_shared<BObjectRefVec>();
+      //      POLLOG_INFOLN( "Function no longer valid" );
+      //    setFunctionResult( new BError( "Function no longer valid" ) );
+      //  return;
     }
 
     // Set the prog and globals to the external function's, updating nLines and
@@ -3872,12 +3877,12 @@ void Executor::call_function_reference( BFunctionRef* funcr, BContinuation* cont
   POLLOG_INFOLN( "CALL FUNC" );
   // params need to be on the stack, without current objectref
   ValueStack.pop_back();
-  if ( funcr->globals.expired() )
-  {
-    POLLOG_INFOLN( "expired" );
-    ValueStack.emplace_back( new BError( "expired" ) );
-    return;
-  }
+  /*  if ( funcr->globals.expired() )
+    {
+      POLLOG_INFOLN( "expired" );
+      ValueStack.emplace_back( new BError( "expired" ) );
+      return;
+    }*/
   // Push captured parameters onto the stack prior to function parameters.
   for ( auto& p : funcr->captures )
     ValueStack.push_back( p );

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -2973,16 +2973,10 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
     rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
 
     if ( auto shared = funcref->globals.lock() )
-    {
       Globals2 = shared;
-    }
     else
-    {
-      Globals2 = std::make_shared<BObjectRefVec>();
-      //      POLLOG_INFOLN( "Function no longer valid" );
-      //    setFunctionResult( new BError( "Function no longer valid" ) );
-      //  return;
-    }
+      Globals2 =
+          std::make_shared<BObjectRefVec>();  // empty but valid, access would stop the executor
 
     // Set the prog and globals to the external function's, updating nLines and
     // execmodules.
@@ -3898,12 +3892,6 @@ void Executor::call_function_reference( BFunctionRef* funcr, BContinuation* cont
 {
   // params need to be on the stack, without current objectref
   ValueStack.pop_back();
-  /*  if ( funcr->globals.expired() )
-    {
-      POLLOG_INFOLN( "expired" );
-      ValueStack.emplace_back( new BError( "expired" ) );
-      return;
-    }*/
   // Push captured parameters onto the stack prior to function parameters.
   for ( auto& p : funcr->captures )
     ValueStack.push_back( p );

--- a/pol-core/bscript/executor.cpp
+++ b/pol-core/bscript/executor.cpp
@@ -2946,7 +2946,6 @@ void Executor::jump( int target_PC, BContinuation* continuation, BFunctionRef* f
   // Only store our global context if the function is external to the current program.
   if ( funcref != nullptr && funcref->prog() != prog_ )
   {
-    POLLOG_INFOLN( "different prog {}", funcref->prog()->name );
     // Store external context for the return path.
     rc.ExternalContext = ReturnContext::External( prog_, std::move( execmodules ), Globals2 );
 
@@ -3874,7 +3873,6 @@ void Executor::show_context( std::string& os, unsigned atPC )
 void Executor::call_function_reference( BFunctionRef* funcr, BContinuation* continuation,
                                         const Instruction& jmp )
 {
-  POLLOG_INFOLN( "CALL FUNC" );
   // params need to be on the stack, without current objectref
   ValueStack.pop_back();
   /*  if ( funcr->globals.expired() )

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -974,6 +974,7 @@ BObjectRef BObjectImp::operDotQMark( const char* /*name*/ )
 
 UninitObject* UninitObject::SharedInstance;
 ref_ptr<BObjectImp> UninitObject::SharedInstanceOwner;
+BObjectRef UninitObject::SharedInstanceRef;
 
 UninitObject::UninitObject() : BObjectImp( OTUninit ) {}
 

--- a/pol-core/bscript/object.cpp
+++ b/pol-core/bscript/object.cpp
@@ -2223,7 +2223,7 @@ std::string BBoolean::getStringRep() const
 }
 
 BFunctionRef::BFunctionRef( ref_ptr<EScriptProgram> program, unsigned function_reference_index,
-                            std::shared_ptr<ValueStackCont> globals, ValueStackCont&& captures )
+                            std::weak_ptr<ValueStackCont> globals, ValueStackCont&& captures )
     : BObjectImp( OTFuncRef ),
       prog_( std::move( program ) ),
       function_reference_index_( function_reference_index ),

--- a/pol-core/doc/breaking-changes.txt
+++ b/pol-core/doc/breaking-changes.txt
@@ -1,7 +1,12 @@
 # This is a short summary of breaking changes.
 # Please consult core-changes.txt for more information.
 
--- POL100.2.0 [work-in-progress] --
+-- POL100.3.0 [work-in-progress] --
+05-25-2026 Turley:
+    When sending classes/functionobjects to another script its no longer valid to access global variables when the sending script is destroyed before the call.
+    The calling script will stop with an error.
+    Original feature description check 08-08-2024
+-- POL100.2.0 --
 11-17-2025 Kevin:
     EquipScript/UnequipScript will now be given an OfflineCharacterRef for the equip_on/equip_by and unequip_on/unequip_by parameters,
     allowing scripts to access the mobile if the mobile is offline.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,9 @@
 -- POL100.3.0 --
+05-25-2026 Turley:
+    Fixed: Memoryleak when storing classes or functionobjects as global variable
+  Changed: When sending classes/functionobjects to another script its no longer valid to access global variables when the sending script is destroyed before the call.
+           The calling script will stop with an error.
+           Original feature description check 08-08-2024
 05-23-2026 Kevin:
     Added: New module function party::ListParties()
 05-10-2026 Turley:

--- a/pol-core/runecl/RunEclMain.cpp
+++ b/pol-core/runecl/RunEclMain.cpp
@@ -47,7 +47,6 @@ void load_fileaccess_cfg();
 }
 namespace Clib
 {
-using namespace std;
 using namespace Pol::Bscript;
 using namespace Pol::Module;
 
@@ -106,52 +105,55 @@ int RunEclMain::runeclScript( std::string fileName )
   FILETIME kernelStart, userStart;
   FILETIME kernelEnd, userEnd;
 #endif
-  Executor exe;
-  exe.addModule( new BasicExecutorModule( exe ) );
-  exe.addModule( new BasicIoExecutorModule( exe ) );
-  exe.addModule( new MathExecutorModule( exe ) );
-  exe.addModule( new UtilExecutorModule( exe ) );
-  exe.addModule( new FileAccessExecutorModule( exe ) );
-  exe.addModule( new ConfigFileExecutorModule( exe ) );
-  exe.addModule( new DataFileExecutorModule( exe ) );
-
-  ref_ptr<EScriptProgram> program( new EScriptProgram );
-  if ( program->read( fileName.c_str() ) )
   {
-    ERROR_PRINTLN( "Error reading {}", fileName );
-    return 1;
-  }
-  exe.setProgram( program.get() );
-  // find and set pkg
-  std::string dir = fileName;
-  Clib::strip_one( dir );
-  dir = Clib::normalized_dir_form( dir );
-  Plib::load_packages( true /*quiet*/ );
+    Executor exe;
+    exe.addModule( new BasicExecutorModule( exe ) );
+    exe.addModule( new BasicIoExecutorModule( exe ) );
+    exe.addModule( new MathExecutorModule( exe ) );
+    exe.addModule( new UtilExecutorModule( exe ) );
+    exe.addModule( new FileAccessExecutorModule( exe ) );
+    exe.addModule( new ConfigFileExecutorModule( exe ) );
+    exe.addModule( new DataFileExecutorModule( exe ) );
+    ref_ptr<EScriptProgram> program( new EScriptProgram );
+    if ( program->read( fileName.c_str() ) )
+    {
+      ERROR_PRINTLN( "Error reading {}", fileName );
+      return 1;
+    }
+    exe.setProgram( program.get() );
+    // find and set pkg
+    std::string dir = fileName;
+    Clib::strip_one( dir );
+    dir = Clib::normalized_dir_form( dir );
+    Plib::load_packages( true /*quiet*/ );
 
-  const auto& pkgs = Plib::systemstate.packages;
-  auto pkg = std::find_if( pkgs.begin(), pkgs.end(), [&dir]( Plib::Package* p )
-                           { return Clib::stringicmp( p->dir(), dir ) == 0; } );
-  if ( pkg != pkgs.end() )
-  {
-    program->pkg = *pkg;
-  }
-  Module::load_fileaccess_cfg();  // after pkg load
+    const auto& pkgs = Plib::systemstate.packages;
+    auto pkg = std::find_if( pkgs.begin(), pkgs.end(), [&dir]( Plib::Package* p )
+                             { return Clib::stringicmp( p->dir(), dir ) == 0; } );
+    if ( pkg != pkgs.end() )
+    {
+      program->pkg = *pkg;
+    }
+    Module::load_fileaccess_cfg();  // after pkg load
 
-  exe.setDebugLevel( m_debug ? Executor::INSTRUCTIONS : Executor::NONE );
-  clock_t start = clock();
+    exe.setDebugLevel( m_debug ? Executor::INSTRUCTIONS : Executor::NONE );
+    clock_t start = clock();
 #ifdef _WIN32
-  GetThreadTimes( GetCurrentThread(), &dummy, &dummy, &kernelStart, &userStart );
+    GetThreadTimes( GetCurrentThread(), &dummy, &dummy, &kernelStart, &userStart );
 #endif
 
-  exres = exe.exec();
+    exres = exe.exec();
 
 #ifdef _WIN32
-  GetThreadTimes( GetCurrentThread(), &dummy, &dummy, &kernelEnd, &userEnd );
+    GetThreadTimes( GetCurrentThread(), &dummy, &dummy, &kernelEnd, &userEnd );
 #endif
-  clocks = clock() - start;
-  seconds = static_cast<double>( clocks ) / CLOCKS_PER_SEC;
+    clocks = clock() - start;
+    seconds = static_cast<double>( clocks ) / CLOCKS_PER_SEC;
 
-  memory_used = exe.sizeEstimate();
+    memory_used = exe.sizeEstimate();
+  }
+  UninitObject::ReleaseSharedInstance();
+  BSpecialUserFuncJump::ReleaseSharedInstance();
 
   if ( m_profile )
   {

--- a/testsuite/pol/testpkgs/funcref/call-and-send.src
+++ b/testsuite/pol/testpkgs/funcref/call-and-send.src
@@ -4,9 +4,14 @@ use os;
 
 program CallAndSend( funcref )
   var ev := wait_for_event( 2 );
+  var call_with_globals;
   if ( !ev )
     return ev;
-  elseif ( ev.type != "call" )
+  elseif ( ev.type == "call_with_globals" )
+    call_with_globals := True;
+  elseif ( ev.type == "call_with_locals" )
+    call_with_globals := False;
+  else
     return ret_error( $"Unexpected event {ev}" );
   endif
 
@@ -15,7 +20,8 @@ program CallAndSend( funcref )
   var mapper := ev.mapper;
 
   // Using a continuation (MTH_FILTER) on a user function inside a different program
-  var res := funcref( args.map( mapper ) ... );
+  var res := funcref( call_with_globals, args.map( mapper )... );
 
   GetProcess( pid ).SendEvent( struct{ type := "return", result := res } );
 endprogram
+

--- a/testsuite/pol/testpkgs/funcref/destroyed.src
+++ b/testsuite/pol/testpkgs/funcref/destroyed.src
@@ -10,7 +10,14 @@ program destroyed( test_pid )
   return 1;
 endprogram
 
-function DestroyedUserFunc( args ... )
-  dest_glob1 := $"{dest_glob0} {dest_glob1} {dest_glob2} DestroyedUserFunc({args})";
-  return dest_glob1;
+function DestroyedUserFunc( use_globals, args... )
+  var dest_loc1 := True;
+  var dest_loc2 := "hello local";
+  if ( use_globals )
+    dest_glob1 := $"{dest_glob0} {dest_glob1} {dest_glob2} DestroyedUserFunc({args})";
+    return dest_glob1;
+  else
+    return $"{dest_loc1} {dest_loc2} DestroyedUserFunc({args})";
+  endif
 endfunction
+

--- a/testsuite/pol/testpkgs/funcref/test_call.src
+++ b/testsuite/pol/testpkgs/funcref/test_call.src
@@ -78,7 +78,7 @@ exported function test_call_destroyed_executor()
     return ret_error( $"Spawned process not destroyed in time" );
   dowhile ( 0 );
 
-  spawned.SendEvent( struct{ type := "call",
+  spawned.SendEvent( struct{ type := "call_with_locals",
                              pid := GetPid(), args := { 1, 2, 3 },
                              mapper := @( what ) {
     return what * 100;
@@ -94,12 +94,62 @@ exported function test_call_destroyed_executor()
 
   var result := ev.result;
 
-  // the three globals in `destroyed` + the arguments array passed above,
+  // the two locals in `destroyed` + the arguments array passed above,
   // passed through the mapper function.
-  var expected := "dg0 dg1 dg2 DestroyedUserFunc({ 100, 200, 300 })";
+  var expected := "true hello local DestroyedUserFunc({ 100, 200, 300 })";
 
   return ret_error_not_equal( result, expected,
                               $"Unexpected return from call, expected '{expected}', actual '{result}'" );
+endfunction
+
+// calls the function in the destroyed script which access globals
+// this has to stop the calling script since its an illegal access.
+exported function test_call_destroyed_globals()
+  var res := start_script( ":testfuncref:destroyed", GetPid() );
+
+  if ( !res )
+    return res;
+  endif
+
+  var destroyed_pid := res.pid;
+
+  var ev := wait_for_event( 1 );
+
+  if ( !ev )
+    return ev;
+  elseif ( ev.type != "spawned" )
+    return ret_error( $"Unexpected event {ev}" );
+  elseif ( !ev.result )
+    return ev.result;
+  endif
+
+  var spawned := ev.result;
+
+  outer: do
+    for i := 1 to 5
+      if ( !GetProcess( destroyed_pid ) )
+        break outer;
+      endif
+      Sleepms( 1 );
+    endfor
+    return ret_error( $"Spawned process not destroyed in time" );
+  dowhile ( 0 );
+
+  spawned.SendEvent( struct{ type := "call_with_globals",
+                             pid := GetPid(), args := { 1, 2, 3 },
+                             mapper := @( what ) {
+    return what * 100;
+  } } );
+
+  ev := wait_for_event( 1 );
+
+  if ( !ev )
+    if ( spawned.state.errortext != "Script has been destroyed" )
+      return ret_error( $"Spawned script wasnt destroyed {spawned.state}" );
+    endif
+    return 1;
+  endif
+  return ret_error( $"Unexpected event {ev}" );
 endfunction
 
 function user_func()
@@ -119,3 +169,4 @@ function embedded_globals()
     }();
   }();
 endfunction
+


### PR DESCRIPTION
To fix this we have to disallow calling a funcref of a destroyed script when it accesses globals.