### PR TITLE
Added Ter Mur and removed width and height settings 

### DIFF
--- a/pol-core/doc/uoconvert.txt
+++ b/pol-core/doc/uoconvert.txt
@@ -18,24 +18,26 @@ copy tiles.cfg config
 uoconvert landtiles
 copy landtiles.cfg config
 
-rem Mondain's Legacy use "width=7168" here
-uoconvert map     realm=britannia mapid=0 usedif=1 width=6144 height=4096
+uoconvert map     realm=britannia mapid=0 usedif=1
 uoconvert statics realm=britannia
 uoconvert maptile realm=britannia
 
-rem Mondain's Legacy use "width=7168" here
-uoconvert map     realm=britannia_alt mapid=1 usedif=1 width=6144 height=4096
+uoconvert map     realm=britannia_alt mapid=1 usedif=1
 uoconvert statics realm=britannia_alt
 uoconvert maptile realm=britannia_alt
 
-uoconvert map     realm=ilshenar mapid=2 usedif=1 width=2304 height=1600
+uoconvert map     realm=ilshenar mapid=2 usedif=1
 uoconvert statics realm=ilshenar
 uoconvert maptile realm=ilshenar
 
-uoconvert map     realm=malas mapid=3 usedif=1 width=2560 height=2048
+uoconvert map     realm=malas mapid=3 usedif=1
 uoconvert statics realm=malas
 uoconvert maptile realm=malas
 
-uoconvert map     realm=tokuno mapid=4 usedif=1 width=1448 height=1448
+uoconvert map     realm=tokuno mapid=4 usedif=1
 uoconvert statics realm=tokuno
 uoconvert maptile realm=tokuno
+
+uoconvert map     realm=termur mapid=5 usedif=1
+uoconvert statics realm=termur
+uoconvert maptile realm=termur


### PR DESCRIPTION
Summary: This PR adds support for the Termur realm to the uoconvert configuration documentation. 

It includes:
New Termur realm commands - Adds uoconvert map, uoconvert statics, and uoconvert maptile commands for the Termur realm (mapid=5)

Simplified map conversion commands - Removes explicit width and height parameters from the existing realm configurations (Britannia, Britannia Alt, Ilshenar, Malas, and Tokuno), allowing the converter to use default dimensions

Cleanup of obsolete comments - Removes the "Mondain's Legacy" comments that referenced specific width parameters

Files Changed:

pol-core/doc/uoconvert.txt - Single file modified
Changes:

Removed hardcoded width/height dimensions from 5 existing realm entries
Added 3 new lines for Termur realm support (map, statics, maptile conversions)
Removed outdated documentation comments