### PR TITLE
Fix CMake bugs: escript tests under multi-config generators, and cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,14 +57,13 @@ if(${ENABLE_TIDY})
   set(NO_PCH ON)
 endif()
 
-set(OUTPUT_BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin" CACHE STRING "binary output dir, defaults to sourcedir/bin")
-set(EXT_DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib" CACHE STRING "external library download dir, defaults to sourcedir/lib")
+set(OUTPUT_BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin" CACHE PATH "binary output dir, defaults to sourcedir/bin")
+set(EXT_DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib" CACHE PATH "external library download dir, defaults to sourcedir/lib")
 option(USE_BOOST_HEADER_STACKTRACE "Use boost::stacktrace as header-only" OFF)
 
 include(CheckIncludeFiles)
 include(ExternalProject)
 include(CheckCXXSourceCompiles)
-include(TestBigEndian)
 
 include(cmake/init.cmake)
 
@@ -90,7 +89,7 @@ if (ENABLE_TIDY)
     DOC "Path to clang-tidy executable"
   )
   if(NOT CLANG_TIDY_EXE)
-    message(ERROR "clang-tidy not found.")
+    message(FATAL_ERROR "clang-tidy not found.")
   else()
     message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
     message(STATUS "clang-tidy args: ${TIDY_ARGS}")
@@ -172,8 +171,8 @@ foreach(child ${children})
       COMMAND ${CMAKE_COMMAND}
         -Dtestdir=${testdir}
         -Dsubtest=${child}
-        -Decompile=${output_bin_dir}/ecompile
-        -Drunecl=${output_bin_dir}/runecl
+        -Decompile=$<TARGET_FILE:ecompile>
+        -Drunecl=$<TARGET_FILE:runecl>
         -Dgit=${GIT_EXECUTABLE}
         -Derrfilesuffix=1
         -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/escripttest.cmake

--- a/cmake/Boost.cmake
+++ b/cmake/Boost.cmake
@@ -20,9 +20,10 @@ elseif (msvc)
   endif()
 endif()
 
-#if (NOT DEFINED BOOST_TOOLSET)
-#  message(FATAL_ERROR "Unknown boost toolset to build")
-#endif()
+# without a toolset bootstrap fails much later with a cryptic error
+if (NOT DEFINED BOOST_TOOLSET)
+  message(FATAL_ERROR "Unknown boost toolset to build (compiler ${CMAKE_CXX_COMPILER_ID}, MSVC toolset '${MSVC_TOOLSET_VERSION}')")
+endif()
 set (BOOST_ARC "")
 if (${windows})
   set (BOOST_CONFIGURE_COMMAND "bootstrap.bat")

--- a/cmake/Curl.cmake
+++ b/cmake/Curl.cmake
@@ -104,4 +104,6 @@ else()
   set_property(TARGET libcurl 
     PROPERTY INTERFACE_LINK_LIBRARIES wldap32)
 endif()
-add_dependencies(libcurl libcurl_ext)
+if(TARGET libcurl_ext)
+  add_dependencies(libcurl libcurl_ext)
+endif()

--- a/cmake/Fmt.cmake
+++ b/cmake/Fmt.cmake
@@ -61,4 +61,6 @@ set_target_properties(libfmt PROPERTIES
 )
 file(MAKE_DIRECTORY ${FMT_INSTALL_DIR}/include) #directory has to exist during configure
 
-add_dependencies(libfmt libfmt_ext)
+if(TARGET libfmt_ext)
+  add_dependencies(libfmt libfmt_ext)
+endif()

--- a/cmake/Kaitai.cmake
+++ b/cmake/Kaitai.cmake
@@ -63,4 +63,6 @@ set_target_properties(libkaitai PROPERTIES
 )
 file(MAKE_DIRECTORY ${KAITAI_INSTALL_DIR}/include) #directory has to exist during configure
 
-add_dependencies(libkaitai libkaitai_ext)
+if(TARGET libkaitai_ext)
+  add_dependencies(libkaitai libkaitai_ext)
+endif()

--- a/cmake/PicoJson.cmake
+++ b/cmake/PicoJson.cmake
@@ -30,4 +30,6 @@ endif()
 set_target_properties(libpicojson PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${PICO_SOURCE_DIR}"
 )
-add_dependencies(libpicojson libpicojson_ext)
+if(TARGET libpicojson_ext)
+  add_dependencies(libpicojson libpicojson_ext)
+endif()

--- a/cmake/SQL.cmake
+++ b/cmake/SQL.cmake
@@ -84,4 +84,6 @@ if(${windows})
   set_property(TARGET libsql
     PROPERTY INTERFACE_LINK_LIBRARIES secur32 crypt32 bcrypt)
 endif()
-add_dependencies(libsql libmaria_ext)
+if(TARGET libmaria_ext)
+  add_dependencies(libsql libmaria_ext)
+endif()

--- a/cmake/UTF8.cmake
+++ b/cmake/UTF8.cmake
@@ -34,4 +34,6 @@ add_library(libutf8 INTERFACE IMPORTED)
 set_target_properties(libutf8 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${UTF_INSTALL_DIR}/include"
 )
-add_dependencies(libutf8 libutf8_ext)
+if(TARGET libutf8_ext)
+  add_dependencies(libutf8 libutf8_ext)
+endif()

--- a/cmake/ZLib.cmake
+++ b/cmake/ZLib.cmake
@@ -53,7 +53,9 @@ if (${windows})
     INTERFACE_INCLUDE_DIRECTORIES ${ZLIB_INSTALL_DIR}/include
     FOLDER 3rdParty
   )
-  add_dependencies(libz libz_ext)
+  if(TARGET libz_ext)
+    add_dependencies(libz libz_ext)
+  endif()
 
 else()
   add_library(libz INTERFACE IMPORTED)

--- a/cmake/compile_defs.cmake
+++ b/cmake/compile_defs.cmake
@@ -12,18 +12,6 @@ function(set_compile_flags target is_executable)
     _REENTRANT
     ARCH_BITS=${ARCH_BITS}
   )
-  if (${release})
-    target_compile_definitions(${target} PRIVATE
-      RELEASE_VERSION
-    )
-  endif()
-
-  if (${debug})
-    target_compile_definitions(${target} PRIVATE
-      DEBUG_VERSION
-    )
-  endif()
-
   if (${linux})
     target_compile_definitions(${target} PRIVATE
       _GNU_SOURCE
@@ -37,8 +25,8 @@ function(set_compile_flags target is_executable)
   endif()
 
   if (${windows})
+    # _WIN32/_WIN64 are compiler-predefined and deliberately not repeated here
     target_compile_definitions(${target} PRIVATE
-      _WIN32
       WIN32
       NOMINMAX
       WINDOWS
@@ -46,11 +34,6 @@ function(set_compile_flags target is_executable)
       _WIN32_WINNT=0x0601
       _CONSOLE
     )
-    if (${ARCH_BITS} EQUAL "64")
-      target_compile_definitions(${target} PRIVATE
-        _WIN64
-      )
-    endif()
   endif()
   
   target_compile_options(${target} PRIVATE
@@ -153,14 +136,6 @@ function(set_compile_flags target is_executable)
     endif()
   endif()
 
-  if(${linux})
-    link_directories(
-      /usr/local/lib
-      /usr/lib
-      /usr/lib${ARCH_BITS}
-    )
-  endif()
-
   set_target_properties(${target} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${output_bin_dir}
     LIBRARY_OUTPUT_DIRECTORY ${output_bin_dir}
@@ -179,7 +154,7 @@ function(source_group_by_folder target)
   foreach(file ${${target}_sources})
     if(IS_ABSOLUTE ${file})
       file(RELATIVE_PATH relative_file "${CMAKE_CURRENT_SOURCE_DIR}" "${file}")
-      get_filename_component(dir "${relative_path}" DIRECTORY)
+      get_filename_component(dir "${relative_file}" DIRECTORY)
     else()
       get_filename_component(dir "${file}" PATH)
     endif()

--- a/cmake/core_tests.cmake
+++ b/cmake/core_tests.cmake
@@ -238,9 +238,8 @@ add_test(NAME shard_test_2
   COMMAND pol
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coretest
 )
-set_tests_properties( shard_test_2 PROPERTIES FIXTURES_REQUIRED "client;shard;uoconvert;ecompile")
+set_tests_properties( shard_test_2 PROPERTIES FIXTURES_REQUIRED "client;shard;uoconvert;ecompile;shard_test")
 set_tests_properties( shard_test_2 PROPERTIES ENVIRONMENT "POLCORE_TEST_RUN=2")
-set_tests_properties( shard_test_2 PROPERTIES FIXTURES_REQUIRED shard_test)
 
 # unit test
 add_test(NAME unittest_pol

--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -20,11 +20,6 @@ macro(detect_compiler)
     set(clang 1)
   elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(msvc 1)
-    if (${MSVC_VERSION} VERSION_GREATER 1900)
-      set(msvc_ide "15")
-    else()
-      set(msvc_ide "14")
-    endif()
   elseif (CMAKE_COMPILER_IS_GNUCXX)
     set(gcc 1)
   endif()
@@ -85,10 +80,9 @@ macro(detect_platform)
     set (windows 1)
   endif()
 
-  test_big_endian(bigendian)
-  if (bigendian)
-    #Error? I don't think that it really works
-    message("Platform is Big Endian")
+  if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    # the packet/file-format code assumes little endian throughout
+    message(WARNING "Platform is Big Endian - unsupported, expect breakage")
   else()
     message("Platform is Little Endian")
   endif()
@@ -262,7 +256,7 @@ macro(git_revision_target)
     -DTMP_FILE=${PROJECT_BINARY_DIR}/pol_revision.h.tmp
     -DOUT_FILE=${PROJECT_BINARY_DIR}/pol_revision.h
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/git_revision.cmake
-    BYPRODUCTS=${PROJECT_BINARY_DIR}/pol_revision.h 
+    BYPRODUCTS ${PROJECT_BINARY_DIR}/pol_revision.h
   )
   set_target_properties(git_rev PROPERTIES FOLDER Misc)
 endmacro()


### PR DESCRIPTION
- escript tests: pass $<TARGET_FILE:ecompile|runecl> instead of ${output_bin_dir}/... - with the Visual Studio generator binaries land in bin/<config>/, so every escript_* test failed locally while Ninja CI passed
- message(ERROR) is not an error mode; clang-tidy-missing is now FATAL_ERROR
- git_rev target: "BYPRODUCTS=path" was a literal command argument, not the BYPRODUCTS keyword; pol_revision.h is now properly declared
- source_group_by_folder: read the computed relative_file variable (relative_path was never set, absolute-path sources got an empty group)
- shard_test_2: the second FIXTURES_REQUIRED overwrote the first; merged into one property value
- remove dead code: unused DEBUG_VERSION/RELEASE_VERSION defines, unused msvc_ide variable, no-op link_directories in set_compile_flags, compiler-predefined _WIN32/_WIN64
- guard add_dependencies(lib* lib*_ext) with if(TARGET ...) consistently (Antlr/Boost/Efsw/Cppdap already did; the target only exists when the prebuilt lib is absent)
- replace deprecated TestBigEndian with CMAKE_CXX_BYTE_ORDER; warn that big-endian is unsupported
- restore Boost unknown-toolset FATAL_ERROR (empty toolset made bootstrap fail much later with a cryptic error)
- OUTPUT_BINARY_DIR/EXT_DOWNLOAD_DIR are CACHE PATH, not STRING