### PR TITLE
Misc modernizations and improvments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             tests: true
             name: Linux Clang
           
-          - os: "macos-latest"
+          - os: "macos-26"
             cxx-compiler: clang++
             c-compiler: clang
             compiler-version: default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             tests: true
             name: Linux Clang
           
-          - os: "macos-15"
+          - os: "macos-latest"
             cxx-compiler: clang++
             c-compiler: clang
             compiler-version: default

--- a/pol-core/bscript/bdouble.cpp
+++ b/pol-core/bscript/bdouble.cpp
@@ -23,7 +23,7 @@
 
 namespace Pol::Bscript
 {
-Clib::fixed_allocator<sizeof( Double ), 256> double_alloc;
+Clib::fixed_allocator<Double, 256> double_alloc;
 
 std::string Double::double_to_string( double val )
 {

--- a/pol-core/bscript/bdouble.h
+++ b/pol-core/bscript/bdouble.h
@@ -87,7 +87,7 @@ private:
   double dval_;
 };
 
-extern Clib::fixed_allocator<sizeof( Double ), 256> double_alloc;
+extern Clib::fixed_allocator<Double, 256> double_alloc;
 inline void* Double::operator new( std::size_t len )
 {
   (void)len;

--- a/pol-core/bscript/blong.cpp
+++ b/pol-core/bscript/blong.cpp
@@ -19,7 +19,7 @@
 
 namespace Pol::Bscript
 {
-Clib::fixed_allocator<sizeof( BLong ), 256> blong_alloc;
+Clib::fixed_allocator<BLong, 256> blong_alloc;
 
 using namespace fmt::literals;
 

--- a/pol-core/bscript/blong.h
+++ b/pol-core/bscript/blong.h
@@ -119,7 +119,7 @@ protected:
   int lval_;
 };
 
-extern Clib::fixed_allocator<sizeof( BLong ), 256> blong_alloc;
+extern Clib::fixed_allocator<BLong, 256> blong_alloc;
 inline void* BLong::operator new( std::size_t len )
 {
   (void)len;

--- a/pol-core/bscript/bobject.cpp
+++ b/pol-core/bscript/bobject.cpp
@@ -14,7 +14,7 @@
 namespace Pol::Bscript
 {
 
-Clib::fixed_allocator<sizeof( BObject ), 256> bobject_alloc;
+Clib::fixed_allocator<BObject, 256> bobject_alloc;
 
 size_t BObjectRef::sizeEstimate() const
 {

--- a/pol-core/bscript/bobject.h
+++ b/pol-core/bscript/bobject.h
@@ -86,7 +86,7 @@ public:
 
 using BObjectImpRefVec = std::vector<ref_ptr<BObjectImp>>;
 
-extern Clib::fixed_allocator<sizeof( BObject ), 256> bobject_alloc;
+extern Clib::fixed_allocator<BObject, 256> bobject_alloc;
 
 inline void* BObject::operator new( std::size_t /*len*/ )
 {

--- a/pol-core/bscript/buninit.cpp
+++ b/pol-core/bscript/buninit.cpp
@@ -5,7 +5,7 @@
 namespace Pol::Bscript
 {
 
-Clib::fixed_allocator<sizeof( UninitObject ), 256> uninit_alloc;
+Clib::fixed_allocator<UninitObject, 256> uninit_alloc;
 
 UninitObject* UninitObject::SharedInstance;
 ref_ptr<BObjectImp> UninitObject::SharedInstanceOwner;

--- a/pol-core/bscript/buninit.h
+++ b/pol-core/bscript/buninit.h
@@ -37,7 +37,7 @@ public:
     SharedInstance = nullptr;
   }
 };
-extern Clib::fixed_allocator<sizeof( UninitObject ), 256> uninit_alloc;
+extern Clib::fixed_allocator<UninitObject, 256> uninit_alloc;
 
 inline void* UninitObject::operator new( std::size_t /*len*/ )
 {

--- a/pol-core/clib/Debugging/ExceptionParser.cpp
+++ b/pol-core/clib/Debugging/ExceptionParser.cpp
@@ -473,7 +473,7 @@ static void handleStackTraceRequestLinux( int signal, siginfo_t* signalInfo, voi
   (void)signalInfo;
   (void)arg;
   threadhelp::ThreadMap::Contents threadDesc;
-  threadhelp::threadmap.CopyContents( threadDesc );
+  threadhelp::threadmap_instance().CopyContents( threadDesc );
 
   std::string output = fmt::format( "STACK TRACE for thread \"{}\"({}):\n",
                                     threadDesc[pthread_self()], pthread_self() );
@@ -493,7 +493,7 @@ static void handleStackTraceRequestLinux( int signal, siginfo_t* signalInfo, voi
 void ExceptionParser::logAllStackTraces()
 {
   threadhelp::ThreadMap::Contents threadsDesc;
-  threadhelp::threadmap.CopyContents( threadsDesc );
+  threadhelp::threadmap_instance().CopyContents( threadsDesc );
   for ( const auto& threadDesc : threadsDesc )
   {
     pthread_t threadID = (pthread_t)threadDesc.first;

--- a/pol-core/clib/fixalloc.h
+++ b/pol-core/clib/fixalloc.h
@@ -12,15 +12,13 @@
  * Remove the include in all StdAfx.h files or live with the consequences :)
  */
 
-
-#ifndef __CLIB_FIXALLOC_H
-#define __CLIB_FIXALLOC_H
+#pragma once
 
 #include "pol_global_config.h"
 
-#include <assert.h>
-#include <stddef.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
 
 #ifdef MEMORYLEAK
 #include "logfacility.h"
@@ -28,77 +26,84 @@
 
 namespace Pol::Clib
 {
-template <size_t N, size_t B>
+template <typename T, size_t B>
 class fixed_allocator
 {
-public:
-  union Buffer
+  static_assert( B > 1, "batch size must be greater than 1" );
+
+  static constexpr size_t N = sizeof( T );
+  static constexpr size_t Align = alignof( T );
+
+  static_assert( Align >= alignof( void* ), "minimum alignment not reached, illegal type" );
+
+  union alignas( Align ) Buffer
   {
     Buffer* next;
     char data[N];
   };
-  void* allocate();
-  void deallocate( void* );
 
-  void* allocate( size_t size );
-  void deallocate( void* size, size_t n );
+  static constexpr size_t ChunkBytes = sizeof( Buffer[B] );
+
+public:
+  fixed_allocator() = default;
+  fixed_allocator( const fixed_allocator& ) = delete;
+  fixed_allocator& operator=( const fixed_allocator& ) = delete;
+  fixed_allocator( fixed_allocator&& ) = delete;
+  fixed_allocator& operator=( fixed_allocator&& ) = delete;
+
+  [[nodiscard]] void* allocate();
+  void deallocate( void* vp ) noexcept;
+
+  [[nodiscard]] void* allocate( size_t size );
+  void deallocate( void* vp, size_t size ) noexcept;
 
 #ifdef MEMORYLEAK
-  fixed_allocator();
   ~fixed_allocator();
   void log_stuff( const std::string& detail );
+#else
+  ~fixed_allocator() = default;
 #endif
 
   size_t memsize = 0;
 
-protected:
+private:
   void* refill();
 
-private:
   Buffer* freelist_ = nullptr;
 #ifdef MEMORYLEAK
-  int buffers;
-  int requests;
-  int max_requests;
+  int buffers_ = 0;
+  int requests_ = 0;
+  int max_requests_ = 0;
 #endif
 };
 
 #ifdef MEMORYLEAK
-template <size_t N, size_t B>
-fixed_allocator<N, B>::fixed_allocator()
-{
-  freelist_ = nullptr;
-  buffers = 0;
-  requests = 0;
-  max_requests = 0;
-};
-
-template <size_t N, size_t B>
-fixed_allocator<N, B>::~fixed_allocator()
+template <typename T, size_t B>
+fixed_allocator<T, B>::~fixed_allocator()
 {
   log_stuff( "destructor" );
 }
 
-template <size_t N, size_t B>
-void fixed_allocator<N, B>::log_stuff( const std::string& detail )
+template <typename T, size_t B>
+void fixed_allocator<T, B>::log_stuff( const std::string& detail )
 {
   DEBUGLOGLN( "fixed_allocator[{}]: {} Buffer with {} Bytes allocated [{} Requests of {}]", detail,
-              buffers, sizeof( Buffer[B] ), requests, max_requests );
+              buffers_, ChunkBytes, requests_, max_requests_ );
 
-  LEAKLOG( "{};{};{};{};", buffers, sizeof( Buffer[B] ), requests, max_requests );
+  LEAKLOG( "{};{};{};{};", buffers_, ChunkBytes, requests_, max_requests_ );
 }
 #endif
 
-template <size_t N, size_t B>
-void* fixed_allocator<N, B>::allocate()
+template <typename T, size_t B>
+void* fixed_allocator<T, B>::allocate()
 {
 #ifdef LEAK_DEBUG
   return ::operator new( N );
-#endif
+#else
 #ifdef MEMORYLEAK
-  requests++;
-  if ( max_requests < requests )
-    max_requests = requests;
+  ++requests_;
+  if ( max_requests_ < requests_ )
+    max_requests_ = requests_;
 #endif
 
   Buffer* p = freelist_;
@@ -109,71 +114,67 @@ void* fixed_allocator<N, B>::allocate()
   }
 
   return refill();
+#endif
 }
 
-template <size_t N, size_t B>
-void* fixed_allocator<N, B>::refill()
+template <typename T, size_t B>
+void* fixed_allocator<T, B>::refill()
 {
-  size_t nbytes = sizeof( Buffer[B] );
-
-  Buffer* morebuf = static_cast<Buffer*>( ::operator new( nbytes ) );
+  Buffer* morebuf = static_cast<Buffer*>( ::operator new( ChunkBytes ) );
 
 #ifdef MEMORYLEAK
-  buffers++;
+  ++buffers_;
 #endif
-  memsize += nbytes;
-  Buffer* walk = morebuf + 1;
-  int count = B - 2;
-  while ( count-- )
-  {
-    Buffer* next = walk + 1;
-    walk->next = next;
-    walk++;
-  }
-  walk->next = nullptr;
-  freelist_ = morebuf + 1;
+  memsize += ChunkBytes;
+
+  for ( size_t i = 1; i + 1 < B; ++i )
+    morebuf[i].next = &morebuf[i + 1];
+  morebuf[B - 1].next = nullptr;
+
+  freelist_ = &morebuf[1];
   return morebuf;
 }
 
-template <size_t N, size_t B>
-void fixed_allocator<N, B>::deallocate( void* vp )
+template <typename T, size_t B>
+void fixed_allocator<T, B>::deallocate( void* vp ) noexcept
 {
 #ifdef LEAK_DEBUG
   return ::operator delete( vp );
-#endif
+#else
 #ifdef MEMORYLEAK
-  requests--;
+  --requests_;
 #endif
 
   Buffer* buf = static_cast<Buffer*>( vp );
   buf->next = freelist_;
   freelist_ = buf;
+#endif
 }
 
-template <size_t N, size_t B>
-void* fixed_allocator<N, B>::allocate( size_t size )
+template <typename T, size_t B>
+void* fixed_allocator<T, B>::allocate( size_t size )
 {
 #ifdef LEAK_DEBUG
   return ::operator new( size );
-#endif
-  assert( size == B );
-  if ( size == B )
+#else
+  assert( size == N );
+  if ( size == N )
     return allocate();
   return ::operator new( size );
+#endif
 }
 
-template <size_t N, size_t B>
-void fixed_allocator<N, B>::deallocate( void* vp, size_t size )
+template <typename T, size_t B>
+void fixed_allocator<T, B>::deallocate( void* vp, size_t size ) noexcept
 {
 #ifdef LEAK_DEBUG
   return ::operator delete( vp );
-#endif
-  assert( size == B );
-  if ( size == B )
+#else
+  assert( size == N );
+  if ( size == N )
     deallocate( vp );
   else
     ::operator delete( vp );
+#endif
 }
 }  // namespace Pol::Clib
-
-#endif

--- a/pol-core/clib/logfacility.cpp
+++ b/pol-core/clib/logfacility.cpp
@@ -12,6 +12,7 @@ POLLOG("hello {}\n", "world");
 
 #include "logfacility.h"
 
+#include <boost/compat/move_only_function.hpp>
 #include <chrono>
 #include <fmt/chrono.h>
 #include <fstream>
@@ -76,7 +77,7 @@ void initLogging( LogFacility* logger )
 // internal worker class which performs the work in a additional thread
 class LogFacility::LogWorker
 {
-  using msg = std::function<void()>;
+  using msg = boost::compat::move_only_function<void()>;
   using msg_queue = message_queue<msg>;
 
 public:
@@ -99,7 +100,7 @@ public:
     _work_thread.join();  // wait for it
   }
   // send msg into queue
-  void send( const msg& msg_ ) { _queue.push( msg_ ); }
+  void send( msg&& msg_ ) { _queue.push_move( std::move( msg_ ) ); }
 
 private:
   // endless loop in thread
@@ -191,18 +192,18 @@ void LogFacility::closeFlexLog( const std::string& id )
 // blocks to return unique identifier
 std::string LogFacility::registerFlexLogger( const std::string& logfilename, bool open_timestamp )
 {
-  auto promise = std::make_shared<std::promise<std::string>>();
-  auto ret = promise->get_future();
+  auto promise = std::promise<std::string>();
+  auto ret = promise.get_future();
   _worker->send(
-      [=]()
+      [=, promise = std::move( promise )]() mutable
       {
         try
         {
-          promise->set_value( getSink<LogSink_flexlog>()->create( logfilename, open_timestamp ) );
+          promise.set_value( getSink<LogSink_flexlog>()->create( logfilename, open_timestamp ) );
         }
         catch ( ... )
         {
-          promise->set_exception( std::current_exception() );
+          promise.set_exception( std::current_exception() );
         }
       } );
   return ret.get();  // block wait till valid
@@ -211,9 +212,9 @@ std::string LogFacility::registerFlexLogger( const std::string& logfilename, boo
 // block waits till the queue is empty
 void LogFacility::wait_for_empty_queue()
 {
-  auto promise = std::make_shared<std::promise<bool>>();
-  auto ret = promise->get_future();
-  _worker->send( [=]() { promise->set_value( true ); } );
+  auto promise = std::promise<bool>();
+  auto ret = promise.get_future();
+  _worker->send( [promise = std::move( promise )]() mutable { promise.set_value( true ); } );
   ret.get();  // block wait till valid
 }
 

--- a/pol-core/clib/message_queue.h
+++ b/pol-core/clib/message_queue.h
@@ -5,6 +5,7 @@ Remove the include in all StdAfx.h files or live with the consequences :)
 */
 #pragma once
 
+#include <chrono>
 #include <condition_variable>
 #include <list>
 #include <mutex>
@@ -42,7 +43,10 @@ public:
   void pop_wait( std::list<Message>* msgs );
   // empties the queue (unsafe)
   void pop_remaining( std::list<Message>* msgs );
-
+  // waits till queue is non empty or timeout is reached
+  template <typename Rep, typename Period>
+  [[nodiscard]] bool pop_wait_for( Message* msg,
+                                   const std::chrono::duration<Rep, Period>& timeout );
   void cancel();
   struct Canceled
   {
@@ -145,6 +149,21 @@ void message_queue<Message>::pop_wait( std::list<Message>* msgs )
   if ( _cancel )
     throw Canceled();
   msgs->splice( msgs->end(), _queue );
+}
+
+template <typename Message>
+template <typename Rep, typename Period>
+bool message_queue<Message>::pop_wait_for( Message* msg,
+                                           const std::chrono::duration<Rep, Period>& timeout )
+{
+  std::unique_lock<std::mutex> lock( _mutex );
+  if ( !_notifier.wait_for( lock, timeout, [this] { return !_queue.empty() || _cancel; } ) )
+    return false;
+  if ( _cancel )
+    throw Canceled();
+  *msg = std::move( _queue.front() );
+  _queue.pop_front();
+  return true;
 }
 
 template <typename Message>

--- a/pol-core/clib/message_queue.h
+++ b/pol-core/clib/message_queue.h
@@ -3,10 +3,8 @@ ATTENTION:
 This header is part of the PCH
 Remove the include in all StdAfx.h files or live with the consequences :)
 */
+#pragma once
 
-#ifndef MESSAGE_QUEUE_H
-#define MESSAGE_QUEUE_H
-#include <chrono>
 #include <condition_variable>
 #include <list>
 #include <mutex>
@@ -132,8 +130,7 @@ template <typename Message>
 void message_queue<Message>::pop_wait( Message* msg )
 {
   std::unique_lock<std::mutex> lock( _mutex );
-  while ( _queue.empty() && !_cancel )
-    _notifier.wait( lock );  // will unlock mutex during wait
+  _notifier.wait( lock, [this] { return !_queue.empty() || _cancel; } );
   if ( _cancel )
     throw Canceled();
   *msg = std::move( _queue.front() );
@@ -144,8 +141,7 @@ template <typename Message>
 void message_queue<Message>::pop_wait( std::list<Message>* msgs )
 {
   std::unique_lock<std::mutex> lock( _mutex );
-  while ( _queue.empty() && !_cancel )
-    _notifier.wait( lock );  // will unlock mutex during wait
+  _notifier.wait( lock, [this] { return !_queue.empty() || _cancel; } );
   if ( _cancel )
     throw Canceled();
   msgs->splice( msgs->end(), _queue );
@@ -167,6 +163,3 @@ void message_queue<Message>::cancel()
   _notifier.notify_all();
 }
 }  // namespace Pol::Clib
-
-
-#endif

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -357,18 +357,20 @@ void TaskThreadPool::init( unsigned int max_count, const std::string& name )
           {
             while ( !_done )
             {
-              _msg_queue.pop_wait( &f );
-              f();
+              try
+              {
+                _msg_queue.pop_wait( &f );
+                f();
+              }
+              catch ( std::exception& ex )
+              {
+                ERROR_PRINTLN( "Thread exception: {}", ex.what() );
+                Clib::force_backtrace( true );
+              }
             }
           }
           catch ( msg_queue::Canceled& )
           {
-          }
-          catch ( std::exception& ex )
-          {
-            ERROR_PRINTLN( "Thread exception: {}", ex.what() );
-            Clib::force_backtrace( true );
-            return;
           }
           // purge the queue empty
           std::list<msg> remaining;

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -291,7 +291,6 @@ HANDLE ThreadMap::getThreadHandle( size_t pid ) const
 #endif
 void ThreadMap::Register( size_t pid, const std::string& name )
 {
-  printf( "register %zu %s\n", pid, name.c_str() );
   Clib::SpinLockGuard guard( _spinlock );
   _contents.insert( std::make_pair( pid, name ) );
 #ifdef _WIN32
@@ -495,9 +494,7 @@ void DynTaskThreadPool::PoolWorker::run()
   _thread = std::jthread(
       [&]()
       {
-        printf( "pool %s\n", _name.c_str() );
         ThreadRegister register_thread( _name );
-        printf( "poolreg %s\n", _name.c_str() );
         ERROR_PRINTLN( "created pool worker {}", _name );
         auto f = msg();
         try

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -13,6 +13,9 @@
 
 #include "threadhelp.h"
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstring>
 #include <exception>
 #include <thread>
@@ -36,6 +39,7 @@
 
 namespace Pol::threadhelp
 {
+using namespace std::chrono_literals;
 ThreadMap threadmap;
 std::atomic<unsigned int> child_threads( 0 );
 static int threads = 0;
@@ -447,63 +451,80 @@ public:
   PoolWorker( DynTaskThreadPool* parent, const std::string& name );
   PoolWorker( const PoolWorker& ) = delete;
   PoolWorker& operator=( const PoolWorker& ) = delete;
-  bool isbusy() const;
-  void join();
   void run();
+  bool isretired() const;
+
+  constexpr static size_t MIN_WORKER = 4;
+  constexpr static auto TIMEOUT = 1min;
 
 private:
   std::string _name;
-  std::atomic<bool> _busy;
-  std::thread _thread;
+  std::jthread _thread;
   DynTaskThreadPool* _parent;
+  std::atomic<bool> _retired;
   struct BusyGuard
   {
-    std::atomic<bool>* _busy;
-    BusyGuard( std::atomic<bool>* busy ) : _busy( busy ) { ( *_busy ) = true; }
-    ~BusyGuard() { ( *_busy ) = false; }
+    std::atomic<size_t>* _busy;
+    BusyGuard( std::atomic<size_t>* busy ) : _busy( busy )
+    {
+      _busy->fetch_add( 1, std::memory_order_relaxed );
+    }
+    ~BusyGuard() { _busy->fetch_sub( 1, std::memory_order_relaxed ); }
   };
 };
 DynTaskThreadPool::PoolWorker::PoolWorker( DynTaskThreadPool* parent, const std::string& name )
-    : _name( name ), _busy( false ), _thread(), _parent( parent )
+    : _name( name ), _thread(), _parent( parent ), _retired( false )
 {
   run();
 }
-bool DynTaskThreadPool::PoolWorker::isbusy() const
-{
-  return _busy;
-}
 
-void DynTaskThreadPool::PoolWorker::join()
+bool DynTaskThreadPool::PoolWorker::isretired() const
 {
-  _thread.join();
+  return _retired.load( std::memory_order_relaxed );
 }
 
 void DynTaskThreadPool::PoolWorker::run()
 {
-  _thread = std::thread(
+  _thread = std::jthread(
       [&]()
       {
         ThreadRegister register_thread( _name );
+        ERROR_PRINTLN( "created pool worker {}", _name );
         auto f = msg();
         try
         {
           while ( !_parent->_done && !Clib::exit_signalled )
           {
-            _parent->_msg_queue.pop_wait( &f );
+            if ( !_parent->_msg_queue.pop_wait_for( &f, TIMEOUT ) )
             {
-              BusyGuard busy( &_busy );
-              f();
+              std::lock_guard<std::mutex> guard( _parent->_pool_mutex );
+              // we timed out: can we retire?
+              if ( _parent->_live_threads > MIN_WORKER )
+              {
+                --_parent->_live_threads;
+                _retired.store( true, std::memory_order_relaxed );
+                ERROR_PRINTLN( "removed pool worker {}", _name );
+                return;
+              }
+              continue;  // keep alive
+            }
+
+            {
+              BusyGuard busy( &_parent->_busy_count );
+              try
+              {
+                f();
+              }
+              catch ( std::exception& ex )
+              {
+                ERROR_PRINTLN( "Thread exception: {}", ex.what() );
+                Clib::force_backtrace( true );
+              }
             }
           }
         }
         catch ( msg_queue::Canceled& )
         {
-        }
-        catch ( std::exception& ex )
-        {
-          ERROR_PRINTLN( "Thread exception: {}", ex.what() );
-          Clib::force_backtrace( true );
-          return;
         }
       } );
 }
@@ -511,6 +532,7 @@ void DynTaskThreadPool::PoolWorker::run()
 /// Creates a dynamic threadpool of workers.
 /// if no idle worker is found creates a new worker thread
 /// blocks on deconstruction
+/// idle worker threads get destroyed after timeout until minimum count is reached
 /// eg:
 /// DynTaskThreadPool workers;
 /// for (....)
@@ -518,66 +540,70 @@ void DynTaskThreadPool::PoolWorker::run()
 DynTaskThreadPool::DynTaskThreadPool( const std::string& name )
     : _done( false ), _msg_queue(), _pool_mutex(), _name( "DynTaskPool" + name )
 {
+  std::lock_guard<std::mutex> guard( _pool_mutex );
+  for ( size_t i = 0; i < PoolWorker::MIN_WORKER; ++i )
+  {
+    _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _live_threads ) ) );
+    ++_live_threads;
+  }
 }
 
 size_t DynTaskThreadPool::threadpoolsize() const
 {
   std::lock_guard<std::mutex> guard( _pool_mutex );
-  return _threads.size();
+  return _live_threads;
 }
 
 void DynTaskThreadPool::create_thread()
 {
   std::lock_guard<std::mutex> guard( _pool_mutex );
-  for ( const auto& worker : _threads )
-  {
-    if ( !worker->isbusy() )  // check for a idle instance
-    {
-      return;
-    }
-  }
-  size_t thread_num = _threads.size();
-  _threads.emplace_back( new PoolWorker( this, _name + " " + std::to_string( thread_num ) ) );
-  ERROR_PRINTLN( "create pool worker {} {}", _name, thread_num );
+  // remove timeout threads
+  std::erase_if( _threads, []( const auto& w ) { return w->isretired(); } );
+  // still atleast one idle worker left?
+  size_t idle = _live_threads - _busy_count.load( std::memory_order_relaxed );
+  if ( idle > 0 )
+    return;
+
+  _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _live_threads ) ) );
+  ++_live_threads;
 }
 
 DynTaskThreadPool::~DynTaskThreadPool()
 {
   // send both done and cancel to wake up all workers
-  _msg_queue.push(
+  _msg_queue.push_move(
       [&]()
       {
         _done = true;
         _msg_queue.cancel();
       } );
-  for ( auto& thread : _threads )
-    thread->join();
+  _threads.clear();  // dont rely on order
 }
 
 /// simply fire and forget only the deconstructor ensures the msg to be finished
-void DynTaskThreadPool::push( const msg& msg )
+void DynTaskThreadPool::push( msg&& msg )
 {
   create_thread();
-  _msg_queue.push( msg );
+  _msg_queue.push_move( std::move( msg ) );
 }
 
 /// returns a future which will be set once the msg is processed
-std::future<bool> DynTaskThreadPool::checked_push( const msg& msg )
+std::future<bool> DynTaskThreadPool::checked_push( msg&& msg )
 {
-  auto promise = std::make_shared<std::promise<bool>>();
-  auto ret = promise->get_future();
+  auto promise = std::promise<bool>();
+  auto ret = promise.get_future();
   create_thread();
-  _msg_queue.push(
-      [=]()
+  _msg_queue.push_move(
+      [promise = std::move( promise ), msg = std::move( msg )]() mutable
       {
         try
         {
           msg();
-          promise->set_value( true );
+          promise.set_value( true );
         }
         catch ( ... )
         {
-          promise->set_exception( std::current_exception() );
+          promise.set_exception( std::current_exception() );
         }
       } );
   return ret;

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -461,13 +461,11 @@ public:
   bool isretired() const;
 
   constexpr static size_t MIN_WORKER = 4;
-  constexpr static auto TIMEOUT = 1min;
+  constexpr static size_t JITTER_STEPS = 10;
+  constexpr static auto TIMEOUT = 5min;
+  constexpr static auto TIMEOUT_JITTER = 15s;
 
-private:
-  std::string _name;
-  std::jthread _thread;
-  DynTaskThreadPool* _parent;
-  std::atomic<bool> _retired;
+  // guard which is alive as long as the task is in the pool
   struct BusyGuard
   {
     std::atomic<size_t>* _busy;
@@ -475,11 +473,31 @@ private:
     {
       _busy->fetch_add( 1, std::memory_order_relaxed );
     }
-    ~BusyGuard() { _busy->fetch_sub( 1, std::memory_order_relaxed ); }
+    BusyGuard( BusyGuard&& o ) noexcept : _busy( o._busy ) { o._busy = nullptr; }
+    BusyGuard( const BusyGuard& ) = delete;
+    BusyGuard& operator=( const BusyGuard& ) = delete;
+    BusyGuard& operator=( BusyGuard&& ) = delete;
+    ~BusyGuard()
+    {
+      if ( _busy )
+        _busy->fetch_sub( 1, std::memory_order_relaxed );
+    }
   };
+
+private:
+  std::string _name;
+  std::jthread _thread;
+  DynTaskThreadPool* _parent;
+  std::atomic<bool> _retired;
+  std::chrono::seconds _timeout;
 };
+
 DynTaskThreadPool::PoolWorker::PoolWorker( DynTaskThreadPool* parent, const std::string& name )
-    : _name( name ), _thread(), _parent( parent ), _retired( false )
+    : _name( name ),
+      _thread(),
+      _parent( parent ),
+      _retired( false ),
+      _timeout( ( parent->_worker_count % JITTER_STEPS ) * TIMEOUT_JITTER )
 {
   run();
 }
@@ -501,7 +519,7 @@ void DynTaskThreadPool::PoolWorker::run()
         {
           while ( !_parent->_done && !Clib::exit_signalled )
           {
-            if ( !_parent->_msg_queue.pop_wait_for( &f, TIMEOUT ) )
+            if ( !_parent->_msg_queue.pop_wait_for( &f, _timeout ) )
             {
               std::lock_guard<std::mutex> guard( _parent->_pool_mutex );
               // we timed out: can we retire?
@@ -515,18 +533,16 @@ void DynTaskThreadPool::PoolWorker::run()
               continue;  // keep alive
             }
 
+            try
             {
-              BusyGuard busy( &_parent->_busy_count );
-              try
-              {
-                f();
-              }
-              catch ( std::exception& ex )
-              {
-                ERROR_PRINTLN( "Thread exception: {}", ex.what() );
-                Clib::force_backtrace( true );
-              }
+              f();
             }
+            catch ( std::exception& ex )
+            {
+              ERROR_PRINTLN( "Thread exception: {}", ex.what() );
+              Clib::force_backtrace( false );
+            }
+            f = nullptr;  // reset BusyGuard
           }
         }
         catch ( msg_queue::Canceled& )
@@ -553,7 +569,7 @@ void DynTaskThreadPool::prefill_workers()
   std::lock_guard<std::mutex> guard( _pool_mutex );
   for ( size_t i = 0; i < PoolWorker::MIN_WORKER; ++i )
   {
-    _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _live_threads ) ) );
+    _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _worker_count++ ) ) );
     ++_live_threads;
   }
 }
@@ -567,14 +583,14 @@ size_t DynTaskThreadPool::threadpoolsize() const
 void DynTaskThreadPool::create_thread()
 {
   std::lock_guard<std::mutex> guard( _pool_mutex );
+  // TODO move to some task and run every X seconds
   // remove timeout threads
   std::erase_if( _threads, []( const auto& w ) { return w->isretired(); } );
   // still atleast one idle worker left?
-  size_t idle = _live_threads - _busy_count.load( std::memory_order_relaxed );
-  if ( idle > 0 )
+  if ( _busy_count.load( std::memory_order_relaxed ) <= _live_threads )
     return;
 
-  _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _live_threads ) ) );
+  _threads.emplace_back( new PoolWorker( this, fmt::format( "{} {}", _name, _worker_count++ ) ) );
   ++_live_threads;
 }
 
@@ -587,14 +603,16 @@ DynTaskThreadPool::~DynTaskThreadPool()
         _done = true;
         _msg_queue.cancel();
       } );
+  create_thread();
   _threads.clear();  // dont rely on order
 }
 
 /// simply fire and forget only the deconstructor ensures the msg to be finished
 void DynTaskThreadPool::push( msg&& msg )
 {
-  create_thread();
-  _msg_queue.push_move( std::move( msg ) );
+  _msg_queue.push_move(
+      [msg = std::move( msg ), busy = PoolWorker::BusyGuard( &_busy_count )]() mutable { msg(); } );
+  create_thread();  // needs to be the last so that busy_count is updated
 }
 
 /// returns a future which will be set once the msg is processed
@@ -602,9 +620,9 @@ std::future<bool> DynTaskThreadPool::checked_push( msg&& msg )
 {
   auto promise = std::promise<bool>();
   auto ret = promise.get_future();
-  create_thread();
   _msg_queue.push_move(
-      [promise = std::move( promise ), msg = std::move( msg )]() mutable
+      [promise = std::move( promise ), msg = std::move( msg ),
+       busy = PoolWorker::BusyGuard( &_busy_count )]() mutable
       {
         try
         {
@@ -616,6 +634,7 @@ std::future<bool> DynTaskThreadPool::checked_push( msg&& msg )
           promise.set_exception( std::current_exception() );
         }
       } );
+  create_thread();  // needs to be the last so that busy_count is updated
   return ret;
 }
 }  // namespace Pol::threadhelp

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -391,7 +391,7 @@ void TaskThreadPool::deinit_pool()
   if ( _threads.empty() )
     return;
   // send both done and cancel to wake up all workers
-  _msg_queue.push(
+  _msg_queue.push_move(
       [&]()
       {
         _done = true;
@@ -407,27 +407,27 @@ TaskThreadPool::~TaskThreadPool()
 }
 
 /// simply fire and forget only the deconstructor ensures the msg to be finished
-void TaskThreadPool::push( const msg& msg )
+void TaskThreadPool::push( msg&& msg )
 {
-  _msg_queue.push( msg );
+  _msg_queue.push_move( std::move( msg ) );
 }
 
 /// returns a future which will be set once the msg is processed
-std::future<bool> TaskThreadPool::checked_push( const msg& msg )
+std::future<bool> TaskThreadPool::checked_push( msg&& msg )
 {
-  auto promise = std::make_shared<std::promise<bool>>();
-  auto ret = promise->get_future();
-  _msg_queue.push(
-      [=]()
+  auto promise = std::promise<bool>();
+  auto ret = promise.get_future();
+  _msg_queue.push_move(
+      [promise = std::move( promise ), msg = std::move( msg )]() mutable
       {
         try
         {
           msg();
-          promise->set_value( true );
+          promise.set_value( true );
         }
         catch ( ... )
         {
-          promise->set_exception( std::current_exception() );
+          promise.set_exception( std::current_exception() );
         }
       } );
   return ret;

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -549,6 +549,10 @@ void DynTaskThreadPool::PoolWorker::run()
 DynTaskThreadPool::DynTaskThreadPool( const std::string& name )
     : _done( false ), _msg_queue(), _pool_mutex(), _name( "DynTaskPool" + name )
 {
+}
+
+void DynTaskThreadPool::prefill_workers()
+{
   std::lock_guard<std::mutex> guard( _pool_mutex );
   for ( size_t i = 0; i < PoolWorker::MIN_WORKER; ++i )
   {

--- a/pol-core/clib/threadhelp.cpp
+++ b/pol-core/clib/threadhelp.cpp
@@ -40,7 +40,13 @@
 namespace Pol::threadhelp
 {
 using namespace std::chrono_literals;
-ThreadMap threadmap;
+
+ThreadMap& threadmap_instance()
+{
+  static ThreadMap threadmap;
+  return threadmap;
+}
+
 std::atomic<unsigned int> child_threads( 0 );
 static int threads = 0;
 
@@ -131,7 +137,7 @@ void run_thread( void ( *threadf )() )
 
   --child_threads;
 
-  threadmap.Unregister( thread_pid() );
+  threadmap_instance().Unregister( thread_pid() );
 }
 void run_thread( void ( *threadf )( void* ), void* arg )
 {
@@ -147,7 +153,7 @@ void run_thread( void ( *threadf )( void* ), void* arg )
 
   --child_threads;
 
-  threadmap.Unregister( thread_pid() );
+  threadmap_instance().Unregister( thread_pid() );
 }
 
 class ThreadData
@@ -171,7 +177,7 @@ void* thread_stub2( void* v_td )
   void ( *entry_noparam )() = td->entry_noparam;
   void* arg = td->arg;
 
-  threadmap.Register( thread_pid(), td->name );
+  threadmap_instance().Register( thread_pid(), td->name );
 
   delete td;
   td = nullptr;
@@ -285,6 +291,7 @@ HANDLE ThreadMap::getThreadHandle( size_t pid ) const
 #endif
 void ThreadMap::Register( size_t pid, const std::string& name )
 {
+  printf( "register %zu %s\n", pid, name.c_str() );
   Clib::SpinLockGuard guard( _spinlock );
   _contents.insert( std::make_pair( pid, name ) );
 #ifdef _WIN32
@@ -317,11 +324,11 @@ void ThreadMap::CopyContents( Contents& out ) const
 
 ThreadRegister::ThreadRegister( const std::string& name )
 {
-  threadmap.Register( thread_pid(), name );
+  threadmap_instance().Register( thread_pid(), name );
 }
 ThreadRegister::~ThreadRegister()
 {
-  threadmap.Unregister( thread_pid() );
+  threadmap_instance().Unregister( thread_pid() );
 }
 
 
@@ -488,7 +495,9 @@ void DynTaskThreadPool::PoolWorker::run()
   _thread = std::jthread(
       [&]()
       {
+        printf( "pool %s\n", _name.c_str() );
         ThreadRegister register_thread( _name );
+        printf( "poolreg %s\n", _name.c_str() );
         ERROR_PRINTLN( "created pool worker {}", _name );
         auto f = msg();
         try

--- a/pol-core/clib/threadhelp.h
+++ b/pol-core/clib/threadhelp.h
@@ -102,7 +102,7 @@ class DynTaskThreadPool
   class PoolWorker;
 
   friend class PoolWorker;
-  using msg = std::function<void()>;
+  using msg = boost::compat::move_only_function<void()>;
   using msg_queue = Clib::message_queue<msg>;
 
 public:
@@ -110,12 +110,14 @@ public:
   ~DynTaskThreadPool();
   DynTaskThreadPool( const DynTaskThreadPool& ) = delete;
   DynTaskThreadPool& operator=( const DynTaskThreadPool& ) = delete;
-  void push( const msg& msg );
-  std::future<bool> checked_push( const msg& msg );
+  void push( msg&& msg );
+  std::future<bool> checked_push( msg&& msg );
   size_t threadpoolsize() const;
 
 protected:
   std::atomic<bool> _done;
+  std::atomic<size_t> _busy_count{ 0 };
+  size_t _live_threads{ 0 };
 
 private:
   void create_thread();

--- a/pol-core/clib/threadhelp.h
+++ b/pol-core/clib/threadhelp.h
@@ -126,6 +126,7 @@ private:
   std::vector<std::unique_ptr<PoolWorker>> _threads;
   mutable std::mutex _pool_mutex;
   std::string _name;
+  size_t _worker_count{ 0 };
 };
 
 

--- a/pol-core/clib/threadhelp.h
+++ b/pol-core/clib/threadhelp.h
@@ -16,6 +16,8 @@
 #include <thread>
 #include <vector>
 
+#include <boost/compat/move_only_function.hpp>
+
 #include "Header_Windows.h"
 #include "message_queue.h"
 #include "spinlock.h"
@@ -71,7 +73,7 @@ public:
 
 class TaskThreadPool
 {
-  using msg = std::function<void()>;
+  using msg = boost::compat::move_only_function<void()>;
   using msg_queue = Clib::message_queue<msg>;
 
 public:
@@ -81,8 +83,8 @@ public:
   TaskThreadPool( const TaskThreadPool& ) = delete;
   TaskThreadPool& operator=( const TaskThreadPool& ) = delete;
   ~TaskThreadPool();
-  void push( const msg& msg );
-  std::future<bool> checked_push( const msg& msg );
+  void push( msg&& msg );
+  std::future<bool> checked_push( msg&& msg );
   size_t size() const;
 
   void init_pool( unsigned int max_count, const std::string& name );

--- a/pol-core/clib/threadhelp.h
+++ b/pol-core/clib/threadhelp.h
@@ -110,6 +110,7 @@ public:
   ~DynTaskThreadPool();
   DynTaskThreadPool( const DynTaskThreadPool& ) = delete;
   DynTaskThreadPool& operator=( const DynTaskThreadPool& ) = delete;
+  void prefill_workers();
   void push( msg&& msg );
   std::future<bool> checked_push( msg&& msg );
   size_t threadpoolsize() const;

--- a/pol-core/clib/threadhelp.h
+++ b/pol-core/clib/threadhelp.h
@@ -58,7 +58,7 @@ private:
   HANDLES _handles;
 #endif
 };
-extern ThreadMap threadmap;
+ThreadMap& threadmap_instance();
 #ifdef _WIN32
 void SetThreadName( int dwThreadID, std::string threadName );
 #endif

--- a/pol-core/pol/CMakeSources.cmake
+++ b/pol-core/pol/CMakeSources.cmake
@@ -402,6 +402,7 @@ set (pol_sources  # sorted !
   testing/testpos.cpp
   testing/testrange.cpp
   testing/testskill.cpp
+  testing/testthreadpool.cpp
   testing/testvector.cpp
   testing/testwalk.cpp
   testing/testwww.cpp

--- a/pol-core/pol/globals/network.cpp
+++ b/pol-core/pol/globals/network.cpp
@@ -100,6 +100,7 @@ void NetworkManager::initialize()
   {
     _dap_debug_server = std::make_unique<Network::DAP::DebugServer>();
   }
+  auxthreadpool->prefill_workers();
 }
 
 void NetworkManager::deinialize()

--- a/pol-core/pol/module/osmod.cpp
+++ b/pol-core/pol/module/osmod.cpp
@@ -77,7 +77,7 @@ namespace
 class CurlStringList
 {
 public:
-  CurlStringList() : resource_( nullptr ) {}
+  CurlStringList() = default;
 
   ~CurlStringList()
   {
@@ -102,7 +102,7 @@ public:
   curl_slist* get() const { return resource_; }
 
 private:
-  curl_slist* resource_;
+  curl_slist* resource_ = nullptr;
 };
 
 };  // namespace
@@ -756,8 +756,9 @@ BObjectImp* OSExecutorModule::mf_HTTPRequest()
   Core::UOExecutor& this_uoexec = uoexec();
   weak_ptr<Core::UOExecutor> uoexec_w = this_uoexec.weakptr;
 
-  std::shared_ptr<CURL> curl_sp( curl_easy_init(), curl_easy_cleanup );
-  CURL* curl = curl_sp.get();
+  std::unique_ptr<CURL, decltype( &curl_easy_cleanup )> curl_up( curl_easy_init(),
+                                                                 curl_easy_cleanup );
+  CURL* curl = curl_up.get();
   if ( !curl )
     return new BError( "curl_easy_init() failed" );
   curl_easy_setopt( curl, CURLOPT_URL, url->data() );
@@ -802,9 +803,9 @@ BObjectImp* OSExecutorModule::mf_HTTPRequest()
   }
 
   Core::networkManager.auxthreadpool->push(
-      [uoexec_w, curl_sp, chunk, flags]()
+      [uoexec_w, curl_up = std::move( curl_up ), chunk, flags]()
       {
-        CURL* curl = curl_sp.get();
+        CURL* curl = curl_up.get();
         CURLcode res;
         std::string readBuffer;
         CurlHeaderData headerData;
@@ -1395,15 +1396,16 @@ BObjectImp* OSExecutorModule::mf_SendEmail()
     return new BError( "Invalid parameter type" );
   }
 
-  std::shared_ptr<CURL> curl_sp( curl_easy_init(), curl_easy_cleanup );
-  CURL* curl = curl_sp.get();
+  std::unique_ptr<CURL, decltype( &curl_easy_cleanup )> curl_up( curl_easy_init(),
+                                                                 curl_easy_cleanup );
+  CURL* curl = curl_up.get();
   if ( !curl )
   {
     return new BError( "curl_easy_init() failed" );
   }
 
-  auto headers_slist = std::make_shared<CurlStringList>();
-  auto recipients_slist = std::make_shared<CurlStringList>();
+  auto headers_slist = std::make_unique<CurlStringList>();
+  auto recipients_slist = std::make_unique<CurlStringList>();
   std::string to_header_value;
 
   auto extract_email_address = []( const String* email_string )
@@ -1563,7 +1565,8 @@ BObjectImp* OSExecutorModule::mf_SendEmail()
                        std::string( curl_easy_strerror( res ) ) );
   }
 
-  std::shared_ptr<curl_mime> mime( curl_mime_init( curl ), curl_mime_free );
+  std::unique_ptr<curl_mime, decltype( &curl_mime_free )> mime( curl_mime_init( curl ),
+                                                                curl_mime_free );
 
   curl_mimepart* part = curl_mime_addpart( mime.get() );
 
@@ -1600,9 +1603,10 @@ BObjectImp* OSExecutorModule::mf_SendEmail()
   weak_ptr<Core::UOExecutor> uoexec_w = this_uoexec.weakptr;
 
   Core::networkManager.auxthreadpool->push(
-      [uoexec_w, curl_sp, recipients_slist, headers_slist, mime]()
+      [uoexec_w, curl_up = std::move( curl_up ), recipients_slist = std::move( recipients_slist ),
+       headers_slist = std::move( headers_slist ), mime = std::move( mime )]()
       {
-        CURL* curl = curl_sp.get();
+        CURL* curl = curl_up.get();
 
         auto res = curl_easy_perform( curl );
 

--- a/pol-core/pol/module/sqlmod.cpp
+++ b/pol-core/pol/module/sqlmod.cpp
@@ -42,51 +42,6 @@ BObjectImp* SQLExecutorModule::background_connect( weak_ptr<Core::UOExecutor> uo
                                                    std::string host, std::string username,
                                                    std::string password, int port )
 {
-  auto msg = [uoexec = std::move( uoexec ), host = std::move( host ),
-              username = std::move( username ), password = std::move( password ), port]()
-  {
-    std::unique_ptr<Core::BSQLConnection> sql;
-    {
-      Core::PolLock lck;
-      sql = std::make_unique<Core::BSQLConnection>();
-    }
-    if ( sql->getLastErrNo() )
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( "Insufficient memory" ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else if ( !sql->connect( host, username, password, port ) )
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( sql->getLastError() ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set( new BObject( sql.release() ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-  };
-
   if ( !uoexec->suspend() )
   {
     DEBUGLOGLN(
@@ -95,8 +50,52 @@ BObjectImp* SQLExecutorModule::background_connect( weak_ptr<Core::UOExecutor> uo
         uoexec->scriptname(), uoexec->PC );
     return new Bscript::BError( "Script can't be blocked" );
   }
+  Core::networkManager.sql_service->push(
+      [uoexec = std::move( uoexec ), host = std::move( host ), username = std::move( username ),
+       password = std::move( password ), port]()
+      {
+        std::unique_ptr<Core::BSQLConnection> sql;
+        {
+          Core::PolLock lck;
+          sql = std::make_unique<Core::BSQLConnection>();
+        }
+        if ( sql->getLastErrNo() )
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set(
+                new BObject( new BError( "Insufficient memory" ) ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+        else if ( !sql->connect( host, username, password, port ) )
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set(
+                new BObject( new BError( sql->getLastError() ) ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+        else
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set( new BObject( sql.release() ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+      } );
 
-  Core::networkManager.sql_service->push( std::move( msg ) );
   return new BLong( 0 );
 }
 
@@ -106,33 +105,6 @@ Bscript::BObjectImp* SQLExecutorModule::background_select( weak_ptr<Core::UOExec
 {
   // The BSQLConnection shouldn't be destroyed before the lambda runs
   ref_ptr<Core::BSQLConnection> sqlRef( sql );
-  auto msg = [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ), db = std::move( db )]()
-  {
-    if ( !sqlRef->select_db( db ) )
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( sqlRef->getLastError() ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set( new BObject( new BLong( 1 ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-  };
-
   if ( !uoexec->suspend() )
   {
     DEBUGLOGLN(
@@ -141,7 +113,34 @@ Bscript::BObjectImp* SQLExecutorModule::background_select( weak_ptr<Core::UOExec
         uoexec->scriptname(), uoexec->PC );
     return new Bscript::BError( "Script can't be blocked" );
   }
-  Core::networkManager.sql_service->push( std::move( msg ) );
+  Core::networkManager.sql_service->push(
+      [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ), db = std::move( db )]()
+      {
+        if ( !sqlRef->select_db( db ) )
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set(
+                new BObject( new BError( sqlRef->getLastError() ) ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+        else
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set( new BObject( new BLong( 1 ) ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+      } );
+
   return new BLong( 0 );
 }
 
@@ -164,34 +163,6 @@ Bscript::BObjectImp* SQLExecutorModule::background_query( weak_ptr<Core::UOExecu
 
   // The BSQLConnection shouldn't be destroyed before the lambda runs
   ref_ptr<Core::BSQLConnection> sqlRef( sql );
-  auto msg = [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ),
-              query = std::move( query ), sharedParams = std::move( sharedParams )]()
-  {
-    if ( !sqlRef->query( query, sharedParams ) )
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( sqlRef->getLastError() ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set( new BObject( sqlRef->getResultSet() ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-  };
-
   if ( !uoexec->suspend() )
   {
     DEBUGLOGLN(
@@ -201,7 +172,35 @@ Bscript::BObjectImp* SQLExecutorModule::background_query( weak_ptr<Core::UOExecu
     return new Bscript::BError( "Script can't be blocked" );
   }
 
-  Core::networkManager.sql_service->push( std::move( msg ) );
+  Core::networkManager.sql_service->push(
+      [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ), query = std::move( query ),
+       sharedParams = std::move( sharedParams )]()
+      {
+        if ( !sqlRef->query( query, sharedParams ) )
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set(
+                new BObject( new BError( sqlRef->getLastError() ) ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+        else
+        {
+          Core::PolLock lck;
+          if ( !uoexec.exists() )
+            INFO_PRINTLN( "Script has been destroyed" );
+          else
+          {
+            uoexec.get_weakptr()->ValueStack.back().set( new BObject( sqlRef->getResultSet() ) );
+            uoexec.get_weakptr()->revive();
+          }
+        }
+      } );
+
   return new BLong( 0 );
 }
 

--- a/pol-core/pol/module/sqlmod.cpp
+++ b/pol-core/pol/module/sqlmod.cpp
@@ -39,11 +39,11 @@ size_t SQLExecutorModule::sizeEstimate() const
 }
 
 BObjectImp* SQLExecutorModule::background_connect( weak_ptr<Core::UOExecutor> uoexec,
-                                                   const std::string host,
-                                                   const std::string username,
-                                                   const std::string password, int port )
+                                                   std::string host, std::string username,
+                                                   std::string password, int port )
 {
-  auto msg = [uoexec, host, username, password, port]()
+  auto msg = [uoexec = std::move( uoexec ), host = std::move( host ),
+              username = std::move( username ), password = std::move( password ), port]()
   {
     std::unique_ptr<Core::BSQLConnection> sql;
     {
@@ -62,7 +62,7 @@ BObjectImp* SQLExecutorModule::background_connect( weak_ptr<Core::UOExecutor> uo
         uoexec.get_weakptr()->revive();
       }
     }
-    else if ( !sql->connect( host.data(), username.data(), password.data(), port ) )
+    else if ( !sql->connect( host, username, password, port ) )
     {
       Core::PolLock lck;
       if ( !uoexec.exists() )
@@ -102,25 +102,13 @@ BObjectImp* SQLExecutorModule::background_connect( weak_ptr<Core::UOExecutor> uo
 
 Bscript::BObjectImp* SQLExecutorModule::background_select( weak_ptr<Core::UOExecutor> uoexec,
                                                            Core::BSQLConnection* sql,
-                                                           const std::string db )
+                                                           std::string db )
 {
   // The BSQLConnection shouldn't be destroyed before the lambda runs
   ref_ptr<Core::BSQLConnection> sqlRef( sql );
-  auto msg = [uoexec, sqlRef, db]()
+  auto msg = [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ), db = std::move( db )]()
   {
-    if ( sqlRef == nullptr )
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( "Invalid parameters" ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else if ( !sqlRef->select_db( db.c_str() ) )
+    if ( !sqlRef->select_db( db ) )
     {
       Core::PolLock lck;
       if ( !uoexec.exists() )
@@ -159,41 +147,27 @@ Bscript::BObjectImp* SQLExecutorModule::background_select( weak_ptr<Core::UOExec
 
 Bscript::BObjectImp* SQLExecutorModule::background_query( weak_ptr<Core::UOExecutor> uoexec,
                                                           Core::BSQLConnection* sql,
-                                                          const std::string query,
+                                                          std::string query,
                                                           const Bscript::ObjArray* params )
 {
   // Copy and parse params before they will be deleted by this thread (go out of scope)
-  Core::QueryParams sharedParams( nullptr );
+  Core::QueryParams sharedParams;
   if ( params != nullptr )
   {
-    sharedParams = std::make_shared<Core::QueryParam>();
-
     for ( const auto& ref : params->ref_arr )
     {
       const BObject* obj = ref.get();
       if ( obj != nullptr )
-        sharedParams->insert( sharedParams->end(), obj->impptr()->getStringRep() );
+        sharedParams.push_back( obj->impptr()->getStringRep() );
     }
   }
 
   // The BSQLConnection shouldn't be destroyed before the lambda runs
   ref_ptr<Core::BSQLConnection> sqlRef( sql );
-  auto msg = [uoexec, sqlRef, query, sharedParams]()
+  auto msg = [uoexec = std::move( uoexec ), sqlRef = std::move( sqlRef ),
+              query = std::move( query ), sharedParams = std::move( sharedParams )]()
   {
-    if ( sqlRef == nullptr )  // TODO: this doesn't make any sense and should be checked before the
-                              // lambda. Same happens in background_select().
-    {
-      Core::PolLock lck;
-      if ( !uoexec.exists() )
-        INFO_PRINTLN( "Script has been destroyed" );
-      else
-      {
-        uoexec.get_weakptr()->ValueStack.back().set(
-            new BObject( new BError( "Invalid parameters" ) ) );
-        uoexec.get_weakptr()->revive();
-      }
-    }
-    else if ( !sqlRef->query( query, sharedParams ) )
+    if ( !sqlRef->query( query, sharedParams ) )
     {
       Core::PolLock lck;
       if ( !uoexec.exists() )

--- a/pol-core/pol/module/sqlmod.h
+++ b/pol-core/pol/module/sqlmod.h
@@ -53,13 +53,12 @@ public:
   [[nodiscard]] Bscript::BObjectImp* mf_mysql_escape_string();
 
   static Bscript::BObjectImp* background_connect( weak_ptr<Core::UOExecutor> uoexec,
-                                                  const std::string host,
-                                                  const std::string username,
-                                                  const std::string password, int port );
+                                                  std::string host, std::string username,
+                                                  std::string password, int port );
   static Bscript::BObjectImp* background_select( weak_ptr<Core::UOExecutor> uoexec,
-                                                 Core::BSQLConnection* sql, const std::string db );
+                                                 Core::BSQLConnection* sql, std::string db );
   static Bscript::BObjectImp* background_query( weak_ptr<Core::UOExecutor> uoexec,
-                                                Core::BSQLConnection* sql, const std::string query,
+                                                Core::BSQLConnection* sql, std::string query,
                                                 const Bscript::ObjArray* params );
 
   size_t sizeEstimate() const override;

--- a/pol-core/pol/network/clienttransmit.cpp
+++ b/pol-core/pol/network/clienttransmit.cpp
@@ -1,7 +1,5 @@
 #include "clienttransmit.h"
 
-#include <memory>
-
 #include "../../clib/esignal.h"
 #include "../../clib/rawtypes.h"
 #include "../globals/network.h"
@@ -11,44 +9,32 @@
 
 namespace Pol::Network
 {
-ClientTransmit::ClientTransmit() : _transmitqueue() {}
-
-ClientTransmit::~ClientTransmit() = default;
-
 void ClientTransmit::Cancel()
 {
   _transmitqueue.cancel();
 }
+
 void ClientTransmit::AddToQueue( Client* client, const void* data, int len )
 {
   const u8* message = static_cast<const u8*>( data );
-  auto transmitdata = std::make_unique<TransmitData>();
-  transmitdata->client = client->getWeakPtr();
-  transmitdata->len = len;
-  transmitdata->data.assign( message, message + len );
-  transmitdata->disconnects = false;
-  _transmitqueue.push_move( std::move( transmitdata ) );
+  _transmitqueue.push_move( { .client = client->getWeakPtr(),
+                              .data = { message, message + len },
+                              .disconnects = false } );
 }
 
 void ClientTransmit::QueueDisconnection( Client* client )
 {
-  auto transmitdata = std::make_unique<TransmitData>();
-  transmitdata->disconnects = true;
-  transmitdata->client = client->getWeakPtr();
-  _transmitqueue.push_move( std::move( transmitdata ) );
+  _transmitqueue.push_move( { .client = client->getWeakPtr(), .disconnects = true } );
 }
 
 void ClientTransmit::QueueDelete( Client* client )
 {
-  auto transmitdata = std::make_unique<TransmitData>();
-  transmitdata->remove = true;
-  transmitdata->client = client->getWeakPtr();
-  _transmitqueue.push_move( std::move( transmitdata ) );
+  _transmitqueue.push_move( { .client = client->getWeakPtr(), .remove = true } );
 }
 
-TransmitDataSPtr ClientTransmit::NextQueueEntry()
+ClientTransmit::TransmitData ClientTransmit::NextQueueEntry()
 {
-  auto transmitdata = TransmitDataSPtr();
+  TransmitData transmitdata;
   _transmitqueue.pop_wait( &transmitdata );
   return transmitdata;
 }
@@ -61,24 +47,25 @@ void ClientTransmitThread()
     try
     {
       auto data = transmit_instance->NextQueueEntry();
-      if ( data->client.exists() )
+      if ( !data.client.exists() )
+        continue;
+
+      if ( data.remove )
       {
-        if ( data->remove )
-        {
-          Core::PolLock lock;
-          delete data->client.get_weakptr();
-        }
-        else if ( data->disconnects )
-        {
-          data->client->forceDisconnect();
-        }
-        else if ( data->client->isReallyConnected() )
-        {
-          data->client->transmit( static_cast<void*>( &data->data[0] ), data->len );
-        }
+        Core::PolLock lock;
+        delete data.client.get_weakptr();
+      }
+      else if ( data.disconnects )
+      {
+        data.client->forceDisconnect();
+      }
+      else if ( data.client->isReallyConnected() )
+      {
+        data.client->transmit( static_cast<void*>( &data.data[0] ),
+                               static_cast<int>( data.data.size() ) );
       }
     }
-    catch ( ClientTransmitQueue::Canceled& )
+    catch ( ClientTransmit::ClientTransmitQueue::Canceled& )
     {
       return;
     }

--- a/pol-core/pol/network/clienttransmit.h
+++ b/pol-core/pol/network/clienttransmit.h
@@ -1,8 +1,5 @@
-#ifndef CLIENTSEND_H
-#define CLIENTSEND_H
+#pragma once
 
-#include <memory>
-#include <mutex>
 #include <vector>
 
 #include "../../clib/message_queue.h"
@@ -14,26 +11,13 @@ namespace Pol::Network
 {
 class Client;
 
-struct TransmitData
-{
-  // store a weak_ptr as a guard for pkts after deleting
-  weak_ptr<Client> client;
-  int len;
-  std::vector<u8> data;
-  bool disconnects;
-  bool remove;
-
-  TransmitData() : client( 0 ), len( 0 ), disconnects( false ), remove( false ){};
-};
-
-using TransmitDataSPtr = std::unique_ptr<TransmitData>;
-using ClientTransmitQueue = Clib::message_queue<TransmitDataSPtr>;
+void ClientTransmitThread();
 
 class ClientTransmit
 {
 public:
-  ClientTransmit();
-  ~ClientTransmit();
+  ClientTransmit() = default;
+  ~ClientTransmit() = default;
   ClientTransmit( const ClientTransmit& ) = delete;
   ClientTransmit& operator=( const ClientTransmit& ) = delete;
 
@@ -44,13 +28,23 @@ public:
   void QueueDelete( Client* client );
   void Cancel();
 
-  TransmitDataSPtr NextQueueEntry();
+protected:
+  friend void ClientTransmitThread();
+
+  struct TransmitData
+  {
+    // store a weak_ptr as a guard for pkts after deleting
+    weak_ptr<Client> client{ nullptr };
+    std::vector<u8> data{};
+    bool disconnects{ false };
+    bool remove{ false };
+  };
+
+  using ClientTransmitQueue = Clib::message_queue<TransmitData>;
+  TransmitData NextQueueEntry();
 
 private:
-  ClientTransmitQueue _transmitqueue;
+  ClientTransmitQueue _transmitqueue{};
 };
 
-void ClientTransmitThread();
 }  // namespace Pol::Network
-
-#endif

--- a/pol-core/pol/pol.cpp
+++ b/pol-core/pol/pol.cpp
@@ -702,7 +702,7 @@ void threadstatus_thread()
                         stateManager.polsig.check_attack_after_move_function_checkpoint );
       tmp += "Current Threads:\n";
       ThreadMap::Contents contents;
-      threadmap.CopyContents( contents );
+      threadmap_instance().CopyContents( contents );
       for ( ThreadMap::Contents::const_iterator citr = contents.begin(); citr != contents.end();
             ++citr )
       {
@@ -768,7 +768,7 @@ void console_thread()
 
 void start_threads()
 {
-  threadmap.Register( thread_pid(), "Main" );
+  threadmap_instance().Register( thread_pid(), "Main" );
 
   if ( Plib::systemstate.config.web_server )
     start_http_server();

--- a/pol-core/pol/sqlscrobj.cpp
+++ b/pol-core/pol/sqlscrobj.cpp
@@ -330,7 +330,8 @@ bool BSQLConnection::isTrue() const
     return true;
   return false;
 }
-bool BSQLConnection::connect( const char* host, const char* user, const char* passwd, int port )
+bool BSQLConnection::connect( const std::string& host, const std::string& user,
+                              const std::string& passwd, int port )
 {
   if ( !_conn->ptr() )
   {
@@ -339,7 +340,8 @@ bool BSQLConnection::connect( const char* host, const char* user, const char* pa
     return false;
   }
   // port == 0 means default sql port
-  if ( !mysql_real_connect( _conn->ptr(), host, user, passwd, nullptr, port, nullptr, 0 ) )
+  if ( !mysql_real_connect( _conn->ptr(), host.c_str(), user.c_str(), passwd.c_str(), nullptr, port,
+                            nullptr, 0 ) )
   {
     _errno = mysql_errno( _conn->ptr() );
     _error = mysql_error( _conn->ptr() );
@@ -347,7 +349,7 @@ bool BSQLConnection::connect( const char* host, const char* user, const char* pa
   }
   return true;
 }
-bool BSQLConnection::select_db( const char* db )
+bool BSQLConnection::select_db( const std::string& db )
 {
   if ( !_conn->ptr() )
   {
@@ -355,7 +357,7 @@ bool BSQLConnection::select_db( const char* db )
     _error = "No active MYSQL object instance.";
     return false;
   }
-  if ( mysql_select_db( _conn->ptr(), db ) )
+  if ( mysql_select_db( _conn->ptr(), db.c_str() ) )
   {
     _errno = mysql_errno( _conn->ptr() );
     _error = mysql_error( _conn->ptr() );
@@ -364,7 +366,7 @@ bool BSQLConnection::select_db( const char* db )
   return true;
 }
 
-bool BSQLConnection::query( const std::string query )
+bool BSQLConnection::query( const std::string& query )
 {
   if ( !_conn->ptr() )
   {
@@ -387,9 +389,9 @@ bool BSQLConnection::query( const std::string query )
  * Allows binding parameters to the query
  * Every occurrence of "?" is replaced with a single parameter
  */
-bool BSQLConnection::query( const std::string query, QueryParams params )
+bool BSQLConnection::query( const std::string& query, const QueryParams& params )
 {
-  if ( params == nullptr || params->empty() )
+  if ( params.empty() )
     return this->query( query );
 
   if ( !_conn->ptr() )
@@ -401,7 +403,7 @@ bool BSQLConnection::query( const std::string query, QueryParams params )
 
   std::string replaced = query;
   std::regex re( "^((?:[^']|'[^']*')*?)(\\?)" );
-  for ( auto& it : *params )
+  for ( auto& it : params )
   {
     if ( !std::regex_search( replaced, re ) )
     {

--- a/pol-core/pol/sqlscrobj.h
+++ b/pol-core/pol/sqlscrobj.h
@@ -7,8 +7,6 @@
 #ifndef SQLSCROBJ_H
 #define SQLSCROBJ_H
 
-#include "pol_global_config.h"
-
 #ifdef _WIN32
 #include "../clib/Header_Windows.h"
 #endif
@@ -17,6 +15,8 @@
 #include <functional>
 #include <memory>
 #include <string>
+
+#include <boost/compat/move_only_function.hpp>
 
 #include "../bscript/bobject.h"
 #include "../clib/message_queue.h"
@@ -108,8 +108,7 @@ private:
 };
 class SQLService;
 
-using QueryParam = std::vector<std::string>;
-using QueryParams = std::shared_ptr<QueryParam>;
+using QueryParams = std::vector<std::string>;
 
 class BSQLConnection final : public Core::PolObjectImp
 {
@@ -119,10 +118,11 @@ public:
   BSQLConnection();
   BSQLConnection( std::shared_ptr<ConnectionWrapper> conn );
   ~BSQLConnection() override;
-  bool connect( const char* host, const char* user, const char* passwd, int port = 0 );
-  bool query( const std::string query );
-  bool query( const std::string query, const QueryParams params );
-  bool select_db( const char* db );
+  bool connect( const std::string& host, const std::string& user, const std::string& passwd,
+                int port = 0 );
+  bool query( const std::string& query );
+  bool query( const std::string& query, const QueryParams& params );
+  bool select_db( const std::string& db );
   bool close();
   Bscript::BObjectImp* getResultSet() const;
 
@@ -166,7 +166,7 @@ private:
 class SQLService
 {
 public:
-  using msg = std::function<void()>;
+  using msg = boost::compat::move_only_function<void()>;
   using msg_queue = Clib::message_queue<msg>;
   SQLService();
   ~SQLService();

--- a/pol-core/pol/testing/poltest.cpp
+++ b/pol-core/pol/testing/poltest.cpp
@@ -57,6 +57,7 @@ bool run_pol_tests()
 
   RUNTEST( caseinsensitive_compare_test )
   RUNTEST( www_test )
+  RUNTEST( dynthreadpool_test )
   //  RUNTEST( dummy )
 
   UnitTest::display_test_results();

--- a/pol-core/pol/testing/testenv.h
+++ b/pol-core/pol/testing/testenv.h
@@ -29,18 +29,17 @@ public:
   template <typename F, typename T>
   UnitTest( F f, T res, const std::string& msg )
   {
-    INFO_PRINT( "    {}", msg );
     auto r = f();
     if ( r == res )
     {
+      INFO_PRINTLN( "    {}", msg );
       UnitTest::inc_successes();
     }
     else
     {
       UnitTest::inc_failures();
-      INFO_PRINT( ": {} != {}", r, res );
+      INFO_PRINT( "    {}: {} != {}", msg, r, res );
     }
-    INFO_PRINTLN( "" );
   }
   static void inc_failures() { ++UnitTest::failures; }
   static void inc_successes() { ++UnitTest::successes; }
@@ -109,6 +108,7 @@ void clamp_test();
 void uoextension_test();
 void caseinsensitive_compare_test();
 void www_test();
+void dynthreadpool_test();
 }  // namespace Testing
 }  // namespace Pol
 #endif

--- a/pol-core/pol/testing/testthreadpool.cpp
+++ b/pol-core/pol/testing/testthreadpool.cpp
@@ -1,0 +1,46 @@
+
+#include "testenv.h"
+
+#include "clib/threadhelp.h"
+#include <thread>
+
+namespace Pol::Testing
+{
+void dynthreadpool_test()
+{
+  threadhelp::DynTaskThreadPool pool{ "test" };
+
+  UnitTest( [&]() { return pool.threadpoolsize(); }, 0u, "init" );
+  UnitTest( [&]() { return pool.checked_push( [] { return true; } ).get(); }, true, "first work" );
+  UnitTest( [&]() { return pool.threadpoolsize(); }, 1u, "pool size after first run" );
+  UnitTest(
+      [&]()
+      {
+        try
+        {
+          pool.checked_push( [] { throw std::exception(); } ).get();
+        }
+        catch ( std::exception& )
+        {
+          return true;
+        }
+        return false;
+      },
+      true, "exception in checked push" );
+  UnitTest(
+      [&]()
+      {
+        pool.push(
+            []
+            {
+              INFO_PRINTLN( "throw" );
+              throw std::exception();
+            } );
+        return true;
+      },
+      true, "exception in push" );
+  UnitTest( [&]() { return pool.checked_push( [] { return true; } ).get(); }, true,
+            "would block endless if worker died before" );
+}
+
+}  // namespace Pol::Testing


### PR DESCRIPTION
Fixedallocator:
Type safe
General cleanup
Log facility:
Use move_only_function for queue
Message queue:
Added timeout wait method
TaskThreadPool:
Use move_only_function for queue 
DynTaskThreadPool:
Use move_only_function for queue
Added minimum number of workers
Instead of keep growing, the workers have now a timeout of 1min, remove these workers until minimum workers are reached
Curl commands:
Get rid of overhead due to DynTaskThreadPool changes
SQL service:
Use move_only_function for queue and get rid of overhead
Client transmit:
Use move_only_function for queue and get rid of overhead
Macos build:
Update to macos-latest 