### PR TITLE
Fixed shortcircuit optimization for consecutive jumps

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,13 +2,13 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-20-2026</datemodified>
+		<datemodified>07-21-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
 		<entry>
-			<date>07-20-2026</date>
+			<date>07-21-2026</date>
 			<author>Turley:</author>
-			<change type="Fixed">reverted changes from 08-06-2025. The further ShortCircuit optimizations created wrong instructions in certain situations.<br/>
+			<change type="Fixed">ShortCircuit optimizations created wrong instructions in certain situations.<br/>
 Since the bug is in codegen recompilation is needed.</change>
 		</entry>
 		<entry>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>07-19-2026</datemodified>
+		<datemodified>07-20-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>07-20-2026</date>
+			<author>Turley:</author>
+			<change type="Fixed">reverted changes from 08-06-2025. The further ShortCircuit optimizations created wrong instructions in certain situations.<br/>
+Since the bug is in codegen recompilation is needed.</change>
+		</entry>
 		<entry>
 			<date>07-18-2026</date>
 			<author>Nando:</author>

--- a/pol-core/bscript/CMakeSources.cmake
+++ b/pol-core/bscript/CMakeSources.cmake
@@ -359,6 +359,8 @@ set (bscript_sources    # sorted !
   compiler/optimizer/BinaryOperatorWithStringOptimizer.h
   compiler/optimizer/ConstantValidator.cpp
   compiler/optimizer/ConstantValidator.h
+  compiler/optimizer/CodeSectionOptimizer.cpp
+  compiler/optimizer/CodeSectionOptimizer.h
   compiler/optimizer/Optimizer.cpp
   compiler/optimizer/Optimizer.h
   compiler/optimizer/ReferencedFunctionGatherer.cpp

--- a/pol-core/bscript/compiler/ast/BinaryOperatorShortCircuit.cpp
+++ b/pol-core/bscript/compiler/ast/BinaryOperatorShortCircuit.cpp
@@ -13,7 +13,6 @@ BinaryOperatorShortCircuit::BinaryOperatorShortCircuit( const SourceLocation& so
     : Expression( source_location ),
       oper( op ),
       end_label( std::make_shared<FlowControlLabel>() ),
-      linked_jmp_label(),
       generate_logical_convert( true )
 {
   children.reserve( 2 );

--- a/pol-core/bscript/compiler/ast/BinaryOperatorShortCircuit.h
+++ b/pol-core/bscript/compiler/ast/BinaryOperatorShortCircuit.h
@@ -18,7 +18,7 @@ enum class ShortCircuitOp
 struct JmpLocationLink : public std::enable_shared_from_this<JmpLocationLink>
 {
   JmpLocationLink( std::shared_ptr<FlowControlLabel> label, ShortCircuitOp op )
-      : jmp_label( std::move( label ) ), oper( op ){};
+      : jmp_label( std::move( label ) ), oper( op ) {};
   void update( const JmpLocationLink& op )
   {
     jmp_label = op.jmp_label;
@@ -41,8 +41,6 @@ public:
   Expression& rhs();
   const ShortCircuitOp oper;
   const std::shared_ptr<FlowControlLabel> end_label;
-  // will be set and changed by the ShortCircuitCombiner
-  std::shared_ptr<JmpLocationLink> linked_jmp_label;
   bool generate_logical_convert;
 };
 

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -18,6 +18,7 @@
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/FlowControlLabel.h"
+#include "bscript/compiler/optimizer/CodeSectionOptimizer.h"
 #include "bscript/compiler/optimizer/ShortCircuitCombiner.h"
 #include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/CompiledScript.h"
@@ -25,9 +26,6 @@
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
 #include "bscript/compiler/representation/ModuleFunctionDescriptor.h"
-#include "bscript/compilercfg.h"
-#include "compiler/optimizer/ShortCircuitCombiner.h"
-
 
 namespace Pol::Bscript::Compiler
 {
@@ -78,8 +76,7 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
 
   std::vector<ClassDescriptor> class_descriptors = class_declaration_registrar.take_descriptors();
 
-  if ( compilercfg.ShortCircuitEvaluation )
-    ShortCircuitCombiner::optimize_jumps( code );
+  CodeSectionOptimizer{}.optimize( code );
 
   std::string tree;
 

--- a/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/CodeGenerator.cpp
@@ -18,12 +18,16 @@
 #include "bscript/compiler/file/SourceFileIdentifier.h"
 #include "bscript/compiler/model/CompilerWorkspace.h"
 #include "bscript/compiler/model/FlowControlLabel.h"
+#include "bscript/compiler/optimizer/ShortCircuitCombiner.h"
 #include "bscript/compiler/representation/ClassDescriptor.h"
 #include "bscript/compiler/representation/CompiledScript.h"
 #include "bscript/compiler/representation/ExportedFunction.h"
 #include "bscript/compiler/representation/FunctionReferenceDescriptor.h"
 #include "bscript/compiler/representation/ModuleDescriptor.h"
 #include "bscript/compiler/representation/ModuleFunctionDescriptor.h"
+#include "bscript/compilercfg.h"
+#include "compiler/optimizer/ShortCircuitCombiner.h"
+
 
 namespace Pol::Bscript::Compiler
 {
@@ -73,6 +77,9 @@ std::unique_ptr<CompiledScript> CodeGenerator::generate(
                                                      workspace->user_function_labels );
 
   std::vector<ClassDescriptor> class_descriptors = class_declaration_registrar.take_descriptors();
+
+  if ( compilercfg.ShortCircuitEvaluation )
+    ShortCircuitCombiner::optimize_jumps( code );
 
   std::string tree;
 

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1114,9 +1114,10 @@ void InstructionGenerator::visit_binary_operator_short_circuit( BinaryOperatorSh
   emit.debug_statementbegin();
   update_debug_location( op );
   generate( op.lhs() );
-
-  emit.logical_jmp( op.linked_jmp_label ? *op.linked_jmp_label->jmp_label : *op.end_label,
-                    op.oper == ShortCircuitOp::OR );
+  emit.logical_jmp( *op.end_label, op.oper == ShortCircuitOp::OR );
+  // disabled: it doesnt work in all cases :(
+  //  emit.logical_jmp( op.linked_jmp_label ? *op.linked_jmp_label->jmp_label : *op.end_label,
+  //                    op.oper == ShortCircuitOp::OR );
   generate( op.rhs() );
   // dont emit convert if the rhs oper is also a ShortCircuit which generated already a convert, or
   // the parent

--- a/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
+++ b/pol-core/bscript/compiler/codegen/InstructionGenerator.cpp
@@ -1115,9 +1115,6 @@ void InstructionGenerator::visit_binary_operator_short_circuit( BinaryOperatorSh
   update_debug_location( op );
   generate( op.lhs() );
   emit.logical_jmp( *op.end_label, op.oper == ShortCircuitOp::OR );
-  // disabled: it doesnt work in all cases :(
-  //  emit.logical_jmp( op.linked_jmp_label ? *op.linked_jmp_label->jmp_label : *op.end_label,
-  //                    op.oper == ShortCircuitOp::OR );
   generate( op.rhs() );
   // dont emit convert if the rhs oper is also a ShortCircuit which generated already a convert, or
   // the parent

--- a/pol-core/bscript/compiler/optimizer/CodeSectionOptimizer.cpp
+++ b/pol-core/bscript/compiler/optimizer/CodeSectionOptimizer.cpp
@@ -1,0 +1,56 @@
+#include "bscript/compiler/optimizer/CodeSectionOptimizer.h"
+#include "bscript/StoredToken.h"
+#include "bscript/compilercfg.h"
+#include "bscript/tokens.h"
+
+namespace Pol::Bscript::Compiler
+{
+void CodeSectionOptimizer::optimize( CodeSection& code ) const
+{
+  if ( compilercfg.ShortCircuitEvaluation )
+    short_circuit_jumps( code );
+}
+
+void CodeSectionOptimizer::short_circuit_jumps( CodeSection& code ) const
+{
+  // recursivly check if a logical jump would jump to another jump and update the final jump
+  // location
+  auto combine = [&]( StoredToken& jump, auto&& combine )
+  {
+    const auto& loc = code[jump.offset];
+    if ( loc.id == RSV_JMPIFFALSE )
+    {
+      if ( jump.type == TYP_LOGICAL_JUMP_FALSE )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == RSV_JMPIFTRUE )
+    {
+      if ( jump.type != TYP_LOGICAL_JUMP_FALSE )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == INS_LOGICAL_JUMP )
+    {
+      if ( loc.type == jump.type )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == INS_LOGICAL_CONVERT )
+    {
+      jump.offset++;
+    }
+    else
+    {
+      return;
+    }
+    return combine( jump, combine );
+  };
+  for ( auto& c : code )
+    if ( c.id == INS_LOGICAL_JUMP )
+      combine( c, combine );
+}
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/CodeSectionOptimizer.h
+++ b/pol-core/bscript/compiler/optimizer/CodeSectionOptimizer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "bscript/compiler/representation/CompiledScript.h"
+
+namespace Pol::Bscript::Compiler
+{
+class CodeSectionOptimizer
+{
+public:
+  CodeSectionOptimizer() = default;
+  void optimize( CodeSection& code ) const;
+
+private:
+  void short_circuit_jumps( CodeSection& code ) const;
+};
+}  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
@@ -1,10 +1,7 @@
 #include "ShortCircuitCombiner.h"
 
-#include "bscript/StoredToken.h"
 #include "bscript/compiler/Report.h"
 #include "bscript/compiler/ast/BinaryOperatorShortCircuit.h"
-#include "bscript/tokens.h"
-
 
 namespace Pol::Bscript::Compiler
 {
@@ -20,7 +17,6 @@ public:
   };
 };
 
-
 ShortCircuitCombiner::ShortCircuitCombiner( Report& ) {}
 
 void ShortCircuitCombiner::visit_children( Node& ) {}
@@ -33,48 +29,4 @@ void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorSh
   ShortCircuitCombinerChildVisitor rhs_child{};
   op.rhs().accept( rhs_child );
 }
-
-void ShortCircuitCombiner::optimize_jumps( CodeSection& code )
-{
-  // recursivly check if a logical jump would jump to another jump and update the final jump
-  // location
-  auto combine = [&]( StoredToken& jump, auto&& combine )
-  {
-    const auto& loc = code[jump.offset];
-    if ( loc.id == RSV_JMPIFFALSE )
-    {
-      if ( jump.type == TYP_LOGICAL_JUMP_FALSE )
-        jump.offset = loc.offset;
-      else
-        jump.offset++;
-    }
-    else if ( loc.id == RSV_JMPIFTRUE )
-    {
-      if ( jump.type != TYP_LOGICAL_JUMP_FALSE )
-        jump.offset = loc.offset;
-      else
-        jump.offset++;
-    }
-    else if ( loc.id == INS_LOGICAL_JUMP )
-    {
-      if ( loc.type == jump.type )
-        jump.offset = loc.offset;
-      else
-        jump.offset++;
-    }
-    else if ( loc.id == INS_LOGICAL_CONVERT )
-    {
-      jump.offset++;
-    }
-    else
-    {
-      return;
-    }
-    return combine( jump, combine );
-  };
-  for ( auto& c : code )
-    if ( c.id == INS_LOGICAL_JUMP )
-      combine( c, combine );
-}
-
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
@@ -1,7 +1,9 @@
 #include "ShortCircuitCombiner.h"
 
+#include "bscript/StoredToken.h"
 #include "bscript/compiler/Report.h"
 #include "bscript/compiler/ast/BinaryOperatorShortCircuit.h"
+#include "bscript/tokens.h"
 
 
 namespace Pol::Bscript::Compiler
@@ -9,33 +11,13 @@ namespace Pol::Bscript::Compiler
 class ShortCircuitCombinerChildVisitor : public NodeVisitor
 {
 public:
-  ShortCircuitCombinerChildVisitor( BinaryOperatorShortCircuit& /*parent*/, bool /*rhs*/ )
-  /*  : parent( parent ), rhs( rhs ) */ {};
+  ShortCircuitCombinerChildVisitor() = default;
   void visit_children( Node& ) override {};
   void visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& child ) override
   {
-    // create a new jmplink or use the existing
-    //   auto parent_endjmp = parent.linked_jmp_label
-    //                          ? parent.linked_jmp_label
-    //                         : std::make_shared<JmpLocationLink>( parent.end_label, parent.oper );
     // its a child so no need to add convert instruction
     child.generate_logical_convert = false;
-    // on the left side dont jump if the operand is different (would skip the rhs)
-    //    if ( !rhs && child.oper != parent_endjmp->oper )
-    //    return;
-    // update the jmp, so that it will propagate
-    // if ( child.linked_jmp_label )
-    // child.linked_jmp_label->update( *parent_endjmp );
-    //    else
-    //    child.linked_jmp_label = parent_endjmp;
-    // set the parent also, thus if its a child it would propagate to its children
-    //    if ( !parent.linked_jmp_label )
-    //    parent.linked_jmp_label = parent_endjmp;
   };
-
-private:
-  //  BinaryOperatorShortCircuit& parent;
-  // bool rhs;
 };
 
 
@@ -46,10 +28,53 @@ void ShortCircuitCombiner::visit_children( Node& ) {}
 void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& op )
 {
   // dont visit recursivly just direct both sides
-  ShortCircuitCombinerChildVisitor lhs_child{ op, false };
+  ShortCircuitCombinerChildVisitor lhs_child{};
   op.lhs().accept( lhs_child );
-  ShortCircuitCombinerChildVisitor rhs_child{ op, true };
+  ShortCircuitCombinerChildVisitor rhs_child{};
   op.rhs().accept( rhs_child );
+}
+
+void ShortCircuitCombiner::optimize_jumps( CodeSection& code )
+{
+  // recursivly check if a logical jump would jump to another jump and update the final jump
+  // location
+  auto combine = [&]( StoredToken& jump, auto&& combine )
+  {
+    const auto& loc = code[jump.offset];
+    if ( loc.id == RSV_JMPIFFALSE )
+    {
+      if ( jump.type == TYP_LOGICAL_JUMP_FALSE )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == RSV_JMPIFTRUE )
+    {
+      if ( jump.type != TYP_LOGICAL_JUMP_FALSE )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == INS_LOGICAL_JUMP )
+    {
+      if ( loc.type == jump.type )
+        jump.offset = loc.offset;
+      else
+        jump.offset++;
+    }
+    else if ( loc.id == INS_LOGICAL_CONVERT )
+    {
+      jump.offset++;
+    }
+    else
+    {
+      return;
+    }
+    return combine( jump, combine );
+  };
+  for ( auto& c : code )
+    if ( c.id == INS_LOGICAL_JUMP )
+      combine( c, combine );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
@@ -9,33 +9,33 @@ namespace Pol::Bscript::Compiler
 class ShortCircuitCombinerChildVisitor : public NodeVisitor
 {
 public:
-  ShortCircuitCombinerChildVisitor( BinaryOperatorShortCircuit& parent, bool rhs )
-      : parent( parent ), rhs( rhs ) {};
+  ShortCircuitCombinerChildVisitor( BinaryOperatorShortCircuit& /*parent*/, bool /*rhs*/ )
+  /*  : parent( parent ), rhs( rhs ) */ {};
   void visit_children( Node& ) override {};
   void visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& child ) override
   {
     // create a new jmplink or use the existing
-    auto parent_endjmp = parent.linked_jmp_label
-                             ? parent.linked_jmp_label
-                             : std::make_shared<JmpLocationLink>( parent.end_label, parent.oper );
+    //   auto parent_endjmp = parent.linked_jmp_label
+    //                          ? parent.linked_jmp_label
+    //                         : std::make_shared<JmpLocationLink>( parent.end_label, parent.oper );
     // its a child so no need to add convert instruction
     child.generate_logical_convert = false;
     // on the left side dont jump if the operand is different (would skip the rhs)
-    if ( !rhs && child.oper != parent_endjmp->oper )
-      return;
+    //    if ( !rhs && child.oper != parent_endjmp->oper )
+    //    return;
     // update the jmp, so that it will propagate
-    if ( child.linked_jmp_label )
-      child.linked_jmp_label->update( *parent_endjmp );
-    else
-      child.linked_jmp_label = parent_endjmp;
+    // if ( child.linked_jmp_label )
+    // child.linked_jmp_label->update( *parent_endjmp );
+    //    else
+    //    child.linked_jmp_label = parent_endjmp;
     // set the parent also, thus if its a child it would propagate to its children
-    if ( !parent.linked_jmp_label )
-      parent.linked_jmp_label = parent_endjmp;
+    //    if ( !parent.linked_jmp_label )
+    //    parent.linked_jmp_label = parent_endjmp;
   };
 
 private:
-  BinaryOperatorShortCircuit& parent;
-  bool rhs;
+  //  BinaryOperatorShortCircuit& parent;
+  // bool rhs;
 };
 
 
@@ -43,16 +43,13 @@ ShortCircuitCombiner::ShortCircuitCombiner( Report& ) {}
 
 void ShortCircuitCombiner::visit_children( Node& ) {}
 
-void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& /*op*/ )
+void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& op )
 {
-  // disabled doesnt work :(
-  return;
-
   // dont visit recursivly just direct both sides
-  //  ShortCircuitCombinerChildVisitor lhs_child{ op, false };
-  // op.lhs().accept( lhs_child );
-  //  ShortCircuitCombinerChildVisitor rhs_child{ op, true };
-  //  op.rhs().accept( rhs_child );
+  ShortCircuitCombinerChildVisitor lhs_child{ op, false };
+  op.lhs().accept( lhs_child );
+  ShortCircuitCombinerChildVisitor rhs_child{ op, true };
+  op.rhs().accept( rhs_child );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.cpp
@@ -10,8 +10,8 @@ class ShortCircuitCombinerChildVisitor : public NodeVisitor
 {
 public:
   ShortCircuitCombinerChildVisitor( BinaryOperatorShortCircuit& parent, bool rhs )
-      : parent( parent ), rhs( rhs ){};
-  void visit_children( Node& ) override{};
+      : parent( parent ), rhs( rhs ) {};
+  void visit_children( Node& ) override {};
   void visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& child ) override
   {
     // create a new jmplink or use the existing
@@ -43,13 +43,16 @@ ShortCircuitCombiner::ShortCircuitCombiner( Report& ) {}
 
 void ShortCircuitCombiner::visit_children( Node& ) {}
 
-void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& op )
+void ShortCircuitCombiner::visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& /*op*/ )
 {
+  // disabled doesnt work :(
+  return;
+
   // dont visit recursivly just direct both sides
-  ShortCircuitCombinerChildVisitor lhs_child{ op, false };
-  op.lhs().accept( lhs_child );
-  ShortCircuitCombinerChildVisitor rhs_child{ op, true };
-  op.rhs().accept( rhs_child );
+  //  ShortCircuitCombinerChildVisitor lhs_child{ op, false };
+  // op.lhs().accept( lhs_child );
+  //  ShortCircuitCombinerChildVisitor rhs_child{ op, true };
+  //  op.rhs().accept( rhs_child );
 }
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.h
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bscript/compiler/ast/NodeVisitor.h"
+#include "bscript/compiler/representation/CompiledScript.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -12,6 +13,8 @@ public:
   ShortCircuitCombiner( Report& );
   void visit_children( Node& ) override;
   void visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& ) override;
+
+  static void optimize_jumps( CodeSection& code );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.h
+++ b/pol-core/bscript/compiler/optimizer/ShortCircuitCombiner.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "bscript/compiler/ast/NodeVisitor.h"
-#include "bscript/compiler/representation/CompiledScript.h"
 
 namespace Pol::Bscript::Compiler
 {
@@ -13,8 +12,6 @@ public:
   ShortCircuitCombiner( Report& );
   void visit_children( Node& ) override;
   void visit_binary_operator_short_circuit( BinaryOperatorShortCircuit& ) override;
-
-  static void optimize_jumps( CodeSection& code );
 };
 
 }  // namespace Pol::Bscript::Compiler

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,6 +1,6 @@
 -- POL100.3.0 --
-07-20-2026 Turley:
-    Fixed: reverted changes from 08-06-2025. The further ShortCircuit optimizations created wrong instructions in certain situations.
+07-21-2026 Turley:
+    Fixed: ShortCircuit optimizations created wrong instructions in certain situations.
            Since the bug is in codegen recompilation is needed.
 07-18-2026 Nando:
   Changed: uoconvert's map conversion is substantially faster. The 'map' and 'maptile'

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.3.0 --
+07-20-2026 Turley:
+    Fixed: reverted changes from 08-06-2025. The further ShortCircuit optimizations created wrong instructions in certain situations.
+           Since the bug is in codegen recompilation is needed.
 07-18-2026 Nando:
   Changed: uoconvert's map conversion is substantially faster. The 'map' and 'maptile'
            commands now build their output files in memory (writing each once instead of

--- a/testsuite/escript/opt/shortcircuit3.optimized.out
+++ b/testsuite/escript/opt/shortcircuit3.optimized.out
@@ -11,76 +11,86 @@ success
 6: :=
 8: "multiple ||" (string)
 10: global variable #1
-11: logical jump if true to 16
+11: logical jump if true to 14
 12: global variable #1
-13: logical jump if true to 16
-14: global variable #0
-15: logical convert
-16: if false goto 21
-17: "success" (string)
-18: "" (string)
-19: call module function (0, 0): Print
-21: "multible &&" (string)
-23: global variable #0
-24: logical jump if false to 29
-25: global variable #0
-26: logical jump if false to 29
-27: global variable #0
-28: logical convert
-29: if false goto 34
-30: "success" (string)
-31: "" (string)
-32: call module function (0, 0): Print
-34: "combined t && (t || t)" (string)
-36: global variable #0
-37: logical jump if false to 42
+13: logical convert
+14: logical jump if true to 17
+15: global variable #0
+16: logical convert
+17: if false goto 22
+18: "success" (string)
+19: "" (string)
+20: call module function (0, 0): Print
+22: "multible &&" (string)
+24: global variable #0
+25: logical jump if false to 28
+26: global variable #0
+27: logical convert
+28: logical jump if false to 31
+29: global variable #0
+30: logical convert
+31: if false goto 36
+32: "success" (string)
+33: "" (string)
+34: call module function (0, 0): Print
+36: "combined t && (t || t)" (string)
 38: global variable #0
-39: logical jump if true to 42
+39: logical jump if false to 45
 40: global variable #0
-41: logical convert
-42: if false goto 47
-43: "success" (string)
-44: "" (string)
-45: call module function (0, 0): Print
-47: "combined 2 t && (f || f)" (string)
-49: global variable #0
-50: logical jump if false to 55
-51: global variable #1
-52: logical jump if true to 55
-53: global variable #1
-54: logical convert
-55: if false goto 60
-56: "failed" (string)
-57: "" (string)
-58: call module function (0, 0): Print
-60: "combined 3 ( f || t ) && ( f || t)" (string)
-62: global variable #1
-63: logical jump if true to 65
-64: global variable #0
-65: logical jump if false to 70
+41: logical jump if true to 44
+42: global variable #0
+43: logical convert
+44: logical convert
+45: if false goto 50
+46: "success" (string)
+47: "" (string)
+48: call module function (0, 0): Print
+50: "combined 2 t && (f || f)" (string)
+52: global variable #0
+53: logical jump if false to 59
+54: global variable #1
+55: logical jump if true to 58
+56: global variable #1
+57: logical convert
+58: logical convert
+59: if false goto 64
+60: "failed" (string)
+61: "" (string)
+62: call module function (0, 0): Print
+64: "combined 3 ( f || t ) && ( f || t)" (string)
 66: global variable #1
 67: logical jump if true to 70
 68: global variable #0
 69: logical convert
-70: if false goto 75
-71: "success" (string)
-72: "" (string)
-73: call module function (0, 0): Print
-75: "combined 4 ( f || t || t ) && ( f || t || t )" (string)
-77: global variable #1
-78: logical jump if true to 82
-79: global variable #0
-80: logical jump if true to 82
-81: global variable #0
-82: logical jump if false to 89
+70: logical jump if false to 76
+71: global variable #1
+72: logical jump if true to 75
+73: global variable #0
+74: logical convert
+75: logical convert
+76: if false goto 81
+77: "success" (string)
+78: "" (string)
+79: call module function (0, 0): Print
+81: "combined 4 ( f || t || t ) && ( f || t || t )" (string)
 83: global variable #1
-84: logical jump if true to 89
+84: logical jump if true to 87
 85: global variable #0
-86: logical jump if true to 89
-87: global variable #0
-88: logical convert
-89: if false goto 94
-90: "success" (string)
-91: "" (string)
-92: call module function (0, 0): Print
+86: logical convert
+87: logical jump if true to 90
+88: global variable #0
+89: logical convert
+90: logical jump if false to 99
+91: global variable #1
+92: logical jump if true to 95
+93: global variable #0
+94: logical convert
+95: logical jump if true to 98
+96: global variable #0
+97: logical convert
+98: logical convert
+99: if false goto 104
+100: "success" (string)
+101: "" (string)
+102: call module function (0, 0): Print
 

--- a/testsuite/escript/opt/shortcircuit3.optimized.out
+++ b/testsuite/escript/opt/shortcircuit3.optimized.out
@@ -11,9 +11,9 @@ success
 6: :=
 8: "multiple ||" (string)
 10: global variable #1
-11: logical jump if true to 13
+11: logical jump if true to 17
 12: global variable #1
-13: logical jump if true to 16
+13: logical jump if true to 17
 14: global variable #0
 15: logical convert
 16: if false goto 21
@@ -22,9 +22,9 @@ success
 19: call module function (0, 0): Print
 21: "multible &&" (string)
 23: global variable #0
-24: logical jump if false to 26
+24: logical jump if false to 34
 25: global variable #0
-26: logical jump if false to 29
+26: logical jump if false to 34
 27: global variable #0
 28: logical convert
 29: if false goto 34
@@ -33,9 +33,9 @@ success
 32: call module function (0, 0): Print
 34: "combined t && (t || t)" (string)
 36: global variable #0
-37: logical jump if false to 42
+37: logical jump if false to 47
 38: global variable #0
-39: logical jump if true to 41
+39: logical jump if true to 43
 40: global variable #0
 41: logical convert
 42: if false goto 47
@@ -44,9 +44,9 @@ success
 45: call module function (0, 0): Print
 47: "combined 2 t && (f || f)" (string)
 49: global variable #0
-50: logical jump if false to 55
+50: logical jump if false to 60
 51: global variable #1
-52: logical jump if true to 54
+52: logical jump if true to 56
 53: global variable #1
 54: logical convert
 55: if false goto 60
@@ -55,11 +55,11 @@ success
 58: call module function (0, 0): Print
 60: "combined 3 ( f || t ) && ( f || t)" (string)
 62: global variable #1
-63: logical jump if true to 65
+63: logical jump if true to 66
 64: global variable #0
-65: logical jump if false to 70
+65: logical jump if false to 75
 66: global variable #1
-67: logical jump if true to 69
+67: logical jump if true to 71
 68: global variable #0
 69: logical convert
 70: if false goto 75
@@ -68,15 +68,15 @@ success
 73: call module function (0, 0): Print
 75: "combined 4 ( f || t || t ) && ( f || t || t )" (string)
 77: global variable #1
-78: logical jump if true to 80
+78: logical jump if true to 83
 79: global variable #0
-80: logical jump if true to 82
+80: logical jump if true to 83
 81: global variable #0
-82: logical jump if false to 89
+82: logical jump if false to 94
 83: global variable #1
-84: logical jump if true to 86
+84: logical jump if true to 90
 85: global variable #0
-86: logical jump if true to 88
+86: logical jump if true to 90
 87: global variable #0
 88: logical convert
 89: if false goto 94

--- a/testsuite/escript/opt/shortcircuit3.optimized.out
+++ b/testsuite/escript/opt/shortcircuit3.optimized.out
@@ -11,86 +11,76 @@ success
 6: :=
 8: "multiple ||" (string)
 10: global variable #1
-11: logical jump if true to 14
+11: logical jump if true to 13
 12: global variable #1
-13: logical convert
-14: logical jump if true to 17
-15: global variable #0
-16: logical convert
-17: if false goto 22
-18: "success" (string)
-19: "" (string)
-20: call module function (0, 0): Print
-22: "multible &&" (string)
-24: global variable #0
-25: logical jump if false to 28
-26: global variable #0
-27: logical convert
-28: logical jump if false to 31
-29: global variable #0
-30: logical convert
-31: if false goto 36
-32: "success" (string)
-33: "" (string)
-34: call module function (0, 0): Print
-36: "combined t && (t || t)" (string)
+13: logical jump if true to 16
+14: global variable #0
+15: logical convert
+16: if false goto 21
+17: "success" (string)
+18: "" (string)
+19: call module function (0, 0): Print
+21: "multible &&" (string)
+23: global variable #0
+24: logical jump if false to 26
+25: global variable #0
+26: logical jump if false to 29
+27: global variable #0
+28: logical convert
+29: if false goto 34
+30: "success" (string)
+31: "" (string)
+32: call module function (0, 0): Print
+34: "combined t && (t || t)" (string)
+36: global variable #0
+37: logical jump if false to 42
 38: global variable #0
-39: logical jump if false to 45
+39: logical jump if true to 41
 40: global variable #0
-41: logical jump if true to 44
-42: global variable #0
-43: logical convert
-44: logical convert
-45: if false goto 50
-46: "success" (string)
-47: "" (string)
-48: call module function (0, 0): Print
-50: "combined 2 t && (f || f)" (string)
-52: global variable #0
-53: logical jump if false to 59
-54: global variable #1
-55: logical jump if true to 58
-56: global variable #1
-57: logical convert
-58: logical convert
-59: if false goto 64
-60: "failed" (string)
-61: "" (string)
-62: call module function (0, 0): Print
-64: "combined 3 ( f || t ) && ( f || t)" (string)
+41: logical convert
+42: if false goto 47
+43: "success" (string)
+44: "" (string)
+45: call module function (0, 0): Print
+47: "combined 2 t && (f || f)" (string)
+49: global variable #0
+50: logical jump if false to 55
+51: global variable #1
+52: logical jump if true to 54
+53: global variable #1
+54: logical convert
+55: if false goto 60
+56: "failed" (string)
+57: "" (string)
+58: call module function (0, 0): Print
+60: "combined 3 ( f || t ) && ( f || t)" (string)
+62: global variable #1
+63: logical jump if true to 65
+64: global variable #0
+65: logical jump if false to 70
 66: global variable #1
-67: logical jump if true to 70
+67: logical jump if true to 69
 68: global variable #0
 69: logical convert
-70: logical jump if false to 76
-71: global variable #1
-72: logical jump if true to 75
-73: global variable #0
-74: logical convert
-75: logical convert
-76: if false goto 81
-77: "success" (string)
-78: "" (string)
-79: call module function (0, 0): Print
-81: "combined 4 ( f || t || t ) && ( f || t || t )" (string)
+70: if false goto 75
+71: "success" (string)
+72: "" (string)
+73: call module function (0, 0): Print
+75: "combined 4 ( f || t || t ) && ( f || t || t )" (string)
+77: global variable #1
+78: logical jump if true to 80
+79: global variable #0
+80: logical jump if true to 82
+81: global variable #0
+82: logical jump if false to 89
 83: global variable #1
-84: logical jump if true to 87
+84: logical jump if true to 86
 85: global variable #0
-86: logical convert
-87: logical jump if true to 90
-88: global variable #0
-89: logical convert
-90: logical jump if false to 99
-91: global variable #1
-92: logical jump if true to 95
-93: global variable #0
-94: logical convert
-95: logical jump if true to 98
-96: global variable #0
-97: logical convert
-98: logical convert
-99: if false goto 104
-100: "success" (string)
-101: "" (string)
-102: call module function (0, 0): Print
+86: logical jump if true to 88
+87: global variable #0
+88: logical convert
+89: if false goto 94
+90: "success" (string)
+91: "" (string)
+92: call module function (0, 0): Print
 

--- a/testsuite/escript/opt/shortcircuit4.optimized.out
+++ b/testsuite/escript/opt/shortcircuit4.optimized.out
@@ -7,18 +7,19 @@ success
 5: false (boolean)
 6: :=
 8: global variable #1
-9: logical jump if true to 19
+9: logical jump if true to 17
 10: global variable #0
 11: logical jump if true to 14
 12: global variable #1
 13: logical convert
 14: "" (string)
 15: call module function (0, 0): Print
-16: logical jump if true to 19
-17: global variable #0
-18: logical convert
-19: if false goto 24
-20: "success" (string)
-21: "" (string)
-22: call module function (0, 0): Print
+16: logical convert
+17: logical jump if true to 20
+18: global variable #0
+19: logical convert
+20: if false goto 25
+21: "success" (string)
+22: "" (string)
+23: call module function (0, 0): Print
 

--- a/testsuite/escript/opt/shortcircuit4.optimized.out
+++ b/testsuite/escript/opt/shortcircuit4.optimized.out
@@ -7,19 +7,18 @@ success
 5: false (boolean)
 6: :=
 8: global variable #1
-9: logical jump if true to 17
+9: logical jump if true to 16
 10: global variable #0
 11: logical jump if true to 14
 12: global variable #1
 13: logical convert
 14: "" (string)
 15: call module function (0, 0): Print
-16: logical convert
-17: logical jump if true to 20
-18: global variable #0
-19: logical convert
-20: if false goto 25
-21: "success" (string)
-22: "" (string)
-23: call module function (0, 0): Print
+16: logical jump if true to 19
+17: global variable #0
+18: logical convert
+19: if false goto 24
+20: "success" (string)
+21: "" (string)
+22: call module function (0, 0): Print
 

--- a/testsuite/escript/opt/shortcircuit4.optimized.out
+++ b/testsuite/escript/opt/shortcircuit4.optimized.out
@@ -7,14 +7,14 @@ success
 5: false (boolean)
 6: :=
 8: global variable #1
-9: logical jump if true to 16
+9: logical jump if true to 20
 10: global variable #0
 11: logical jump if true to 14
 12: global variable #1
 13: logical convert
 14: "" (string)
 15: call module function (0, 0): Print
-16: logical jump if true to 19
+16: logical jump if true to 20
 17: global variable #0
 18: logical convert
 19: if false goto 24

--- a/testsuite/escript/opt/shortcircuit5.optimized.out
+++ b/testsuite/escript/opt/shortcircuit5.optimized.out
@@ -1,0 +1,41 @@
+success
+0: declare global #0
+1: true (boolean)
+2: :=
+4: declare global #1
+5: true (boolean)
+6: :=
+8: declare global #2
+9: true (boolean)
+10: :=
+12: declare global #3
+13: false (boolean)
+14: :=
+16: declare global #4
+17: false (boolean)
+18: :=
+20: global variable #4
+21: logical jump if false to 24
+22: global variable #0
+23: logical jump if true to 37
+24: global variable #4
+25: logical jump if false to 28
+26: global variable #1
+27: logical jump if true to 37
+28: global variable #2
+29: logical jump if false to 32
+30: global variable #2
+31: logical jump if true to 37
+32: global variable #4
+33: logical jump if false to 42
+34: global variable #3
+35: logical convert
+36: if false goto 42
+37: "success" (string)
+38: "" (string)
+39: call module function (0, 0): Print
+41: goto 46
+42: "failed" (string)
+43: "" (string)
+44: call module function (0, 0): Print
+

--- a/testsuite/escript/opt/shortcircuit5.out
+++ b/testsuite/escript/opt/shortcircuit5.out
@@ -1,0 +1,1 @@
+success

--- a/testsuite/escript/opt/shortcircuit5.out
+++ b/testsuite/escript/opt/shortcircuit5.out
@@ -1,1 +1,40 @@
 success
+0: declare global #0
+1: true (boolean)
+2: :=
+4: declare global #1
+5: true (boolean)
+6: :=
+8: declare global #2
+9: true (boolean)
+10: :=
+12: declare global #3
+13: false (boolean)
+14: :=
+16: declare global #4
+17: false (boolean)
+18: :=
+20: global variable #4
+21: global variable #0
+22: && (logical and)
+23: global variable #4
+24: global variable #1
+25: && (logical and)
+26: || (logical or)
+27: global variable #2
+28: global variable #2
+29: && (logical and)
+30: || (logical or)
+31: global variable #4
+32: global variable #3
+33: && (logical and)
+34: || (logical or)
+35: if false goto 41
+36: "success" (string)
+37: "" (string)
+38: call module function (0, 0): Print
+40: goto 45
+41: "failed" (string)
+42: "" (string)
+43: call module function (0, 0): Print
+

--- a/testsuite/escript/opt/shortcircuit5.src
+++ b/testsuite/escript/opt/shortcircuit5.src
@@ -1,0 +1,16 @@
+// this will fail with the current jump optimization
+var t1 := true;
+var t2 := true;
+var t3 := true;
+var t4 := false;
+var f := false;
+if ( ( f && t1 )     //
+     || ( f && t2 )  //
+     || ( t3 && t3 ) //
+     || ( f && t4 )  //
+     )
+  print( "success" );
+else
+  print( "failed" );
+endif
+

--- a/testsuite/escript/opt/shortcircuit5.src
+++ b/testsuite/escript/opt/shortcircuit5.src
@@ -1,5 +1,5 @@
 include "listfile";
-// this will fail with the current jump optimization
+// this used to fail, (f && t2) jumped to the end
 var t1 := true;
 var t2 := true;
 var t3 := true;

--- a/testsuite/escript/opt/shortcircuit5.src
+++ b/testsuite/escript/opt/shortcircuit5.src
@@ -1,3 +1,4 @@
+include "listfile";
 // this will fail with the current jump optimization
 var t1 := true;
 var t2 := true;
@@ -13,4 +14,6 @@ if ( ( f && t1 )     //
 else
   print( "failed" );
 endif
+
+print_listfile( "shortcircuit5" );
 

--- a/testsuite/escript/opt/shortcircuit6.optimized.out
+++ b/testsuite/escript/opt/shortcircuit6.optimized.out
@@ -1,0 +1,74 @@
+=== Chained OR (2 terms): A || B ===
+PASS OR2-1: true || X  [evaluated: A]
+PASS OR2-2: false || true  [evaluated: AB]
+PASS OR2-3: false || false  [evaluated: AB]
+
+=== Chained OR (3 terms): A || B || C ===
+PASS OR3-1: true || X || X  [evaluated: A]
+PASS OR3-2: false || true || X  [evaluated: AB]
+PASS OR3-3: false || false || true  [evaluated: ABC]
+PASS OR3-4: false || false || false  [evaluated: ABC]
+
+=== Chained OR (4 terms): A || B || C || D ===
+PASS OR4-1: true || X || X || X  [evaluated: A]
+PASS OR4-2: false || true || X || X  [evaluated: AB]
+PASS OR4-3: false || false || true || X  [evaluated: ABC]
+PASS OR4-4: false*3 || true  [evaluated: ABCD]
+PASS OR4-5: false*4  [evaluated: ABCD]
+
+=== Chained OR (5 terms): A || B || C || D || E ===
+PASS OR5-1: true || X || X || X || X  [evaluated: A]
+PASS OR5-2: false || true || X || X || X  [evaluated: AB]
+PASS OR5-3: false || false || true || X || X  [evaluated: ABC]
+PASS OR5-4: false*3 || true || X  [evaluated: ABCD]
+PASS OR5-5: false*4 || true  [evaluated: ABCDE]
+PASS OR5-6: false*5  [evaluated: ABCDE]
+
+=== Chained AND (2 terms): A && B ===
+PASS AND2-1: false && X  [evaluated: A]
+PASS AND2-2: true && false  [evaluated: AB]
+PASS AND2-3: true && true  [evaluated: AB]
+
+=== Chained AND (3 terms): A && B && C ===
+PASS AND3-1: false && X && X  [evaluated: A]
+PASS AND3-2: true && false && X  [evaluated: AB]
+PASS AND3-3: true && true && false  [evaluated: ABC]
+PASS AND3-4: true && true && true  [evaluated: ABC]
+
+=== Chained AND (4 terms): A && B && C && D ===
+PASS AND4-1: false && X && X && X  [evaluated: A]
+PASS AND4-2: true && false && X && X  [evaluated: AB]
+PASS AND4-3: true && true && false && X  [evaluated: ABC]
+PASS AND4-4: true*3 && false  [evaluated: ABCD]
+PASS AND4-5: true*4  [evaluated: ABCD]
+
+=== Chained AND (5 terms): A && B && C && D && E ===
+PASS AND5-1: false && X && X && X && X  [evaluated: A]
+PASS AND5-2: true && false && X && X && X  [evaluated: AB]
+PASS AND5-3: true && true && false && X && X  [evaluated: ABC]
+PASS AND5-4: true*3 && false && X  [evaluated: ABCD]
+PASS AND5-5: true*4 && false  [evaluated: ABCDE]
+PASS AND5-6: true*5  [evaluated: ABCDE]
+
+=== Mixed precedence (5 terms): A || B && C || D && E  (== A || (B&&C) || (D&&E)) ===
+PASS MIX5A-1: true || (X&&X) || (X&&X)  [evaluated: A]
+PASS MIX5A-2: false || (true&&true) || X  [evaluated: ABC]
+PASS MIX5A-3: false || (false&&X) || (true&&true)  [evaluated: ABDE]
+PASS MIX5A-4: false || (false&&X) || (false&&X)  [evaluated: ABD]
+PASS MIX5A-5: false || (true&&false) || (false&&X)  [evaluated: ABCD]
+PASS MIX5A-6: false || (true&&false) || (true&&true)  [evaluated: ABCDE]
+
+=== Mixed precedence (5 terms): A && B || C && D || E  (== (A&&B) || (C&&D) || E) ===
+PASS MIX5B-1: (true&&true) || X || X  [evaluated: AB]
+PASS MIX5B-2: (false&&X) || (true&&true) || X  [evaluated: ACD]
+PASS MIX5B-3: (false&&X) || (false&&X) || true  [evaluated: ACE]
+PASS MIX5B-4: (false&&X) || (false&&X) || false  [evaluated: ACE]
+PASS MIX5B-5: (true&&false) || (true&&false) || true  [evaluated: ABCDE]
+PASS MIX5B-6: (true&&false) || (false&&X) || false  [evaluated: ABCE]
+
+=== Nested (5 terms): (A || B || C) && (D || E) ===
+PASS NEST5-1: (true || X || X) && (true || X)  [evaluated: AD]
+PASS NEST5-2: (false*3) && (X || X)  [evaluated: ABC]
+PASS NEST5-3: (false || true || X) && (false || true)  [evaluated: ABDE]
+PASS NEST5-4: (false || false || true) && (true || X)  [evaluated: ABCD]
+PASS NEST5-5: (false || true || X) && (false || false)  [evaluated: ABDE]

--- a/testsuite/escript/opt/shortcircuit6.out
+++ b/testsuite/escript/opt/shortcircuit6.out
@@ -1,0 +1,144 @@
+=== Chained OR (2 terms): A || B ===
+FAIL OR2-1: true || X
+      expected evaluated=A  got=AB
+      expected result=true  got=true
+PASS OR2-2: false || true  [evaluated: AB]
+PASS OR2-3: false || false  [evaluated: AB]
+
+=== Chained OR (3 terms): A || B || C ===
+FAIL OR3-1: true || X || X
+      expected evaluated=A  got=ABC
+      expected result=true  got=true
+FAIL OR3-2: false || true || X
+      expected evaluated=AB  got=ABC
+      expected result=true  got=true
+PASS OR3-3: false || false || true  [evaluated: ABC]
+PASS OR3-4: false || false || false  [evaluated: ABC]
+
+=== Chained OR (4 terms): A || B || C || D ===
+FAIL OR4-1: true || X || X || X
+      expected evaluated=A  got=ABCD
+      expected result=true  got=true
+FAIL OR4-2: false || true || X || X
+      expected evaluated=AB  got=ABCD
+      expected result=true  got=true
+FAIL OR4-3: false || false || true || X
+      expected evaluated=ABC  got=ABCD
+      expected result=true  got=true
+PASS OR4-4: false*3 || true  [evaluated: ABCD]
+PASS OR4-5: false*4  [evaluated: ABCD]
+
+=== Chained OR (5 terms): A || B || C || D || E ===
+FAIL OR5-1: true || X || X || X || X
+      expected evaluated=A  got=ABCDE
+      expected result=true  got=true
+FAIL OR5-2: false || true || X || X || X
+      expected evaluated=AB  got=ABCDE
+      expected result=true  got=true
+FAIL OR5-3: false || false || true || X || X
+      expected evaluated=ABC  got=ABCDE
+      expected result=true  got=true
+FAIL OR5-4: false*3 || true || X
+      expected evaluated=ABCD  got=ABCDE
+      expected result=true  got=true
+PASS OR5-5: false*4 || true  [evaluated: ABCDE]
+PASS OR5-6: false*5  [evaluated: ABCDE]
+
+=== Chained AND (2 terms): A && B ===
+FAIL AND2-1: false && X
+      expected evaluated=A  got=AB
+      expected result=false  got=false
+PASS AND2-2: true && false  [evaluated: AB]
+PASS AND2-3: true && true  [evaluated: AB]
+
+=== Chained AND (3 terms): A && B && C ===
+FAIL AND3-1: false && X && X
+      expected evaluated=A  got=ABC
+      expected result=false  got=false
+FAIL AND3-2: true && false && X
+      expected evaluated=AB  got=ABC
+      expected result=false  got=false
+PASS AND3-3: true && true && false  [evaluated: ABC]
+PASS AND3-4: true && true && true  [evaluated: ABC]
+
+=== Chained AND (4 terms): A && B && C && D ===
+FAIL AND4-1: false && X && X && X
+      expected evaluated=A  got=ABCD
+      expected result=false  got=false
+FAIL AND4-2: true && false && X && X
+      expected evaluated=AB  got=ABCD
+      expected result=false  got=false
+FAIL AND4-3: true && true && false && X
+      expected evaluated=ABC  got=ABCD
+      expected result=false  got=false
+PASS AND4-4: true*3 && false  [evaluated: ABCD]
+PASS AND4-5: true*4  [evaluated: ABCD]
+
+=== Chained AND (5 terms): A && B && C && D && E ===
+FAIL AND5-1: false && X && X && X && X
+      expected evaluated=A  got=ABCDE
+      expected result=false  got=false
+FAIL AND5-2: true && false && X && X && X
+      expected evaluated=AB  got=ABCDE
+      expected result=false  got=false
+FAIL AND5-3: true && true && false && X && X
+      expected evaluated=ABC  got=ABCDE
+      expected result=false  got=false
+FAIL AND5-4: true*3 && false && X
+      expected evaluated=ABCD  got=ABCDE
+      expected result=false  got=false
+PASS AND5-5: true*4 && false  [evaluated: ABCDE]
+PASS AND5-6: true*5  [evaluated: ABCDE]
+
+=== Mixed precedence (5 terms): A || B && C || D && E  (== A || (B&&C) || (D&&E)) ===
+FAIL MIX5A-1: true || (X&&X) || (X&&X)
+      expected evaluated=A  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5A-2: false || (true&&true) || X
+      expected evaluated=ABC  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5A-3: false || (false&&X) || (true&&true)
+      expected evaluated=ABDE  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5A-4: false || (false&&X) || (false&&X)
+      expected evaluated=ABD  got=ABCDE
+      expected result=false  got=false
+FAIL MIX5A-5: false || (true&&false) || (false&&X)
+      expected evaluated=ABCD  got=ABCDE
+      expected result=false  got=false
+PASS MIX5A-6: false || (true&&false) || (true&&true)  [evaluated: ABCDE]
+
+=== Mixed precedence (5 terms): A && B || C && D || E  (== (A&&B) || (C&&D) || E) ===
+FAIL MIX5B-1: (true&&true) || X || X
+      expected evaluated=AB  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5B-2: (false&&X) || (true&&true) || X
+      expected evaluated=ACD  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5B-3: (false&&X) || (false&&X) || true
+      expected evaluated=ACE  got=ABCDE
+      expected result=true  got=true
+FAIL MIX5B-4: (false&&X) || (false&&X) || false
+      expected evaluated=ACE  got=ABCDE
+      expected result=false  got=false
+PASS MIX5B-5: (true&&false) || (true&&false) || true  [evaluated: ABCDE]
+FAIL MIX5B-6: (true&&false) || (false&&X) || false
+      expected evaluated=ABCE  got=ABCDE
+      expected result=false  got=false
+
+=== Nested (5 terms): (A || B || C) && (D || E) ===
+FAIL NEST5-1: (true || X || X) && (true || X)
+      expected evaluated=AD  got=ABCDE
+      expected result=true  got=true
+FAIL NEST5-2: (false*3) && (X || X)
+      expected evaluated=ABC  got=ABCDE
+      expected result=false  got=false
+FAIL NEST5-3: (false || true || X) && (false || true)
+      expected evaluated=ABDE  got=ABCDE
+      expected result=true  got=true
+FAIL NEST5-4: (false || false || true) && (true || X)
+      expected evaluated=ABCD  got=ABCDE
+      expected result=true  got=true
+FAIL NEST5-5: (false || true || X) && (false || false)
+      expected evaluated=ABDE  got=ABCDE
+      expected result=false  got=false

--- a/testsuite/escript/opt/shortcircuit6.src
+++ b/testsuite/escript/opt/shortcircuit6.src
@@ -1,0 +1,646 @@
+var call_log := "";
+
+function mk( id, val )
+  call_log := call_log + id;
+  return val;
+endfunction
+
+function reset()
+  call_log := "";
+endfunction
+
+function check( test_name, expr_desc, expected_log, actual_result, expected_result )
+  if ( call_log == expected_log && actual_result == expected_result )
+    print( $"PASS {test_name}: {expr_desc}  [evaluated: {call_log}]" );
+  else
+    print( $"FAIL {test_name}: {expr_desc}" );
+    print( $"      expected evaluated={expected_log}  got={call_log}" );
+    print( $"      expected result={expected_result}  got={actual_result}" );
+  endif
+endfunction
+
+var test_name := "";
+var expr_desc := "";
+var expected_log := "";
+var expected_result := false;
+
+print( "=== Chained OR (2 terms): A || B ===" );
+
+reset();
+test_name := "OR2-1";
+expr_desc := "true || X";
+expected_log := "A";
+expected_result := true;
+if ( mk( "A", true ) || mk( "B", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR2-2";
+expr_desc := "false || true";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR2-3";
+expr_desc := "false || false";
+expected_log := "AB";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained OR (3 terms): A || B || C ===" );
+
+reset();
+test_name := "OR3-1";
+expr_desc := "true || X || X";
+expected_log := "A";
+expected_result := true;
+if ( mk( "A", true ) || mk( "B", true ) || mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR3-2";
+expr_desc := "false || true || X";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) || mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR3-3";
+expr_desc := "false || false || true";
+expected_log := "ABC";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR3-4";
+expr_desc := "false || false || false";
+expected_log := "ABC";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained OR (4 terms): A || B || C || D ===" );
+
+reset();
+test_name := "OR4-1";
+expr_desc := "true || X || X || X";
+expected_log := "A";
+expected_result := true;
+if ( mk( "A", true ) || mk( "B", true ) || mk( "C", true ) || mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR4-2";
+expr_desc := "false || true || X || X";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) || mk( "C", true ) || mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR4-3";
+expr_desc := "false || false || true || X";
+expected_log := "ABC";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", true ) || mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR4-4";
+expr_desc := "false*3 || true";
+expected_log := "ABCD";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) || mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR4-5";
+expr_desc := "false*4";
+expected_log := "ABCD";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) || mk( "D", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained OR (5 terms): A || B || C || D || E ===" );
+
+reset();
+test_name := "OR5-1";
+expr_desc := "true || X || X || X || X";
+expected_log := "A";
+expected_result := true;
+if ( mk( "A", true ) || mk( "B", true ) || mk( "C", true ) || mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR5-2";
+expr_desc := "false || true || X || X || X";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) || mk( "C", true ) || mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR5-3";
+expr_desc := "false || false || true || X || X";
+expected_log := "ABC";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", true ) || mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR5-4";
+expr_desc := "false*3 || true || X";
+expected_log := "ABCD";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) || mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR5-5";
+expr_desc := "false*4 || true";
+expected_log := "ABCDE";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) || mk( "D", false ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "OR5-6";
+expr_desc := "false*5";
+expected_log := "ABCDE";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) || mk( "D", false ) || mk( "E", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained AND (2 terms): A && B ===" );
+
+reset();
+test_name := "AND2-1";
+expr_desc := "false && X";
+expected_log := "A";
+expected_result := false;
+if ( mk( "A", false ) && mk( "B", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND2-2";
+expr_desc := "true && false";
+expected_log := "AB";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND2-3";
+expr_desc := "true && true";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained AND (3 terms): A && B && C ===" );
+
+reset();
+test_name := "AND3-1";
+expr_desc := "false && X && X";
+expected_log := "A";
+expected_result := false;
+if ( mk( "A", false ) && mk( "B", true ) && mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND3-2";
+expr_desc := "true && false && X";
+expected_log := "AB";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", false ) && mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND3-3";
+expr_desc := "true && true && false";
+expected_log := "ABC";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND3-4";
+expr_desc := "true && true && true";
+expected_log := "ABC";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained AND (4 terms): A && B && C && D ===" );
+
+reset();
+test_name := "AND4-1";
+expr_desc := "false && X && X && X";
+expected_log := "A";
+expected_result := false;
+if ( mk( "A", false ) && mk( "B", true ) && mk( "C", true ) && mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND4-2";
+expr_desc := "true && false && X && X";
+expected_log := "AB";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", false ) && mk( "C", true ) && mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND4-3";
+expr_desc := "true && true && false && X";
+expected_log := "ABC";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", false ) && mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND4-4";
+expr_desc := "true*3 && false";
+expected_log := "ABCD";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) && mk( "D", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND4-5";
+expr_desc := "true*4";
+expected_log := "ABCD";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) && mk( "D", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Chained AND (5 terms): A && B && C && D && E ===" );
+
+reset();
+test_name := "AND5-1";
+expr_desc := "false && X && X && X && X";
+expected_log := "A";
+expected_result := false;
+if ( mk( "A", false ) && mk( "B", true ) && mk( "C", true ) && mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND5-2";
+expr_desc := "true && false && X && X && X";
+expected_log := "AB";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", false ) && mk( "C", true ) && mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND5-3";
+expr_desc := "true && true && false && X && X";
+expected_log := "ABC";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", false ) && mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND5-4";
+expr_desc := "true*3 && false && X";
+expected_log := "ABCD";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) && mk( "D", false ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND5-5";
+expr_desc := "true*4 && false";
+expected_log := "ABCDE";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) && mk( "D", true ) && mk( "E", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "AND5-6";
+expr_desc := "true*5";
+expected_log := "ABCDE";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", true ) && mk( "C", true ) && mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Mixed precedence (5 terms): A || B && C || D && E  (== A || (B&&C) || (D&&E)) ===" );
+
+reset();
+test_name := "MIX5A-1";
+expr_desc := "true || (X&&X) || (X&&X)";
+expected_log := "A";
+expected_result := true;
+if ( mk( "A", true ) || mk( "B", true ) && mk( "C", true ) || mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5A-2";
+expr_desc := "false || (true&&true) || X";
+expected_log := "ABC";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) && mk( "C", true ) || mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5A-3";
+expr_desc := "false || (false&&X) || (true&&true)";
+expected_log := "ABDE";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", false ) && mk( "C", true ) || mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5A-4";
+expr_desc := "false || (false&&X) || (false&&X)";
+expected_log := "ABD";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", false ) && mk( "C", true ) || mk( "D", false ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5A-5";
+expr_desc := "false || (true&&false) || (false&&X)";
+expected_log := "ABCD";
+expected_result := false;
+if ( mk( "A", false ) || mk( "B", true ) && mk( "C", false ) || mk( "D", false ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5A-6";
+expr_desc := "false || (true&&false) || (true&&true)";
+expected_log := "ABCDE";
+expected_result := true;
+if ( mk( "A", false ) || mk( "B", true ) && mk( "C", false ) || mk( "D", true ) && mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Mixed precedence (5 terms): A && B || C && D || E  (== (A&&B) || (C&&D) || E) ===" );
+
+reset();
+test_name := "MIX5B-1";
+expr_desc := "(true&&true) || X || X";
+expected_log := "AB";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", true ) || mk( "C", true ) && mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5B-2";
+expr_desc := "(false&&X) || (true&&true) || X";
+expected_log := "ACD";
+expected_result := true;
+if ( mk( "A", false ) && mk( "B", true ) || mk( "C", true ) && mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5B-3";
+expr_desc := "(false&&X) || (false&&X) || true";
+expected_log := "ACE";
+expected_result := true;
+if ( mk( "A", false ) && mk( "B", true ) || mk( "C", false ) && mk( "D", true ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5B-4";
+expr_desc := "(false&&X) || (false&&X) || false";
+expected_log := "ACE";
+expected_result := false;
+if ( mk( "A", false ) && mk( "B", true ) || mk( "C", false ) && mk( "D", true ) || mk( "E", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5B-5";
+expr_desc := "(true&&false) || (true&&false) || true";
+expected_log := "ABCDE";
+expected_result := true;
+if ( mk( "A", true ) && mk( "B", false ) || mk( "C", true ) && mk( "D", false ) || mk( "E", true ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "MIX5B-6";
+expr_desc := "(true&&false) || (false&&X) || false";
+expected_log := "ABCE";
+expected_result := false;
+if ( mk( "A", true ) && mk( "B", false ) || mk( "C", false ) && mk( "D", true ) || mk( "E", false ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+print( "" );
+print( "=== Nested (5 terms): (A || B || C) && (D || E) ===" );
+
+reset();
+test_name := "NEST5-1";
+expr_desc := "(true || X || X) && (true || X)";
+expected_log := "AD";
+expected_result := true;
+if ( ( mk( "A", true ) || mk( "B", true ) || mk( "C", true ) ) && ( mk( "D", true ) ||
+     mk( "E", true ) ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "NEST5-2";
+expr_desc := "(false*3) && (X || X)";
+expected_log := "ABC";
+expected_result := false;
+if ( ( mk( "A", false ) || mk( "B", false ) || mk( "C", false ) ) && ( mk( "D", true ) ||
+     mk( "E", true ) ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "NEST5-3";
+expr_desc := "(false || true || X) && (false || true)";
+expected_log := "ABDE";
+expected_result := true;
+if ( ( mk( "A", false ) || mk( "B", true ) || mk( "C", true ) ) && ( mk( "D", false ) ||
+     mk( "E", true ) ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "NEST5-4";
+expr_desc := "(false || false || true) && (true || X)";
+expected_log := "ABCD";
+expected_result := true;
+if ( ( mk( "A", false ) || mk( "B", false ) || mk( "C", true ) ) && ( mk( "D", true ) ||
+     mk( "E", true ) ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+
+reset();
+test_name := "NEST5-5";
+expr_desc := "(false || true || X) && (false || false)";
+expected_log := "ABDE";
+expected_result := false;
+if ( ( mk( "A", false ) || mk( "B", true ) || mk( "C", true ) ) && ( mk( "D", false ) ||
+     mk( "E", false ) ) )
+  check( test_name, expr_desc, expected_log, true, expected_result );
+else
+  check( test_name, expr_desc, expected_log, false, expected_result );
+endif
+


### PR DESCRIPTION
Fixes #800 
The shared jump logic fails after the third ShortCircuit and jumps completely to the end.
Added minimal reproducer as test.

Fixed it by iterating over the bytecode rather then the ast to find consecutive jumps.