### PR TITLE
Improve single threaded login

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -1001,7 +1001,6 @@ PidFilePath=(where POL will write its .pid file {default ./})
 [MaxAnimID=(0x800/0xFFFFFFFF {default 0x800})]
 [DiscardOldEvents=(1/0 {default 0})]
 [UseSingleThreadLogin=(1/0 {default 1})]
-[LoginServerSelectTimeout=(int {default 1})]
 [StalledPeerTimeout=(int seconds {default 60})]
 [DisableNagle=(1/0 {default 0})]
 [ShowRealmInfo=(1/0 {default 0})]

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,14 +8,17 @@
 		<entry>
 			<date>07-27-2026</date>
 			<author>Nando:</author>
-			<change type="Fixed">Clients connecting at the same time were let in slowly, and the delay grew<br/>
-with the square of how many were waiting. Each pass of a UO listener accepted<br/>
-only one connection, and a pass also polls every client still on the login<br/>
-server, so each new connection waited for all the earlier ones to be polled<br/>
-first. A listener now accepts every connection already queued, up to 64 per<br/>
-pass. Measured on loopback, admitting 75 simultaneous connections went from<br/>
-28.7 to 1.2 seconds. This is most visible right after a restart, when many<br/>
-players reconnect at once.</change>
+			<change type="Fixed">Logging in was slow, and got slower the more players were logging in at the<br/>
+same time. A UO listener waited on each client still on the login server one<br/>
+after another, and accepted only one new connection per pass, so every client<br/>
+waited for all the others to be checked first. A listener now waits on all of<br/>
+them at once and accepts every connection already queued. Measured on<br/>
+loopback with 75 clients on the login server: a login packet went from 247ms<br/>
+to 0.8ms, and admitting 75 connections went from 28.7 to 0.8 seconds. This is<br/>
+most visible right after a restart, when many players reconnect at once.</change>
+			<change type="Removed">pol.cfg LoginServerSelectTimeout. It bounded a wait the login server paid<br/>
+once per waiting client, which no longer happens. Leaving the setting in<br/>
+pol.cfg is harmless, it is simply ignored.</change>
 			<change type="Added">pol.cfg StalledPeerTimeout (seconds, default 60) sets how long a peer may<br/>
 accept no data at all before the core closes the connection. It applies to<br/>
 both places that wait one out: aux service / os::OpenConnection() transmits<br/>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -8,6 +8,14 @@
 		<entry>
 			<date>07-27-2026</date>
 			<author>Nando:</author>
+			<change type="Fixed">Clients connecting at the same time were let in slowly, and the delay grew<br/>
+with the square of how many were waiting. Each pass of a UO listener accepted<br/>
+only one connection, and a pass also polls every client still on the login<br/>
+server, so each new connection waited for all the earlier ones to be polled<br/>
+first. A listener now accepts every connection already queued, up to 64 per<br/>
+pass. Measured on loopback, admitting 75 simultaneous connections went from<br/>
+28.7 to 1.2 seconds. This is most visible right after a restart, when many<br/>
+players reconnect at once.</change>
 			<change type="Added">pol.cfg StalledPeerTimeout (seconds, default 60) sets how long a peer may<br/>
 accept no data at all before the core closes the connection. It applies to<br/>
 both places that wait one out: aux service / os::OpenConnection() transmits<br/>

--- a/pol-core/clib/CMakeSources.cmake
+++ b/pol-core/clib/CMakeSources.cmake
@@ -49,6 +49,7 @@ set (clib_sources
   message_queue.h
   mlog.cpp 
   mlog.h
+  network/multipoller.h
   network/singlepoller.h
   network/singlepollers/pollingwithpoll.h
   network/sockets.h

--- a/pol-core/clib/network/multipoller.h
+++ b/pol-core/clib/network/multipoller.h
@@ -1,0 +1,91 @@
+#pragma once
+#ifndef H_MULTIPOLLER
+#define H_MULTIPOLLER
+
+#include <chrono>
+#include <vector>
+
+#include "clib/network/sockets.h"
+
+// for the poll()/nfds_t compatibility wrappers
+#include "clib/network/singlepollers/pollingwithpoll.h"
+
+
+namespace Pol::Clib
+{
+// What the last wait() reported about one socket.
+struct PollResult
+{
+  bool incoming = false;
+  bool writable = false;
+  bool error = false;
+};
+
+// Waits on several sockets at once, where SinglePoller waits on one.
+//
+// Use it when the sockets would otherwise be waited on one after another in a
+// single thread: N separate waits cost N timeouts and only notice the last
+// socket after inspecting all the others, while one wait over all of them
+// returns as soon as any is ready. Sockets already being waited on by their
+// own threads gain nothing from this - there each thread has to block on
+// something anyway, and batching would only make every wakeup scan every
+// socket.
+//
+// Rebuild it each pass: add() the sockets, wait() once, then read each back
+// with the index add() returned.
+class MultiPoller
+{
+public:
+  void clear() { _fds.clear(); }
+  bool empty() const { return _fds.empty(); }
+  size_t size() const { return _fds.size(); }
+
+  // Returns the index to pass to result(). Errors are always reported, so
+  // there is no flag for them (poll() does not need to be asked).
+  size_t add( SOCKET socket, bool notify_writable )
+  {
+    pollfd entry;
+    entry.fd = socket;
+    entry.events = static_cast<short>( POLLIN | ( notify_writable ? POLLOUT : 0 ) );
+    entry.revents = 0;
+    _fds.push_back( entry );
+    return _fds.size() - 1;
+  }
+
+  // <0 on error, 0 if the timeout expired, otherwise the number of sockets
+  // with something to report.
+  int wait( std::chrono::milliseconds timeout )
+  {
+    _processed = false;
+    if ( _fds.empty() )
+      return 0;
+
+    // The one place a duration becomes the plain integer milliseconds poll()
+    // wants; see pollingwithpoll.h for why an int is always enough.
+    int res = poll( _fds.data(), static_cast<nfds_t>( _fds.size() ),
+                    static_cast<int>( timeout.count() ) );
+
+    // only trust the revents if the wait itself succeeded
+    if ( res >= 0 )
+      _processed = true;
+
+    return res;
+  }
+
+  PollResult result( size_t index ) const
+  {
+    if ( !_processed || index >= _fds.size() )
+      return {};
+
+    const short revents = _fds[index].revents;
+    return { ( revents & POLLIN ) != 0, ( revents & POLLOUT ) != 0,
+             ( revents & ( POLLHUP | POLLERR | POLLNVAL ) ) != 0 };
+  }
+
+private:
+  std::vector<pollfd> _fds;
+  bool _processed = false;
+};
+}  // namespace Pol::Clib
+
+#endif

--- a/pol-core/clib/network/singlepollers/pollingwithpoll.h
+++ b/pol-core/clib/network/singlepollers/pollingwithpoll.h
@@ -9,8 +9,10 @@
 
 #ifdef _WIN32
 
-// compatibility wrapper for windows
-inline int poll( struct pollfd* fds, ULONG nfds, int timeout )
+// compatibility wrappers for windows
+using nfds_t = ULONG;
+
+inline int poll( struct pollfd* fds, nfds_t nfds, int timeout )
 {
   return WSAPoll( fds, nfds, timeout );
 };

--- a/pol-core/clib/network/socketsvc.h
+++ b/pol-core/clib/network/socketsvc.h
@@ -19,7 +19,18 @@ class SocketListener
 public:
   explicit SocketListener( unsigned short port, bool loopback_only = false );
   SocketListener( unsigned short port, Socket::option opt, bool loopback_only = false );
+
+  // Waits for a connection and takes it. Callers that have other sockets to
+  // wait on at the same time should instead poll listen_socket() themselves
+  // and call Accept() when it reports something.
   bool GetConnection( Socket* newsck, std::chrono::milliseconds timeout );
+
+  SOCKET listen_socket() const { return _listen_sck.handle(); }
+
+  // Takes an already-pending connection without waiting first. Only call this
+  // after the listen socket reported incoming data; on a listener opened
+  // without Socket::nonblocking it would otherwise block until one arrives.
+  bool Accept( Socket* newsck ) { return _listen_sck.accept( newsck ); }
 
   friend class SocketClientThread;
 

--- a/pol-core/clib/network/wnsckt.cpp
+++ b/pol-core/clib/network/wnsckt.cpp
@@ -24,6 +24,8 @@
 
 namespace Pol::Clib
 {
+using namespace std::chrono_literals;
+
 namespace
 {
 // Read by every StallBudget on every socket thread, written once at startup and again on
@@ -524,7 +526,7 @@ bool Socket::send( const void* vdata, unsigned length )
   // This blocks the calling thread until the peer drains its receive buffer, so it is only
   // ever called from threads that may block: aux transmits and the webserver's file
   // streaming, never from the scripts thread.
-  constexpr auto wait_slice = std::chrono::milliseconds( 500 );
+  constexpr auto wait_slice = 500ms;
   StallBudget budget;
 
   while ( datalen )

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,5 +1,13 @@
 -- POL100.3.0 --
 07-27-2026 Nando:
+    Fixed: Clients connecting at the same time were let in slowly, and the delay grew
+           with the square of how many were waiting. Each pass of a UO listener accepted
+           only one connection, and a pass also polls every client still on the login
+           server, so each new connection waited for all the earlier ones to be polled
+           first. A listener now accepts every connection already queued, up to 64 per
+           pass. Measured on loopback, admitting 75 simultaneous connections went from
+           28.7 to 1.2 seconds. This is most visible right after a restart, when many
+           players reconnect at once.
     Added: pol.cfg StalledPeerTimeout (seconds, default 60) sets how long a peer may
            accept no data at all before the core closes the connection. It applies to
            both places that wait one out: aux service / os::OpenConnection() transmits

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,13 +1,16 @@
 -- POL100.3.0 --
 07-27-2026 Nando:
-    Fixed: Clients connecting at the same time were let in slowly, and the delay grew
-           with the square of how many were waiting. Each pass of a UO listener accepted
-           only one connection, and a pass also polls every client still on the login
-           server, so each new connection waited for all the earlier ones to be polled
-           first. A listener now accepts every connection already queued, up to 64 per
-           pass. Measured on loopback, admitting 75 simultaneous connections went from
-           28.7 to 1.2 seconds. This is most visible right after a restart, when many
-           players reconnect at once.
+    Fixed: Logging in was slow, and got slower the more players were logging in at the
+           same time. A UO listener waited on each client still on the login server one
+           after another, and accepted only one new connection per pass, so every client
+           waited for all the others to be checked first. A listener now waits on all of
+           them at once and accepts every connection already queued. Measured on
+           loopback with 75 clients on the login server: a login packet went from 247ms
+           to 0.8ms, and admitting 75 connections went from 28.7 to 0.8 seconds. This is
+           most visible right after a restart, when many players reconnect at once.
+  Removed: pol.cfg LoginServerSelectTimeout. It bounded a wait the login server paid
+           once per waiting client, which no longer happens. Leaving the setting in
+           pol.cfg is harmless, it is simply ignored.
     Added: pol.cfg StalledPeerTimeout (seconds, default 60) sets how long a peer may
            accept no data at all before the core closes the connection. It applies to
            both places that wait one out: aux service / os::OpenConnection() transmits

--- a/pol-core/ecompile/ECompileMain.cpp
+++ b/pol-core/ecompile/ECompileMain.cpp
@@ -1,5 +1,6 @@
 #include "ecompile/ECompileMain.h"
 
+#include <chrono>
 #include <cstdio>
 #include <exception>
 #include <filesystem>
@@ -46,6 +47,7 @@ namespace fs = std::filesystem;
 using namespace Pol::Core;
 using namespace Pol::Plib;
 using namespace Pol::Bscript;
+using namespace std::chrono_literals;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -979,7 +981,7 @@ void EnterWatchMode()
 
   while ( !Clib::exit_signalled )
   {
-    std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+    std::this_thread::sleep_for( 1s );
     listener.take_messages( watch_messages );
     if ( !watch_messages.empty() )
     {

--- a/pol-core/plib/polcfg.cpp
+++ b/pol-core/plib/polcfg.cpp
@@ -99,7 +99,6 @@ void PolConfig::read( bool initial_load )
   verbose = elem.remove_bool( "Verbose", false );
   watch_mapcache = elem.remove_bool( "WatchMapCache", false );
   loglevel = elem.remove_ushort( "LogLevel", 0 );
-  loginserver_select_timeout_msecs = elem.remove_ushort( "LoginServerSelectTimeout", 1 );
   loginserver_timeout_mins = elem.remove_ushort( "LoginServerTimeout", 10 );
   // floored at one second: zero would drop a peer the moment its buffer filled once
   stalled_peer_timeout_secs =

--- a/pol-core/plib/polcfg.h
+++ b/pol-core/plib/polcfg.h
@@ -27,7 +27,6 @@ struct PolConfig
   std::string pidfile_path;
   std::atomic<bool> verbose;
   std::atomic<unsigned short> loglevel;  // 0=nothing 10=lots
-  unsigned short loginserver_select_timeout_msecs;
   unsigned short loginserver_timeout_mins;
   unsigned short stalled_peer_timeout_secs;
   bool watch_rpm;

--- a/pol-core/pol/network/auxclient.cpp
+++ b/pol-core/pol/network/auxclient.cpp
@@ -246,7 +246,7 @@ void AuxClientThread::run()
   // last one still inside transmit(). This keeps the tasks (which capture
   // `this`) from outliving the object, whose destruction closes the socket.
   while ( !Clib::exit_signalled && _transmit_counter > 0 )
-    std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+    std::this_thread::sleep_for( 1s );
 
   Core::PolLock lock;
   // hold also the transmit mutex, the counter syncs but not in a way that the threadsanitizer

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -55,45 +55,11 @@ void call_chr_scripts( Mobile::Character* chr, const std::string& root_script_ec
 void report_weird_packet( Network::ThreadedClient* session,
                           const std::string& why );  // Defined below
 
-// LoginServerSelectTimeout is configured in milliseconds
-std::chrono::milliseconds polling_timeout( bool single_threaded_login )
+constexpr auto polling_timeout = std::chrono::milliseconds( 2000 );
+
+bool threadedclient_io_step( Network::ThreadedClient* session, SocketReadiness ready, int& nidle )
 {
-  return std::chrono::milliseconds(
-      single_threaded_login ? Plib::systemstate.config.loginserver_select_timeout_msecs : 2000 );
-}
-
-// Taking a reference to SinglePoller is ugly here. But io_step, io_loop and clientpoller will
-// eventually move into the same class.
-bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePoller& clientpoller,
-                             int& nidle )
-{
-  SESSION_CHECKPOINT( 1 );
-  if ( !clientpoller.prepare( session->have_queued_data() ) )
-  {
-    POLLOG_INFO( "Client#{}: ERROR - couldn't poll socket={}\n", session->myClient.instance_,
-                 session->csocket );
-
-    if ( session->csocket != INVALID_SOCKET )
-      session->forceDisconnect();
-
-    return false;
-  }
-
-  int res = 0;
-  do
-  {
-    SESSION_CHECKPOINT( 2 );
-    res = clientpoller.wait_for_events();
-    SESSION_CHECKPOINT( 3 );
-  } while ( res < 0 && !Clib::exit_signalled && Clib::socket_errno() == Clib::sockerr::intr );
-
-  if ( res < 0 )
-  {
-    int sckerr = Clib::socket_errno();
-    POLLOGLN( "Client#{}: select res={}, sckerr={}", session->myClient.instance_, res, sckerr );
-    return false;
-  }
-  if ( res == 0 )
+  if ( ready.timed_out )
   {
     if ( session->myClient.should_check_idle() )
     {
@@ -115,7 +81,7 @@ bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePolle
   if ( !session->isReallyConnected() )
     return false;
 
-  if ( clientpoller.error() )
+  if ( ready.error )
   {
     session->forceDisconnect();
     return false;
@@ -129,7 +95,7 @@ bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePolle
   }
   // endregion Speedhack
 
-  if ( clientpoller.incoming() )
+  if ( ready.incoming )
   {
     SESSION_CHECKPOINT( 6 );
     if ( process_data( session ) )
@@ -159,7 +125,7 @@ bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePolle
     return false;
   }
 
-  if ( session->have_queued_data() && clientpoller.writable() )
+  if ( session->have_queued_data() && ready.writable )
   {
     PolLock lck;
     SESSION_CHECKPOINT( 8 );
@@ -170,18 +136,57 @@ bool threadedclient_io_step( Network::ThreadedClient* session, Clib::SinglePolle
   return true;
 }  // namespace Pol::Core
 
-void threadedclient_io_loop( Network::ThreadedClient* session, bool login )
+// Waits on this one client's socket. Returns false if the wait itself failed,
+// in which case the client has been disconnected and there is nothing to run.
+bool threadedclient_wait( Network::ThreadedClient* session, Clib::SinglePoller& clientpoller,
+                          SocketReadiness* ready )
+{
+  SESSION_CHECKPOINT( 1 );
+  if ( !clientpoller.prepare( session->have_queued_data() ) )
+  {
+    POLLOG_INFO( "Client#{}: ERROR - couldn't poll socket={}\n", session->myClient.instance_,
+                 session->csocket );
+
+    if ( session->csocket != INVALID_SOCKET )
+      session->forceDisconnect();
+
+    return false;
+  }
+
+  int res = 0;
+  do
+  {
+    SESSION_CHECKPOINT( 2 );
+    res = clientpoller.wait_for_events();
+    SESSION_CHECKPOINT( 3 );
+  } while ( res < 0 && !Clib::exit_signalled && Clib::socket_errno() == Clib::sockerr::intr );
+
+  if ( res < 0 )
+  {
+    int sckerr = Clib::socket_errno();
+    POLLOGLN( "Client#{}: select res={}, sckerr={}", session->myClient.instance_, res, sckerr );
+    return false;
+  }
+
+  *ready = { clientpoller.incoming(), clientpoller.writable(), clientpoller.error(), res == 0 };
+  return true;
+}
+
+void threadedclient_io_loop( Network::ThreadedClient* session )
 {
   int nidle = 0;
   session->last_packet_at = polclock();
   session->last_activity_at = polclock();
 
   Clib::SinglePoller clientpoller( session->csocket );
-  clientpoller.set_timeout( polling_timeout( login ) );
+  clientpoller.set_timeout( polling_timeout );
 
   while ( !Clib::exit_signalled && session->isReallyConnected() )
   {
-    if ( !threadedclient_io_step( session, clientpoller, nidle ) || login )
+    SocketReadiness ready;
+    if ( !threadedclient_wait( session, clientpoller, &ready ) )
+      break;
+    if ( !threadedclient_io_step( session, ready, nidle ) )
       break;
   }
 }
@@ -221,38 +226,16 @@ void threadedclient_io_finalize( Network::ThreadedClient* session )
   }
 }
 
-bool client_io_thread( Network::Client* client, bool login )
+void report_io_exception( Network::Client* client, const std::string& what )
 {
-  if ( !login && Plib::systemstate.config.loglevel >= 11 )
-  {
-    POLLOGLN( "Network::Client#{} i/o thread starting", client->instance_ );
-  }
+  POLLOG_ERRORLN( "Client#{}: Exception in i/o thread: {}! (checkpoint={})", client->instance_,
+                  what, client->session()->checkpoint );
+}
 
-  CLIENT_CHECKPOINT( 0 );
-  try
-  {
-    threadedclient_io_loop( client->session(), login );
-  }
-  catch ( std::string& str )
-  {
-    POLLOG_ERRORLN( "Client#{}: Exception in i/o thread: {}! (checkpoint={})", client->instance_,
-                    str, client->session()->checkpoint );
-  }
-  catch ( const char* msg )
-  {
-    POLLOG_ERRORLN( "Client#{}: Exception in i/o thread: {}! (checkpoint={})", client->instance_,
-                    msg, client->session()->checkpoint );
-  }
-  catch ( std::exception& ex )
-  {
-    POLLOG_ERRORLN( "Client#{}: Exception in i/o thread: {}! (checkpoint={})", client->instance_,
-                    ex.what(), client->session()->checkpoint );
-  }
-  CLIENT_CHECKPOINT( 20 );
-
-  if ( login && client->isConnected() )
-    return true;
-
+// Logs the client off and hands it over to be deleted. Always returns false,
+// so callers can say `return client_io_done( client );`.
+bool client_io_done( Network::Client* client )
+{
   POLLOGLN( "Client#{} ({}): disconnected (account {})", client->instance_,
             client->ipaddrAsString(),
             ( ( client->acct != nullptr ) ? client->acct->name() : "unknown" ) );
@@ -270,6 +253,72 @@ bool client_io_thread( Network::Client* client, bool login )
   // queue delete of client ptr see method doc for reason
   Core::networkManager.clientTransmit->QueueDelete( client );
   return false;
+}
+
+bool client_io_thread( Network::Client* client )
+{
+  if ( Plib::systemstate.config.loglevel >= 11 )
+  {
+    POLLOGLN( "Network::Client#{} i/o thread starting", client->instance_ );
+  }
+
+  CLIENT_CHECKPOINT( 0 );
+  try
+  {
+    threadedclient_io_loop( client->session() );
+  }
+  catch ( std::string& str )
+  {
+    report_io_exception( client, str );
+  }
+  catch ( const char* msg )
+  {
+    report_io_exception( client, msg );
+  }
+  catch ( std::exception& ex )
+  {
+    report_io_exception( client, ex.what() );
+  }
+  CLIENT_CHECKPOINT( 20 );
+
+  return client_io_done( client );
+}
+
+bool client_io_login_step( Network::Client* client, SocketReadiness ready )
+{
+  auto* session = client->session();
+
+  CLIENT_CHECKPOINT( 0 );
+  try
+  {
+    // A login client only ever runs one pass per call, so nidle never gets
+    // anywhere: the idle warn/disconnect belongs to the threaded loop, and
+    // LoginServerTimeout is what bounds a client's stay on the login server.
+    int nidle = 0;
+    session->last_packet_at = polclock();
+    session->last_activity_at = polclock();
+
+    if ( !Clib::exit_signalled && session->isReallyConnected() )
+      threadedclient_io_step( session, ready, nidle );
+  }
+  catch ( std::string& str )
+  {
+    report_io_exception( client, str );
+  }
+  catch ( const char* msg )
+  {
+    report_io_exception( client, msg );
+  }
+  catch ( std::exception& ex )
+  {
+    report_io_exception( client, ex.what() );
+  }
+  CLIENT_CHECKPOINT( 20 );
+
+  if ( client->isConnected() )
+    return true;
+
+  return client_io_done( client );
 }
 
 bool valid_message_length( Network::ThreadedClient* session, unsigned int length )

--- a/pol-core/pol/network/clientthread.cpp
+++ b/pol-core/pol/network/clientthread.cpp
@@ -47,6 +47,8 @@
 
 namespace Pol::Core
 {
+using namespace std::chrono_literals;
+
 // This function below is defined (for now) in pol.cpp. That's ugly.
 void call_chr_scripts( Mobile::Character* chr, const std::string& root_script_ecl,
                        const std::string& pkg_script_ecl, bool offline = false );
@@ -55,7 +57,7 @@ void call_chr_scripts( Mobile::Character* chr, const std::string& root_script_ec
 void report_weird_packet( Network::ThreadedClient* session,
                           const std::string& why );  // Defined below
 
-constexpr auto polling_timeout = std::chrono::milliseconds( 2000 );
+constexpr auto polling_timeout = 2000ms;
 
 bool threadedclient_io_step( Network::ThreadedClient* session, SocketReadiness ready, int& nidle )
 {

--- a/pol-core/pol/network/clientthread.h
+++ b/pol-core/pol/network/clientthread.h
@@ -9,7 +9,27 @@ class ThreadedClient;
 
 namespace Pol::Core
 {
-bool client_io_thread( Network::Client* client, bool login );
+// What a wait on a client's socket reported. Whoever does the waiting fills
+// this in: a client with its own thread polls its own socket, while login
+// clients are all waited on together by the listener that owns them.
+struct SocketReadiness
+{
+  bool incoming = false;
+  bool writable = false;
+  bool error = false;
+  // polled, but the socket had nothing to say
+  bool timed_out = false;
+};
+
+// Runs a connected client's socket until it disconnects. Returns false, having
+// cleaned the client up, once it is done.
+bool client_io_thread( Network::Client* client );
+
+// Runs one pass for a client still on the login server, using readiness the
+// caller has already collected. Returns false, having cleaned the client up,
+// if it is finished with the login server.
+bool client_io_login_step( Network::Client* client, SocketReadiness ready );
+
 bool process_data( Network::ThreadedClient* client );
 bool check_inactivity( Network::ThreadedClient* session );
 

--- a/pol-core/pol/polwww.cpp
+++ b/pol-core/pol/polwww.cpp
@@ -780,7 +780,7 @@ void http_func( SOCKET client_socket )
   bool first_line = true;
   unsigned int header_count = 0;
   const unsigned int max_header_count = 64;
-  const auto max_request_time = std::chrono::seconds( 10 );
+  const auto max_request_time = 10s;
   Tools::HighPerfTimer requestTimer;
   while ( sck.connected() && lineReader.read( tmpstr, &timed_out ) )
   {

--- a/pol-core/pol/uoclient.h
+++ b/pol-core/pol/uoclient.h
@@ -121,6 +121,10 @@ public:
   std::vector<boost::asio::ip::network_v4> allowed_proxies;
 
 private:
+  // Turns one accepted connection into a client, either parked in
+  // login_clients or handed to its own thread.
+  void accept_connection( Clib::Socket&& newsck );
+
   std::atomic<size_t> login_clients_size;  // multiple threads want to know the login size
   std::list<std::unique_ptr<UoClientThread>> login_clients;
 };

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -13,6 +13,7 @@
 
 #include "clib/esignal.h"
 #include "clib/logfacility.h"
+#include "clib/network/multipoller.h"
 #include "clib/network/socketsvc.h"
 #include "clib/network/wnsckt.h"
 #include "clib/strutil.h"
@@ -21,8 +22,10 @@
 #include "pol/core.h"
 #include "pol/globals/network.h"
 #include "pol/network/client.h"
+#include "pol/network/clientthread.h"
 #include "pol/network/clienttransmit.h"
 #include "pol/network/cliface.h"
+#include "pol/polclock.h"
 #include "pol/polsem.h"
 #include "pol/uoclient.h"
 
@@ -38,8 +41,6 @@ UoClientThread::UoClientThread( UoClientListener* def, Clib::Socket&& newsck )
       login_time( 0 )
 {
 }
-
-bool client_io_thread( Network::Client* client, bool login = false );
 
 void UoClientThread::run()
 {
@@ -113,7 +114,9 @@ void UoClientListener::accept_connection( Clib::Socket&& newsck )
     std::unique_ptr<UoClientThread> thread( new UoClientThread( this, std::move( newsck ) ) );
     if ( thread->create() )
     {
-      if ( client_io_thread( thread->client, true ) )
+      // Nothing has been waited on yet - a connection this new cannot have
+      // sent anything, and the next pass polls it along with the others.
+      if ( client_io_login_step( thread->client, SocketReadiness{ .timed_out = true } ) )
       {
         login_clients.push_back( std::move( thread ) );
         ++login_clients_size;
@@ -134,36 +137,85 @@ void UoClientListener::run()
 
   Clib::SocketListener SL(
       port, Clib::Socket::option( Clib::Socket::nonblocking | Clib::Socket::reuseaddr ) );
+
+  // The listen socket and every client still on the login server, waited on
+  // together. Waiting on them one at a time meant a client's packet sat
+  // untouched until every client before it had been polled in turn, and each
+  // of those waits costs a whole timer tick on Windows however short a timeout
+  // it is given. Rebuilt every pass, since which clients are here changes.
+  Clib::MultiPoller poller;
+  std::vector<size_t> client_slots;
+  // for a login client that has no socket to wait on; MultiPoller reports
+  // nothing ready for an index it does not know
+  constexpr size_t no_slot = static_cast<size_t>( -1 );
+
   while ( !Clib::exit_signalled )
   {
-    auto timeout = 2000ms;
-    if ( !login_clients.empty() )
-      timeout = 200ms;
+    poller.clear();
+    client_slots.clear();
+    poller.add( SL.listen_socket(), false );
 
-    // Take every connection that is already queued, not just one per pass.
-    // Accepting a single one per pass costs a full pass per connection, and a
-    // pass polls each pending login client in turn, so a burst of N clients
-    // used to be admitted in O(N^2) time - measured at 28.7s for 75 clients on
-    // loopback. The cap bounds how long a connection flood can delay the login
-    // clients handled below.
-    constexpr int max_accepts_per_pass = 64;
-    for ( int accepted = 0; accepted < max_accepts_per_pass; ++accepted )
+    for ( const auto& login_client : login_clients )
     {
-      // Only the first attempt waits; the rest drain what is already pending.
-      Clib::Socket newsck;
-      if ( !SL.GetConnection( &newsck, accepted == 0 ? timeout : 0ms ) || !newsck.connected() )
-        break;
-
-      accept_connection( std::move( newsck ) );
+      auto* client = login_client->client;
+      if ( client == nullptr || !client->isReallyConnected() )
+      {
+        // no socket to wait on; the walk below drops it
+        client_slots.push_back( no_slot );
+        continue;
+      }
+      client_slots.push_back(
+          poller.add( client->session()->csocket, client->session()->have_queued_data() ) );
     }
 
+    // Only bounds how often the timeout bookkeeping below runs: the wait ends
+    // as soon as any socket has something, so this is not a latency floor.
+    int res = poller.wait( 1000ms );
+    if ( res < 0 && Clib::socket_errno() != Clib::sockerr::intr )
+    {
+      // Nothing was waited on, so go round again rather than spinning on a
+      // listener that has stopped working.
+      POLLOG_ERRORLN( "Listener on port {}: poll failed, sckerr={}", port, Clib::socket_errno() );
+      pol_sleep_ms( 1000 );
+      continue;
+    }
+
+    if ( poller.result( 0 ).incoming )
+    {
+      // Take every connection that is already queued, not just one per pass.
+      // Accepting a single one per pass costs a full pass per connection, so a
+      // burst of N clients used to be admitted in O(N^2) time - measured at
+      // 28.7s for 75 clients on loopback. The cap bounds how long a connection
+      // flood can delay the login clients handled below.
+      constexpr int max_accepts_per_pass = 64;
+      for ( int accepted = 0; accepted < max_accepts_per_pass; ++accepted )
+      {
+        Clib::Socket newsck;
+        if ( !SL.Accept( &newsck ) || !newsck.connected() )
+          break;
+
+        accept_connection( std::move( newsck ) );
+      }
+    }
+
+    size_t slot = 0;
     auto itr = login_clients.begin();
     while ( itr != login_clients.end() )
     {
       auto client = ( *itr )->client;
+      // Clients accepted just above were appended after the slots were built,
+      // so they have none; they are polled from the next pass on.
+      const auto result =
+          slot < client_slots.size() ? poller.result( client_slots[slot] ) : Clib::PollResult{};
+      ++slot;
       if ( client != nullptr && client->isReallyConnected() )
       {
-        if ( !client_io_thread( client, true ) )
+        // Every login client gets a pass, whether or not its socket had
+        // anything, so the bookkeeping below keeps running at the rate the
+        // wait's timeout sets.
+        SocketReadiness ready{ result.incoming, result.writable, result.error,
+                               !result.incoming && !result.writable && !result.error };
+        if ( !client_io_login_step( client, ready ) )
         {
           itr = login_clients.erase( itr );
           --login_clients_size;

--- a/pol-core/pol/uolisten.cpp
+++ b/pol-core/pol/uolisten.cpp
@@ -105,6 +105,28 @@ void uo_client_listener_thread( void* arg )
   ls->run();
 }
 
+void UoClientListener::accept_connection( Clib::Socket&& newsck )
+{
+  // create an appropriate Client object
+  if ( Plib::systemstate.config.use_single_thread_login )
+  {
+    std::unique_ptr<UoClientThread> thread( new UoClientThread( this, std::move( newsck ) ) );
+    if ( thread->create() )
+    {
+      if ( client_io_thread( thread->client, true ) )
+      {
+        login_clients.push_back( std::move( thread ) );
+        ++login_clients_size;
+      }
+    }
+  }
+  else
+  {
+    Clib::SocketClientThread* thread = new UoClientThread( this, std::move( newsck ) );
+    thread->start();
+  }
+}
+
 void UoClientListener::run()
 {
   INFO_PRINTLN( "Listening for UO clients on port {} (encryption: {},{:#x},{:#x})", port,
@@ -117,27 +139,22 @@ void UoClientListener::run()
     auto timeout = 2000ms;
     if ( !login_clients.empty() )
       timeout = 200ms;
-    Clib::Socket newsck;
-    if ( SL.GetConnection( &newsck, timeout ) && newsck.connected() )
+
+    // Take every connection that is already queued, not just one per pass.
+    // Accepting a single one per pass costs a full pass per connection, and a
+    // pass polls each pending login client in turn, so a burst of N clients
+    // used to be admitted in O(N^2) time - measured at 28.7s for 75 clients on
+    // loopback. The cap bounds how long a connection flood can delay the login
+    // clients handled below.
+    constexpr int max_accepts_per_pass = 64;
+    for ( int accepted = 0; accepted < max_accepts_per_pass; ++accepted )
     {
-      // create an appropriate Client object
-      if ( Plib::systemstate.config.use_single_thread_login )
-      {
-        std::unique_ptr<UoClientThread> thread( new UoClientThread( this, std::move( newsck ) ) );
-        if ( thread->create() )
-        {
-          if ( client_io_thread( thread->client, true ) )
-          {
-            login_clients.push_back( std::move( thread ) );
-            ++login_clients_size;
-          }
-        }
-      }
-      else
-      {
-        Clib::SocketClientThread* thread = new UoClientThread( this, std::move( newsck ) );
-        thread->start();
-      }
+      // Only the first attempt waits; the rest drain what is already pending.
+      Clib::Socket newsck;
+      if ( !SL.GetConnection( &newsck, accepted == 0 ? timeout : 0ms ) || !newsck.connected() )
+        break;
+
+      accept_connection( std::move( newsck ) );
     }
 
     auto itr = login_clients.begin();

--- a/pol-core/support/pol.cfg.example
+++ b/pol-core/support/pol.cfg.example
@@ -228,12 +228,16 @@ TimestampEveryLine=1
 #
 #UseSingleThreadLogin=1
 
-# LoginServerSelectTimeout
-# socket timeout in ms
-# only used when UseSingleThreadLogin is active
-# Default 1
 #
-#LoginServerSelectTimeout=1
+# StalledPeerTimeout
+# how many seconds a peer may accept no data at all before the core closes the
+# connection. Applies to aux service / os::OpenConnection() transmits and to web
+# pages being written by a script. Any progress at all restarts the countdown, so
+# a merely slow peer is never dropped, only one that has stopped receiving.
+# Minimum 1. Re-read on configuration reload.
+# Default is 60
+#
+#StalledPeerTimeout=60
 
 #
 # ThreadDecayStatistics

--- a/testsuite/loginlatency/loginlatency.py
+++ b/testsuite/loginlatency/loginlatency.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Measure UO login-handshake service latency against a running POL shard.
+
+Step 0 of specs/sockets/12-batched-login-poll.md: the claim under test is that
+UoClientListener::run() discovers readiness for the listen socket and every
+pending login socket with 1+N separate poll() calls, so a login packet waits
+up to (listener timeout) + N ms before anyone looks at it.
+
+This speaks only enough of the protocol to time one round trip:
+
+  - "parked" clients connect and send the 4-byte crypt seed, then sit idle.
+    They stay in the listener's login_clients list (until LoginServerTimeout,
+    10 min by default), inflating N without generating traffic.
+  - the "probe" sends a 0x80 account-login for an account that does not exist
+    and times the 0x82 reply. That crosses exactly the same sweep a real
+    0xA8 server-list would, needs no valid account, and mutates no shard
+    state: loginserver_login() rejects an unknown name before touching MD5,
+    account records or scripts (pol-core/pol/login.cpp:150-156).
+
+Run against a manual test shard (bin/Release/pol.exe with cwd build/coretest
+and POLCORE_TEST_RUN unset), which listens on port 5003 with Encryption=none.
+
+Usage:
+  python loginlatency.py --parked 0 --samples 30
+  python loginlatency.py --sweep 0,10,25,50 --samples 20
+"""
+
+import argparse
+import socket
+import statistics
+import sys
+import time
+
+# The client's own IP, the classic seed value. Must not be 0xffffffff (UOKR
+# probe) or start with 0xef (6.0.5.0+ seed), which take other branches in
+# process_data(); see clientthread.cpp:451-470.
+SEED = b"\x7f\x00\x00\x01"
+
+LOGIN_PKT_LEN = 62  # PKTIN_80: u8 msgtype + char[30] name + char[30] pass + u8
+
+
+def login_packet(name: str, password: str) -> bytes:
+    """Build a 0x80 account-login packet (pol-core/pol/network/pktin.h:257)."""
+    pkt = bytearray(LOGIN_PKT_LEN)
+    pkt[0] = 0x80
+    n = name.encode("ascii")[:29]
+    p = password.encode("ascii")[:29]
+    pkt[1 : 1 + len(n)] = n
+    pkt[31 : 31 + len(p)] = p
+    return bytes(pkt)
+
+
+def connect(host: str, port: int, timeout: float) -> socket.socket:
+    s = socket.create_connection((host, port), timeout=timeout)
+    # Without this the probe measures Nagle, not POL.
+    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    return s
+
+
+def count_accepts(pol_log: str) -> int:
+    """Number of 'connected from' lines POL has logged (uolisten.cpp:88-97)."""
+    if not pol_log:
+        return 0
+    try:
+        with open(pol_log, "r", encoding="utf-8", errors="replace") as fh:
+            return sum(1 for line in fh if "connected from" in line)
+    except OSError:
+        return 0
+
+
+def park(host: str, port: int, count: int, args):
+    """Open `count` sockets that sit in login_clients doing nothing.
+
+    Returns (sockets, admit_seconds). The listener accepts at most one
+    connection per sweep (uolisten.cpp:121 -- GetConnection does a single
+    accept), so a batch of N needs N sweeps to be fully admitted, and the
+    sweep itself grows with N. A fixed sleep is not enough: probing while
+    the set is still filling measures a moving target.
+
+    With --pol-log we wait for N new accept lines, which is exact and also
+    yields the accept-drain time. Without it, fall back to a scaled sleep.
+    """
+    if not count:
+        return [], 0.0
+
+    before = count_accepts(args.pol_log)
+    parked = []
+    t0 = time.perf_counter()
+    for _ in range(count):
+        s = connect(host, port, args.timeout)
+        s.sendall(SEED)
+        parked.append(s)
+
+    if args.pol_log:
+        deadline = t0 + args.admit_timeout
+        while time.perf_counter() < deadline:
+            if count_accepts(args.pol_log) - before >= count:
+                break
+            time.sleep(0.05)
+        else:
+            print(f"  WARNING: only {count_accepts(args.pol_log) - before} of "
+                  f"{count} parked clients admitted within "
+                  f"{args.admit_timeout}s; results are unreliable")
+    else:
+        time.sleep(args.settle + count * args.settle_per_parked)
+
+    admit = time.perf_counter() - t0
+    # Let the seeds be consumed too: admission only means accept() ran.
+    time.sleep(args.settle)
+    return parked, admit
+
+
+def probe(host: str, port: int, pkt: bytes, timeout: float, settle: float,
+          isolate: bool):
+    """Return milliseconds from sending 0x80 to the first response byte.
+
+    isolate=True first sends the seed alone and waits for the shard to accept
+    the connection and consume it, so the timed window is one sweep. Otherwise
+    the seed and 0x80 go together and the window also covers the accept plus
+    the extra sweep the seed costs -- process_data() returns after consuming
+    the crypt seed (clientthread.cpp:473-475 falling through to :604), so the
+    0x80 is necessarily handled on a later sweep either way.
+    """
+    s = connect(host, port, timeout)
+    try:
+        if isolate:
+            s.sendall(SEED)
+            time.sleep(settle)
+            payload = pkt
+        else:
+            payload = SEED + pkt
+
+        s.settimeout(timeout)
+        t0 = time.perf_counter()
+        s.sendall(payload)
+        data = s.recv(64)
+        t1 = time.perf_counter()
+
+        if not data:
+            return None, "connection closed with no reply"
+        if data[0] != 0x82:
+            return None, f"unexpected reply {data[0]:#04x} (expected 0x82)"
+        return (t1 - t0) * 1000.0, None
+    except socket.timeout:
+        return None, "timed out waiting for reply"
+    finally:
+        s.close()
+
+
+def pct(values, p):
+    """Nearest-rank percentile; avoids numpy for a script this small."""
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    k = max(0, min(len(ordered) - 1, int(round(p / 100.0 * len(ordered))) - 1))
+    return ordered[k]
+
+
+def run_one(args, parked_count):
+    parked = []
+    try:
+        parked, admit = park(args.host, args.port, parked_count, args)
+        pkt = login_packet(args.account, args.password)
+
+        samples, errors = [], []
+        for i in range(args.samples):
+            ms, err = probe(args.host, args.port, pkt, args.timeout,
+                            args.settle, not args.full)
+            if err:
+                errors.append(f"sample {i}: {err}")
+            else:
+                samples.append(ms)
+            time.sleep(args.gap)
+
+        return samples, errors, admit
+    finally:
+        for s in parked:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Measure POL login round-trip latency",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:")[-1])
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5003,
+                    help="login listener port (test shard: 5003)")
+    ap.add_argument("--parked", type=int, default=0,
+                    help="idle login clients to hold open during the run")
+    ap.add_argument("--sweep", default=None,
+                    help="comma-separated parked counts, e.g. 0,10,25,50")
+    ap.add_argument("--samples", type=int, default=30)
+    ap.add_argument("--gap", type=float, default=0.05,
+                    help="seconds between probes; keep above 0 so consecutive "
+                         "probes do not share a sweep")
+    ap.add_argument("--settle", type=float, default=1.5,
+                    help="seconds to wait for the shard to accept and consume "
+                         "seeds before timing")
+    ap.add_argument("--settle-per-parked", type=float, default=1.0,
+                    help="extra settle seconds per parked client when "
+                         "--pol-log is not given (accept is 1 per sweep)")
+    ap.add_argument("--pol-log", default=None,
+                    help="path to the shard's pol.log; makes parking wait for "
+                         "actual admission instead of guessing, and reports "
+                         "accept-drain time (e.g. build/coretest/log/pol.log)")
+    ap.add_argument("--admit-timeout", type=float, default=180.0,
+                    help="max seconds to wait for parked clients to be admitted")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--account", default="__probe_no_such_account__",
+                    help="must NOT exist on the shard: the run relies on the "
+                         "unknown-account rejection path")
+    ap.add_argument("--password", default="x")
+    ap.add_argument("--full", action="store_true",
+                    help="time seed+0x80 together (includes accept latency) "
+                         "instead of isolating a single sweep")
+    args = ap.parse_args()
+
+    counts = ([int(x) for x in args.sweep.split(",")] if args.sweep
+              else [args.parked])
+
+    mode = "seed+0x80 (accept included)" if args.full else "0x80 only (one sweep)"
+    print(f"target   {args.host}:{args.port}")
+    print(f"mode     {mode}")
+    print(f"samples  {args.samples} per point\n")
+    print(f"{'parked':>7} {'n':>4} {'min':>9} {'median':>9} {'p90':>9} "
+          f"{'max':>9} {'admit':>9}")
+    print("-" * 62)
+
+    rows = []
+    for n in counts:
+        samples, errors, admit = run_one(args, n)
+        if not samples:
+            print(f"{n:>7} {0:>4}  no successful samples")
+            for e in errors[:3]:
+                print(f"          {e}")
+            continue
+        row = (n, len(samples), min(samples), statistics.median(samples),
+               pct(samples, 90), max(samples), admit)
+        rows.append(row)
+        print(f"{row[0]:>7} {row[1]:>4} {row[2]:>8.2f}ms {row[3]:>8.2f}ms "
+              f"{row[4]:>8.2f}ms {row[5]:>8.2f}ms {row[6]:>8.2f}s")
+        for e in errors[:3]:
+            print(f"          note: {e}")
+
+    if len(rows) > 1:
+        base, last = rows[0], rows[-1]
+        dn = last[0] - base[0]
+        if dn > 0:
+            slope = (last[3] - base[3]) / dn
+            print(f"\nmedian slope {slope:+.3f} ms per parked client "
+                  f"({base[0]} -> {last[0]})")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/testsuite/pol/pol.cfg
+++ b/testsuite/pol/pol.cfg
@@ -247,13 +247,6 @@ TimestampEveryLine=1
 #
 #UseSingleThreadLogin=1
 
-# LoginServerSelectTimeout
-# socket timeout in ms
-# only used when UseSingleThreadLogin is active
-# Default 1
-#
-#LoginServerSelectTimeout=1
-
 #
 # ThreadDecayStatistics
 # Prints statistics per run how many items are able


### PR DESCRIPTION
Single threaded login had bad O(N²) behavior when accepting sockets. For 75 connections, went from 28sec to a couple ms. Also poll all sockets at once instead of spending 1-10ms on each. The single threaded login should now be drastically better at handling the re-logins after a shard restart.