### PR TITLE
Customhouse tests

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -10,7 +10,7 @@
 			<author>Turley:</author>
 			<change type="Fixed">several ways to crash the shard in CustomHouses</change>
 			<change type="Fixed">the wrong revision was send after erase and clear</change>
-			<change type="Changed">if no misc/customhousecommit.src exists but CloseCustomHouse hook its called when the client commits.</change>
+			<change type="Changed">syshook CloseCustomHouse now also gets called when the client commits, if no misc/customhousecommit.src exists</change>
 		</entry>
 		<entry>
 			<date>08-02-2026</date>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,23 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-01-2026</datemodified>
+		<datemodified>08-04-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>08-03-2026</date>
+			<author>Turley:</author>
+			<change type="Fixed">several ways to crash the shard in CustomHouses</change>
+			<change type="Fixed">the wrong revision was send after erase and clear</change>
+			<change type="Changed">if no misc/customhousecommit.src exists but CloseCustomHouse hook its called when the client commits.</change>
+		</entry>
+		<entry>
+			<date>08-02-2026</date>
+			<author>Turley:</author>
+			<change type="Fixed">PacketHook with SubCommandOffset where the packet was too short, its now handled by the parent hook or default handler.</change>
+			<change type="Fixed">several out-of-bounds reads in packet scriptobjects</change>
+			<change type="Fixed">an outgoing PacketHook setting an encoded length larger than the packet buffer shut the server down, its sent with the buffer size now and logged.</change>
+		</entry>
 		<entry>
 			<date>08-01-2026</date>
 			<author>Turley:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 -- POL100.3.0 --
+08-03-2026 Turley:
+    Fixed: several ways to crash the shard in CustomHouses
+    Fixed: the wrong revision was send after erase and clear
+  Changed: if no misc/customhousecommit.src exists but CloseCustomHouse hook its called when the client commits.
 08-02-2026 Turley:
     Fixed: PacketHook with SubCommandOffset where the packet was too short, its now handled by the parent hook or default handler.
     Fixed: several out-of-bounds reads in packet scriptobjects

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -2,7 +2,7 @@
 08-03-2026 Turley:
     Fixed: several ways to crash the shard in CustomHouses
     Fixed: the wrong revision was send after erase and clear
-  Changed: if no misc/customhousecommit.src exists but CloseCustomHouse hook its called when the client commits.
+  Changed: syshook CloseCustomHouse now also gets called when the client commits, if no misc/customhousecommit.src exists
 08-02-2026 Turley:
     Fixed: PacketHook with SubCommandOffset where the packet was too short, its now handled by the parent hook or default handler.
     Fixed: several out-of-bounds reads in packet scriptobjects

--- a/pol-core/pol/module/uomod2.cpp
+++ b/pol-core/pol/module/uomod2.cpp
@@ -2576,6 +2576,9 @@ BObjectImp* UOExecutorModule::mf_SendHousingTool()
   {
     return new BError( "Invalid parameter type" );
   }
+  if ( !chr->has_active_client() )
+    return new BError( "No client attached." );
+
   if ( !chr->client->acctSupports( Plib::ExpansionVersion::AOS ) )
     return new BError( "Charater does not have AOS enabled." );
 
@@ -2589,11 +2592,11 @@ BObjectImp* UOExecutorModule::mf_SendHousingTool()
   if ( !house->IsCustom() )
     return new BError( "Not a Custom House." );
 
-  if ( house->editing )
-    return new BError( "House currently being customized." );
-
   if ( house->IsWaitingForAccept() )
     return new BError( "House currently being waiting for a commit" );
+
+  if ( house->editing )
+    return new BError( "House currently being customized." );
 
   if ( chr->realm()->find_supporting_multi( chr->pos3d() ) != house )
     return new BError( "You must be inside the house to customize it." );

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -145,6 +145,10 @@ void CustomHouseDesign::Add( const CUSTOM_HOUSE_ELEMENT& elem )
   int floor_num = z_to_custom_house_table( elem.z );
   if ( floor_num == -1 )
     return;
+  u32 xidx = elem.xoffset + xoff;
+  u32 yidx = elem.yoffset + yoff;
+  if ( !ValidLocation( xidx, yidx ) )
+    return;
   Elements[floor_num].AddElement( elem );
   floor_sizes[floor_num]++;
 }
@@ -237,9 +241,10 @@ void CustomHouseDesign::ReplaceDirtFloor( s32 xoffset, s32 yoffset )
 {
   int floor_num = 1;  // dirt always goes on floor 1 (z=7)
 
+  // don't replace dirt at the far-west and far-north sides, nor on the front
+  // step row - the last row of the design, which the house itself does not cover
   if ( xoffset + xoff == 0 || yoffset + yoff == 0 ||
-       Clib::clamp_convert<u32>( yoffset + yoff ) ==
-           height )  // don't replace dirt at far-west and far-north sides, check height for y + 1
+       Clib::clamp_convert<u32>( yoffset + yoff ) == height - 1 )
     return;
 
   bool floor_exists = false;
@@ -796,11 +801,11 @@ void CustomHousesErase( Core::PKTBI_D7* msg )
   std::vector<u8> newvec;
   house->WorkingCompressed.swap( newvec );
 
+  house->revision++;
+
   Mobile::Character* chr = Core::find_character( serial );
   if ( chr && chr->client )
     CustomHousesSendFull( house, chr->client, HOUSE_DESIGN_WORKING );
-
-  house->revision++;
 }
 
 void CustomHousesClear( Core::PKTBI_D7* msg )
@@ -819,10 +824,11 @@ void CustomHousesClear( Core::PKTBI_D7* msg )
 
   // add foundation back to design
   house->WorkingDesign.AddMultiAtOffset( house->multiid(), 0, 0, 0 );
-  if ( chr != nullptr && chr->client != nullptr )
-    CustomHousesSendFull( house, chr->client, HOUSE_DESIGN_WORKING );
 
   house->revision++;
+
+  if ( chr != nullptr && chr->client != nullptr )
+    CustomHousesSendFull( house, chr->client, HOUSE_DESIGN_WORKING );
 }
 
 // if the client closed his tool
@@ -864,6 +870,13 @@ void CustomHousesCommit( Core::PKTBI_D7* msg )
     }
   }
   house->AcceptHouseCommit( chr, true );
+
+  // if no commit script exists, but the closehook call this instead
+  if ( Core::gamestate.system_hooks.close_customhouse_hook )
+  {
+    Core::gamestate.system_hooks.close_customhouse_hook->call(
+        make_mobileref( chr ), new Module::EMultiRefObjImp( house ) );
+  }
 }
 
 void CustomHousesSelectFloor( Core::PKTBI_D7* msg )

--- a/pol-core/pol/multi/customhouses.cpp
+++ b/pol-core/pol/multi/customhouses.cpp
@@ -46,6 +46,8 @@
 #include "pol/item/itemdesc.h"
 #include "pol/mkscrobj.h"
 #include "pol/mobile/charactr.h"
+#include "pol/multi/house.h"
+#include "pol/multi/multidef.h"
 #include "pol/network/cgdata.h"
 #include "pol/network/client.h"
 #include "pol/network/packethelper.h"
@@ -60,8 +62,6 @@
 #include "pol/ufunc.h"
 #include "pol/uoscrobj.h"
 #include "pol/uworld.h"
-#include "pol/multi/house.h"
-#include "pol/multi/multidef.h"
 
 #include <zlib.h>
 
@@ -72,14 +72,13 @@ namespace Pol::Multi
 #define BYTES_PER_TILE 5
 
 // fixed z offsets for each floor
-const char CustomHouseDesign::custom_house_z_xlate_table[CUSTOM_HOUSE_NUM_PLANES] = { 0,  7,  27,
-                                                                                      47, 67, 80 };
+const u8 CustomHouseDesign::custom_house_z_xlate_table[CUSTOM_HOUSE_NUM_PLANES] = { 0,  7,  27,
+                                                                                    47, 67, 80 };
 
 // translate z offset to floor number, use floor below passed-in z value, unless exact match
-char CustomHouseDesign::z_to_custom_house_table( char z )
+int CustomHouseDesign::z_to_custom_house_table( u8 z )
 {
-  unsigned char i;
-  for ( i = 0; i < CUSTOM_HOUSE_NUM_PLANES; i++ )
+  for ( u8 i = 0; i < CUSTOM_HOUSE_NUM_PLANES; i++ )
   {
     if ( z == custom_house_z_xlate_table[i] )
       return i;

--- a/pol-core/pol/multi/customhouses.h
+++ b/pol-core/pol/multi/customhouses.h
@@ -143,7 +143,7 @@ public:
   s32 xoff, yoff;     // offsets from center west-most and north-most indicies are 0
   CustomHouseElements Elements[CUSTOM_HOUSE_NUM_PLANES];  // 5 planes
 
-  static const char custom_house_z_xlate_table[CUSTOM_HOUSE_NUM_PLANES];
+  static const u8 custom_house_z_xlate_table[CUSTOM_HOUSE_NUM_PLANES];
   // for testing
   void testprint( std::ostream& os ) const;
 
@@ -154,7 +154,7 @@ public:
 
 private:
   bool isEditableItem( UHouse* house, Items::Item* item );
-  static char z_to_custom_house_table( char z );
+  static int z_to_custom_house_table( u8 z );
 };
 
 // House Tool Command Implementations:

--- a/pol-core/pol/multi/house.cpp
+++ b/pol-core/pol/multi/house.cpp
@@ -37,6 +37,7 @@
 #include "plib/systemstate.h"
 #include "plib/uconst.h"
 
+#include "pol/base/range.h"
 #include "pol/core.h"
 #include "pol/fnsearch.h"
 #include "pol/globals/object_storage.h"
@@ -44,6 +45,9 @@
 #include "pol/item/itemdesc.h"
 #include "pol/mobile/charactr.h"
 #include "pol/module/uomod.h"
+#include "pol/multi/customhouses.h"
+#include "pol/multi/multi.h"
+#include "pol/multi/multidef.h"
 #include "pol/network/cgdata.h"
 #include "pol/network/client.h"
 #include "pol/realms/realm.h"
@@ -53,10 +57,6 @@
 #include "pol/uoexec.h"
 #include "pol/uoscrobj.h"
 #include "pol/uworld.h"
-#include "pol/base/range.h"
-#include "pol/multi/customhouses.h"
-#include "pol/multi/multi.h"
-#include "pol/multi/multidef.h"
 
 
 namespace Pol::Multi
@@ -530,7 +530,7 @@ Bscript::BObjectImp* UHouse::script_method_id( const int id, Core::UOExecutor& e
     int drop_changes;
     if ( ex.getCharacterParam( 0, chr ) && ex.getParam( 1, drop_changes ) )
     {
-      if ( chr->client->gd->custom_house_serial == serial )
+      if ( chr->has_active_client() && chr->client->gd->custom_house_serial == serial )
         CustomHousesQuit( chr, drop_changes ? true : false );
       else
         return new BError( "Character is not editing this house" );

--- a/pol-core/pol/multi/multidef.cpp
+++ b/pol-core/pol/multi/multidef.cpp
@@ -247,8 +247,6 @@ bool MultiDefByMultiIDExists( u16 multiid )
 }
 const MultiDef* MultiDefByMultiID( u16 multiid )
 {
-  passert( multidef_buffer.multidefs_by_multiid.count( multiid ) != 0 );
-
   MultiDefs::const_iterator citr = multidef_buffer.multidefs_by_multiid.find( multiid );
   if ( citr != multidef_buffer.multidefs_by_multiid.end() )
     return ( *citr ).second;

--- a/pol-core/pol/network/client.cpp
+++ b/pol-core/pol/network/client.cpp
@@ -301,6 +301,30 @@ Bscript::BStruct* Client::getclientinfo() const
   return ret.release();
 }
 
+void Client::setversion( const std::string& ver )
+{
+  std::lock_guard<std::mutex> lock( version_lock_ );
+  version_ = ver;
+}
+
+const std::string& Client::getversion() const
+{
+  std::lock_guard<std::mutex> lock( version_lock_ );
+  return version_;
+}
+
+VersionDetailStruct Client::getversiondetail() const
+{
+  std::lock_guard<std::mutex> lock( version_lock_ );
+  return versiondetail_;
+}
+
+void Client::setversiondetail( VersionDetailStruct& detail )
+{
+  std::lock_guard<std::mutex> lock( version_lock_ );
+  versiondetail_ = detail;
+}
+
 void Client::itemizeclientversion( const std::string& ver, VersionDetailStruct& detail )
 {
   try

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -365,7 +365,7 @@ private:
   bool paused_;
   VersionDetailStruct versiondetail_;
   weak_ptr_owner<Client> weakptr;
-  std::mutex version_lock_;
+  mutable std::mutex version_lock_;
 };
 
 inline bool ThreadedClient::have_queued_data() const

--- a/pol-core/pol/network/client.h
+++ b/pol-core/pol/network/client.h
@@ -38,9 +38,9 @@
 #include "plib/uconst.h"
 #include "plib/uoexpansion.h"
 #include "pol/crypt/cryptkey.h"
-#include "pol/polclock.h"
 #include "pol/network/pktdef.h"
 #include "pol/network/pktin.h"
+#include "pol/polclock.h"
 
 namespace Pol
 {
@@ -298,10 +298,10 @@ public:
 
   void send_KR_encryption_response();
 
-  void setversion( const std::string& ver ) { version_ = ver; }
-  const std::string& getversion() const { return version_; }
-  VersionDetailStruct getversiondetail() const { return versiondetail_; }
-  void setversiondetail( VersionDetailStruct& detail ) { versiondetail_ = detail; }
+  void setversion( const std::string& ver );
+  const std::string& getversion() const;
+  VersionDetailStruct getversiondetail() const;
+  void setversiondetail( VersionDetailStruct& detail );
   static void itemizeclientversion( const std::string& ver, VersionDetailStruct& detail );
   bool compareVersion( const std::string& ver );
   bool compareVersion( const VersionDetailStruct& ver2 );
@@ -365,6 +365,7 @@ private:
   bool paused_;
   VersionDetailStruct versiondetail_;
   weak_ptr_owner<Client> weakptr;
+  std::mutex version_lock_;
 };
 
 inline bool ThreadedClient::have_queued_data() const

--- a/pol-core/poltool/testfiles.cpp
+++ b/pol-core/poltool/testfiles.cpp
@@ -731,6 +731,16 @@ void FileGenerator::modifyMultis( std::vector<std::vector<T>>& multis )
       elem( 0x31F4, 2, 0, 0, 1 ),   elem( 0x31F4, 2, 3, 0, 1 ),   elem( 0x31F4, 3, -2, 0, 1 ),
       elem( 0x31F4, 3, -1, 0, 1 ),  elem( 0x31F4, 3, 0, 0, 1 ),   elem( 0x31F4, 3, 1, 0, 1 ),
       elem( 0x31F4, 3, 2, 0, 1 ),   elem( 0x31F4, 3, 3, 0, 1 ) };
+
+  // A north facing staircase, the lowest of the multiids the custom house design
+  // editor accepts (STAIR_MULTIID_MIN). Four steps climbing north, each one a
+  // stack of blocks 5 z apart, which is the shape CustomHouseDesign::DeleteStairs
+  // walks back down when one of these is erased.
+  multis[0x1db0] = std::vector<T>{ elem( 0x0751, 0, 0, 0, 1 ),   elem( 0x0751, 0, -1, 0, 1 ),
+                                   elem( 0x0751, 0, -1, 5, 1 ),  elem( 0x0751, 0, -2, 0, 1 ),
+                                   elem( 0x0751, 0, -2, 5, 1 ),  elem( 0x0751, 0, -2, 10, 1 ),
+                                   elem( 0x0751, 0, -3, 0, 1 ),  elem( 0x0751, 0, -3, 5, 1 ),
+                                   elem( 0x0751, 0, -3, 10, 1 ), elem( 0x0751, 0, -3, 15, 1 ) };
 }
 
 template <typename T>

--- a/testsuite/pol/scripts/misc/customhousecommit.src
+++ b/testsuite/pol/scripts/misc/customhousecommit.src
@@ -1,0 +1,38 @@
+// The custom house commit script, which the core starts instead of applying a
+// commit itself.
+//
+// CustomHousesCommit looks for misc/customhousecommit.ecl and, when it is there,
+// sets the house waiting for an accept and hands it to this script with the
+// character that asked for the commit. Nothing applies the design until somebody
+// calls house.acceptcommit() - a real shard works out the cost here, asks the
+// player to confirm and takes the payment.
+//
+// This is shard-wide and cannot be unloaded, so every commit in the whole run
+// comes through here. Unless a test has parked something in #HouseCommitHold it
+// therefore accepts straight away, which is what the core would have done on a
+// shard with no commit script at all; only a test that wants to see the waiting
+// state holds it.
+
+use uo;
+use os;
+
+program CustomHouseCommit( chr, house )
+  // record the call for whoever is watching, before anything is decided
+  var call := struct{};
+  call.+character := chr.serial;
+  call.+house := house.serial;
+  call.+parts := house.house_parts.size();
+  SetGlobalProperty( "#HouseCommitCall", call );
+
+  if ( GetGlobalProperty( "#HouseCommitHold" ) )
+    return 1;
+  endif
+
+  var res := house.acceptcommit( chr, 1 );
+  if ( !res )
+    // leaving a house waiting for an accept nobody will send would break every
+    // later test on it, so say so where it can be found
+    syslog( $"customhousecommit: acceptcommit refused: {res}" );
+  endif
+  return 1;
+endprogram

--- a/testsuite/pol/testpkgs/client/cleanup.src
+++ b/testsuite/pol/testpkgs/client/cleanup.src
@@ -18,6 +18,11 @@ foreach guild in ( ListGuilds() )
   endif
 endforeach
 
+// The commit script is shard-wide and holds every commit while this is set, so
+// a case that failed while it was armed would leave the rest of the run unable
+// to commit a house at all.
+EraseGlobalProperty( "#HouseCommitHold" );
+
 foreach multi in ( ListMultisInBox( 0, 0, -200, 10000, 10000, 200 ) )
   DestroyMulti( multi );
 endforeach

--- a/testsuite/pol/testpkgs/client/closehousehook.src
+++ b/testsuite/pol/testpkgs/client/closehousehook.src
@@ -1,0 +1,28 @@
+// The CloseCustomHouse system hook, installed by syshook.cfg.
+//
+// The core calls it at the end of every design session, from CustomHousesQuit -
+// so on a quit from the client, on a cancelediting from a script, and on the
+// accept half of a commit. It is told which character left and which house it
+// left, and its answer is not read.
+//
+// It records every call and nothing else. Unlike the commit script it cannot
+// change what happens, so there is nothing to arm: the last call is simply left
+// where a test can read it.
+
+use uo;
+use os;
+
+program Install()
+  return 1;
+endprogram
+
+exported function CloseCustomHouseHook( chr, house )
+  var call := struct{};
+  call.+character := chr.serial;
+  call.+house := house.serial;
+  // the core clears this before it calls the hook, which is worth recording
+  // rather than asking for again later
+  call.+editing := house.house_editing;
+  SetGlobalProperty( "#CloseHouseCall", call );
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/client/closehousehook.src
+++ b/testsuite/pol/testpkgs/client/closehousehook.src
@@ -1,8 +1,11 @@
 // The CloseCustomHouse system hook, installed by syshook.cfg.
 //
-// The core calls it at the end of every design session, from CustomHousesQuit -
-// so on a quit from the client, on a cancelediting from a script, and on the
-// accept half of a commit. It is told which character left and which house it
+// The core calls it from UHouse::CustomHousesQuit - so on a quit from the client
+// and on a cancelediting from a script, which is what the hook is documented to
+// cover - and from CustomHousesCommit on a shard with no
+// misc/customhousecommit.ecl, where nothing else would say the session ended.
+// This shard has that script, so a commit does not reach the hook here; see
+// commit_skips_close_hook. It is told which character left and which house it
 // left, and its answer is not read.
 //
 // It records every call and nothing else. Unlike the commit script it cannot

--- a/testsuite/pol/testpkgs/client/communication.inc
+++ b/testsuite/pol/testpkgs/client/communication.inc
@@ -41,6 +41,9 @@ const EVT_STATUS_BAR := "status_bar";
 const EVT_TRADE := "trade";
 const EVT_CLILOC := "cliloc";
 const EVT_PARTY := "party";
+const EVT_HOUSE_DESIGN := "house_design";
+const EVT_HOUSE_EDIT := "house_edit";
+const EVT_HOUSE_REV := "house_rev";
 
 // actions of the secure trade window packet, see PKTBI_6F in the core
 const TRADE_ACTION_INIT := 0;
@@ -263,6 +266,75 @@ function poll_client_listing( clientcon, id, serial, cont_serial, wanted, timeou
     return ret_error( $"0x{serial:x} never showed up in {where} within {timeout}s" );
   endif
   return ret_error( $"0x{serial:x} is still in {where} after {timeout}s" );
+endfunction
+
+// Asks a client what it thinks a mobile is wearing. Drops whatever is queued
+// first, so the answer cannot be an older listing.
+//
+// The same race as list_client_objs(): the client answers out of its own loop
+// and knows nothing of the packets still on their way to it, so a listing taken
+// straight after equipping something can be older than the equip. A caller
+// asking whether a layer is filled, or empty, has to go through
+// client_finds_layer() or client_lost_layer().
+function list_client_equipment( clientcon, id, serial, timeout := 10 )
+  Clear_Event_Queue();
+  clientcon.sendevent( struct{ todo := "list_equipped_items", arg := serial, id := id } );
+  return waitForClient( id, { EVT_LIST_EQUIPPED_ITEMS }, timeout );
+endfunction
+
+// Waits for a layer of a mobile's equipment to be filled as the client sees it,
+// and hands that entry back.
+function client_finds_layer( clientcon, id, serial, layer, timeout := 5 )
+  var res := poll_client_equipment( clientcon, id, serial, layer, 1, timeout );
+  if ( !res )
+    return res;
+  endif
+  return res.entry;
+endfunction
+
+// Waits for a layer to be empty as the client sees it.
+function client_lost_layer( clientcon, id, serial, layer, timeout := 5 )
+  var res := poll_client_equipment( clientcon, id, serial, layer, 0, timeout );
+  if ( !res )
+    return res;
+  endif
+  return 1;
+endfunction
+
+// Lists over and over until the layer is filled (wanted := 1) or empty
+// (wanted := 0). A listing that already says so costs a single round trip.
+function poll_client_equipment( clientcon, id, serial, layer, wanted, timeout )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  var answered := 0;
+
+  while ( ReadMillisecondClock() < deadline )
+    var ev := list_client_equipment( clientcon, id, serial, 1 );
+    if ( !ev )
+      continue;
+    endif
+    answered := 1;
+
+    var entry := 0;
+    foreach item in ( ev.objs )
+      // the client events come out of UnpackJson, so every number in them is a
+      // Double
+      if ( CInt( item.layer ) == layer )
+        entry := item;
+        break;
+      endif
+    endforeach
+    if ( wanted == ( entry ? 1 : 0 ) )
+      return struct{ entry := entry };
+    endif
+    Sleepms( POLL_INTERVAL * 1000 );
+  endwhile
+
+  if ( !answered )
+    return ret_error( $"client {id} never listed the equipment of 0x{serial:x}" );
+  elseif ( wanted )
+    return ret_error( $"client {id} never saw layer {layer} of 0x{serial:x} filled" );
+  endif
+  return ret_error( $"client {id} still has layer {layer} of 0x{serial:x} after {timeout}s" );
 endfunction
 
 function disable_auto_delete( clientcon, id )

--- a/testsuite/pol/testpkgs/client/customhouse.inc
+++ b/testsuite/pol/testpkgs/client/customhouse.inc
@@ -12,12 +12,11 @@
 // asserts on the design event, and one that cares about the model asserts on
 // house_parts.
 //
-// Several cases in these files are written but commented out, because they fail
-// against the core as it stands and some of them take the shard or the test
-// client down with them. Each is headed by a line beginning
-// "TODO core bug <n>", so `grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs`
-// finds all of them and says what has to change before it can be uncommented.
-// The numbers are the ones in the write-up the branch was handed over with.
+// Two cases in test_client_house.src are written but commented out, because they
+// fail against the core as it stands and one of them takes the test client down
+// with it. Each is headed by a line beginning "TODO core bug <n>", so
+// `grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs` finds them and says
+// what has to change before each can be uncommented.
 
 use os;
 use uo;
@@ -49,6 +48,8 @@ const CH_EDIT_END := 0x05;
 // part added at any z between two of these belongs to the lower one.
 const CH_PLANE_Z := 0;
 const CH_PLANE_Z1 := 7;
+// the plane index CH_PLANE_Z1 belongs to, which is what a plane header carries
+const CH_PLANE_INDEX_Z1 := 1;
 const CH_PLANE_Z2 := 27;
 const CH_PLANE_Z3 := 47;
 const CH_PLANE_Z4 := 67;
@@ -81,9 +82,11 @@ const CH_FOUNDATION_Y := 0;
 // plane there
 const CH_BOARD := 0x4AC;
 
-// The most tiles one plane of a design packet can describe. Its plane header
-// gives the uncompressed length 12 bits, and a tile is five bytes, so 4095/5
-// tiles is all that fits - see the packing in CustomHousesSendFull.
+// The most a plane header can describe: it gives the uncompressed and the
+// compressed length 12 bits each, and a tile is five bytes, so 4095/5 tiles is
+// all one plane fits - see the packing in CustomHousesSendFull. A floor holding
+// more than that is sent as several planes under the same index.
+const CH_PLANE_MAX_LEN := 4095;
 const CH_PLANE_MAX_TILES := 819;
 
 // Where the design tests put their house. Every case builds its own through the
@@ -389,9 +392,9 @@ endfunction
 //
 // What it cannot be used for is the revision. CustomHousesSendFull keeps the
 // packet it built in WorkingCompressed and replays it byte for byte until an
-// edit throws it away, so a design built before a revision was incremented goes
-// on being sent under the old number. Erase and clear both send before they
-// increment, which is what erase_revision_lags in test_client_house_erase.src
+// edit throws it away, so the number a synch answers with is the one the design
+// was built under. Every command that changes the design increments before it
+// builds, which is what erase_revision_advances in test_client_house_erase.src
 // pins down.
 function house_settle( id )
   house_cmd( id, CH_SYNCH );
@@ -492,12 +495,18 @@ function expect_parts( multi, wanted, what )
 endfunction
 
 // Whether the design the client was sent holds together: what its header claims
-// and what its planes actually carried have to be the same number of tiles.
+// and what its planes actually carried have to be the same number of tiles, and
+// the plane count has to be the number of planes the buffer really held.
 function design_is_consistent( ev )
   var claimed := CInt( ev.numtiles );
   var got := ev.tiles.size();
   if ( claimed != got )
     return ret_error( $"design says {claimed} tiles, its planes carried {got}" );
+  endif
+  var planes := CInt( ev.planecount );
+  var decoded := ev.planes.size();
+  if ( planes != decoded )
+    return ret_error( $"design says {planes} planes, its buffer held {decoded}" );
   endif
   return 1;
 endfunction

--- a/testsuite/pol/testpkgs/client/customhouse.inc
+++ b/testsuite/pol/testpkgs/client/customhouse.inc
@@ -1,0 +1,503 @@
+// Shared helpers for the custom house design editor tests.
+//
+// A design session only exists while a client is in it: the core looks the house
+// up by the editing character's serial and drops any 0xD7 that does not belong
+// to one. So every assertion about design content is made from escript through
+// house.house_parts, which reads the working design while editing is on, and the
+// client is only there to send commands and to be told what the server thinks
+// the design is.
+//
+// The two views can disagree - that is the point of decoding 0xD8 rather than
+// swallowing it - so a case that cares about what the client was actually sent
+// asserts on the design event, and one that cares about the model asserts on
+// house_parts.
+//
+// Several cases in these files are written but commented out, because they fail
+// against the core as it stands and some of them take the shard or the test
+// client down with them. Each is headed by a line beginning
+// "TODO core bug <n>", so `grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs`
+// finds all of them and says what has to change before it can be uncommented.
+// The numbers are the ones in the write-up the branch was handed over with.
+
+use os;
+use uo;
+
+include "testutil";
+include "communication";
+
+// the subcommands of the 0xD7 packet, see PKTBI_D7 in the core. Keep in sync
+// with the SUB_ constants of pyuo's CustomHouseCommandPacket.
+const CH_BACKUP := 0x02;
+const CH_RESTORE := 0x03;
+const CH_COMMIT := 0x04;
+const CH_ERASE := 0x05;
+const CH_ADD := 0x06;
+const CH_QUIT := 0x0C;
+const CH_ADD_MULTI := 0x0D;
+const CH_SYNCH := 0x0E;
+const CH_CLEAR := 0x10;
+const CH_SELECT_FLOOR := 0x12;
+const CH_SELECT_ROOF := 0x13;
+const CH_DELETE_ROOF := 0x14;
+const CH_REVERT := 0x1A;
+
+// what the 0xBF sub 0x20 packet says about the editing session
+const CH_EDIT_BEGIN := 0x04;
+const CH_EDIT_END := 0x05;
+
+// the z of each design plane, see custom_house_z_xlate_table in the core. A
+// part added at any z between two of these belongs to the lower one.
+const CH_PLANE_Z := 0;
+const CH_PLANE_Z1 := 7;
+const CH_PLANE_Z2 := 27;
+const CH_PLANE_Z3 := 47;
+const CH_PLANE_Z4 := 67;
+
+// the stair multiids the editor accepts, see STAIR_MULTIID_MIN/MAX. Only the
+// first of them is in the generated test data, as a ten tile pyramid of 0x751
+// climbing north over four tiles.
+const CH_STAIR_MIN := 0x1DB0;
+const CH_STAIR_MAX := 0x1DF3;
+const CH_STAIR_PARTS := 10;
+const CH_STAIR := 0x751;
+// a multi that is not one of them, and does exist - the range check has to
+// answer before anything looks the multi up
+const CH_NOT_A_STAIR := 0x6C;
+
+// what an emptied ground floor tile is paved with again, see ReplaceDirtFloor
+const CH_DIRT := 0x31F4;
+
+// a roof shingle, the marker for everything that has to be a non-floor tile:
+// AddOrReplace only replaces like with like, and Plib::tileheight decides which
+// is which. It is part of the house multi at x 1 and nowhere else.
+const CH_ROOF := 0x5C2;
+
+// a wall of the house multi, on the west side of the foundation
+const CH_FOUNDATION := 0x64;
+const CH_FOUNDATION_X := -3;
+const CH_FOUNDATION_Y := 0;
+
+// a floor board of the house multi, in the middle of the room and alone on its
+// plane there
+const CH_BOARD := 0x4AC;
+
+// The most tiles one plane of a design packet can describe. Its plane header
+// gives the uncompressed length 12 bits, and a tile is five bytes, so 4095/5
+// tiles is all that fits - see the packing in CustomHousesSendFull.
+const CH_PLANE_MAX_TILES := 819;
+
+// Where the design tests put their house. Every case builds its own through the
+// resource manager and hands it back at the end of the case, so only ever one
+// stands here and none of them outlives the case that made it.
+//
+// That matters for more than tidiness. A house within visual range of another
+// test's path shows that test the door and the sign arriving as items out of
+// nowhere: while these houses were being left standing for a whole package, one
+// of them broke multi_update_range in test_client_range.src, which walks a
+// character east from (100,100) and measures where a multi first appears. The
+// spot below is still kept well away from everything else the package touches,
+// because a case is free to move a character about while its house is up.
+const HOUSE_X := 100;
+const HOUSE_Y := 155;
+// the small house of testpkgs/house/itemdesc.cfg, multi 0x6b. The dirt plots
+// there carry a WalkOnScript, which fires as a character is moved into them.
+const HOUSE_OBJTYPE := 0x12000;
+
+// What that multi covers: offsets -3..4 in x and -3..4 in y, which the design
+// widens by one row in y for the front steps. Everything the design model
+// indexes is derived from those bounds, so a test that reaches outside them is
+// asking the core to read past an array rather than to refuse.
+const HOUSE_MIN_OFF := -3;
+const HOUSE_MAX_OFF := 4;
+// the row the core forces to z 0 because it hangs off the south side
+const HOUSE_STEP_Y := 5;
+
+var clientcon := getClientConnection();
+var char;
+var house;
+var house_x;
+var house_y;
+var was_expansion;
+
+// Finds the character the design tests drive and puts its account onto AOS, for
+// the program of every design test file. The expansion is account state the rest
+// of the run sees, so it is set once per file rather than per case.
+function house_setup()
+  var acct := FindAccount( "testclient0" );
+  char := acct.getcharacter( 1 );
+  if ( !char )
+    return ret_error( "Could not find char at slot 1" );
+  endif
+
+  // the shard default is T2A, under which SendHousingTool refuses outright
+  was_expansion := set_expansion( "testclient0", "AOS" );
+  if ( !was_expansion )
+    return was_expansion;
+  endif
+  return 1;
+endfunction
+
+// Puts a fresh custom house up with the client 0 character standing in it, ready
+// for SendHousingTool. Every case opens with this.
+//
+// The house belongs to the resource manager, which the test framework empties
+// after each exported function whether it passed or not - so each case gets a
+// house nothing has edited, and none of them is left standing for the tests that
+// come after. That is what makes the cases independent of the order they run in
+// and of each other's failures; the alternative, one house per file, has to undo
+// by hand whatever the last case did to it.
+function house_start( resmgn )
+  house_x := HOUSE_X;
+  house_y := HOUSE_Y;
+
+  // A case that failed with its design session still open leaves its house
+  // standing: the resource manager cannot take down a multi that is being
+  // edited. Two houses on the plot then both hold the character up, and
+  // SendHousingTool refuses the new one with "You must be inside the house to
+  // customize it." - which says nothing about the case that really failed. Clear
+  // the plot first so a failure is reported once instead of once per case.
+  foreach leftover in ( ListMultisInBox( HOUSE_X - 8, HOUSE_Y - 8, -100, HOUSE_X + 8, HOUSE_Y + 8,
+                                         100 ) )
+    if ( leftover.custom && leftover.house_editing )
+      leftover.cancelediting( char, 1 );
+    endif
+    DestroyMulti( leftover );
+    drain_events();
+  endforeach
+
+  house := resmgn.CreateMultiAtLocation( house_x, house_y, 0, HOUSE_OBJTYPE, CRMULTI_IGNORE_ALL );
+  if ( !house )
+    return ret_error( $"Could not place the house: {house}" );
+  endif
+  house.setcustom( 1 );
+
+  // the tool only opens for a character the house itself is holding up
+  MoveObjectToLocation( char, house_x, house_y, 0, flags := MOVEOBJECT_FORCELOCATION );
+  var ev := waitForClient( 0, { EVT_OWNCREATE } );
+  if ( !ev )
+    return ret_error( "client 0 was not moved into the house" );
+  endif
+  return 1;
+endfunction
+
+// Puts the account expansion back the way the rest of the run expects it.
+function house_teardown()
+  if ( was_expansion )
+    set_expansion( "testclient0", was_expansion );
+  endif
+  return 1;
+endfunction
+
+// Puts an account onto AOS and hands back what it was on before. The shard
+// default is T2A, under which SendHousingTool refuses to do anything, and the
+// expansion is account state the rest of the run sees - so whatever this returns
+// belongs in a cleanup.
+function set_expansion( acctname, expansion )
+  var acct := FindAccount( acctname );
+  if ( !acct )
+    return ret_error( $"no account {acctname}" );
+  endif
+  var was := acct.uo_expansion;
+  var res := acct.Set_UO_Expansion( expansion );
+  if ( !res )
+    return ret_error( $"could not set {acctname} to {expansion}: {res}" );
+  endif
+  return was;
+endfunction
+
+// Sends one design command as the given client. The arguments each subcommand
+// takes are the ones its packet carries, see CustomHouseCommandPacket.fill():
+// a graphic and an offset, optionally a z, or a floor number on its own.
+function house_cmd( id, sub, arg := 0 )
+  var todo := struct{ todo := "house", id := id };
+  if ( !arg )
+    arg := struct{};
+  endif
+  arg.+sub := sub;
+  todo.+arg := arg;
+  clientcon.sendevent( todo );
+  return 1;
+endfunction
+
+function house_add( id, graphic, xoffset, yoffset )
+  return house_cmd( id, CH_ADD, struct{ graphic := graphic, x := xoffset, y := yoffset } );
+endfunction
+
+function house_add_multi( id, multiid, xoffset, yoffset )
+  return house_cmd( id, CH_ADD_MULTI, struct{ graphic := multiid, x := xoffset, y := yoffset } );
+endfunction
+
+function house_erase( id, graphic, xoffset, yoffset, zoffset )
+  return house_cmd( id, CH_ERASE, struct{ graphic := graphic, x := xoffset,
+                                          y := yoffset, z := zoffset } );
+endfunction
+
+function house_roof( id, sub, graphic, xoffset, yoffset, zoffset )
+  return house_cmd( id, sub, struct{ graphic := graphic, x := xoffset,
+                                     y := yoffset, z := zoffset } );
+endfunction
+
+function house_select_floor( id, floor )
+  return house_cmd( id, CH_SELECT_FLOOR, struct{ floor := floor } );
+endfunction
+
+// Opens the design editor on a house and waits for the client to be put into it.
+// Answers the design the server sent to start the session with.
+//
+// A house that is still open refuses the tool, so a case that failed before it
+// could quit would take every later one in the file down with it. Closing the
+// session here rather than in a cleanup keeps the cases independent of the order
+// they run in.
+//
+// Quitting a session keeps the working design rather than dropping it, so the
+// tiles a case laid down are still there when the next one opens the editor.
+// The session therefore starts with a revert, which is what puts the working
+// design back to the one the house is really built from - without it every case
+// would have to know what every case before it left behind.
+function enter_design( id, chr, multi )
+  // the member is house_editing, not editing - a plain "editing" reads back as
+  // an uninitialized object rather than failing, which looks exactly like a
+  // house that is not being edited
+  if ( multi.house_editing )
+    // a case that failed before it could quit; cancelling ends the session the
+    // way a quit does, which puts an end packet and a design on the wire. They
+    // have to be off it again before this session's own can be told apart from
+    // them - otherwise one failing case turns every later one in the file into
+    // "wanted a begin, got an end"
+    multi.cancelediting( chr, 1 );
+    drain_events();
+  endif
+  // leaving a design session parks the character on the front step, outside the
+  // footprint, and the tool only opens for one the house is holding up - so
+  // every entry after the first has to put it back first
+  MoveObjectToLocation( chr, house_x, house_y, 0, flags := MOVEOBJECT_FORCELOCATION );
+
+  Clear_Event_Queue();
+  var res := SendHousingTool( chr, multi );
+  if ( !res )
+    return ret_error( $"SendHousingTool refused: {res}" );
+  endif
+
+  var ev := waitForClient( id, { EVT_HOUSE_EDIT } );
+  if ( !ev )
+    return ret_error( $"client {id} was never put into design mode" );
+  endif
+  if ( CInt( ev.action ) != CH_EDIT_BEGIN )
+    return ret_error( $"client {id} got design action {ev.action}, wanted a begin" );
+  endif
+
+  // the design the tool sends, which still holds whatever the last session left
+  ev := wait_for_design( id );
+  if ( !ev )
+    return ev;
+  endif
+
+  // a revert answers with the committed design, so this is both the reset and
+  // the read of what the case starts from
+  house_cmd( id, CH_REVERT );
+  return wait_for_design( id );
+endfunction
+
+// Closes the editor from the client side and waits for the end packet. Answers a
+// plain 1 rather than the event: a case usually ends on this call, and the test
+// framework wants exactly 1 back from one that passed.
+//
+// Quitting also hands the client the design the house is really built from, and
+// that one is waited for too - every design the server sends has to be taken off
+// the queue by the case that caused it, or the next case reads it as the answer
+// to something of its own.
+function quit_design( id )
+  house_cmd( id, CH_QUIT );
+  var ev := waitForClient( id, { EVT_HOUSE_EDIT } );
+  if ( !ev )
+    return ret_error( $"client {id} was never taken out of design mode" );
+  endif
+  if ( CInt( ev.action ) != CH_EDIT_END )
+    return ret_error( $"client {id} got design action {ev.action}, wanted an end" );
+  endif
+  ev := wait_for_design( id );
+  if ( !ev )
+    return ev;
+  endif
+  return 1;
+endfunction
+
+// Reads events until none have come for a while. Only for putting the queue
+// back into a known state after something went wrong - it costs its whole
+// window every time it is called.
+function drain_events( quiet := QUIET_SECS )
+  var deadline := ReadMillisecondClock() + quiet * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    if ( Wait_For_Event( POLL_INTERVAL ) )
+      deadline := ReadMillisecondClock() + quiet * 1000;
+    endif
+  endwhile
+  return 1;
+endfunction
+
+// Makes the working design the one the house is really built from, and waits
+// for the client to be taken out of the editor. A commit ends the session the
+// same way a quit does - the character is put back on the front step and the
+// design goes out to everyone in range - so nothing is left to close afterwards.
+//
+// A house with a commit script attached would answer by asking the character to
+// accept rather than by ending the session; the test shard has none, so this is
+// the straight-through path.
+function commit_design( id )
+  house_cmd( id, CH_COMMIT );
+  var ev := waitForClient( id, { EVT_HOUSE_EDIT } );
+  if ( !ev )
+    return ret_error( $"client {id} was never taken out of design mode by a commit" );
+  endif
+  if ( CInt( ev.action ) != CH_EDIT_END )
+    return ret_error( $"client {id} got design action {ev.action}, wanted an end" );
+  endif
+  return 1;
+endfunction
+
+// Waits for the next design the server sends a client.
+function wait_for_design( id, timeout := 10 )
+  var ev := waitForClient( id, { EVT_HOUSE_DESIGN }, timeout );
+  if ( !ev )
+    return ret_error( $"client {id} was sent no design within {timeout}s" );
+  endif
+  return ev;
+endfunction
+
+// Asserts that a client is sent no design at all. The whole cost of a case that
+// wants this is the wait, so it is kept short - see the wait cost model in
+// communication.inc.
+function wait_for_no_design( id, timeout := QUIET_SECS )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    var ev := Wait_For_Event( POLL_INTERVAL );
+    if ( !ev or ev.type != EVT_HOUSE_DESIGN or CInt( ev.id ) != id )
+      continue;
+    endif
+    return ret_error( $"client {id} was sent a design at revision {ev.revision}" );
+  endwhile
+  return 1;
+endfunction
+
+// Asks for the working design and waits for it, which is how a case knows the
+// commands it sent before have been read. Answers that design.
+//
+// This is the synchronisation every case needs and the revision is not: a synch
+// travels the same connection as the commands ahead of it, so by the time its
+// answer is in, the design escript reads through house_parts is the one those
+// commands left behind.
+//
+// What it cannot be used for is the revision. CustomHousesSendFull keeps the
+// packet it built in WorkingCompressed and replays it byte for byte until an
+// edit throws it away, so a design built before a revision was incremented goes
+// on being sent under the old number. Erase and clear both send before they
+// increment, which is what erase_revision_lags in test_client_house_erase.src
+// pins down.
+function house_settle( id )
+  house_cmd( id, CH_SYNCH );
+  return wait_for_design( id );
+endfunction
+
+// Asks the server for the working design over and over until the one it sends
+// back is at the wanted revision, and hands that design over.
+//
+// Most subcommands bump the revision without sending anything, so a client is
+// usually behind the model it is editing. A synch is the only way to make it
+// catch up, and a design already on its way can be older than the one asked for
+// - never one-shot this.
+function client_sees_revision( id, revision, timeout := 5 )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  var last := -1;
+
+  while ( ReadMillisecondClock() < deadline )
+    Clear_Event_Queue();
+    house_cmd( id, CH_SYNCH );
+    var ev := waitForClient( id, { EVT_HOUSE_DESIGN }, 1 );
+    if ( !ev )
+      continue;
+    endif
+    last := CInt( ev.revision );
+    if ( last == revision )
+      return ev;
+    endif
+    Sleepms( POLL_INTERVAL * 1000 );
+  endwhile
+
+  if ( last < 0 )
+    return ret_error( $"client {id} answered no synch within {timeout}s" );
+  endif
+  return ret_error( $"client {id} is at design revision {last}, wanted {revision}" );
+endfunction
+
+// Every part of the design escript sees with that graphic at that offset. The
+// counterpart of design_tiles_at(), which reads what the client was sent.
+function house_parts_at( multi, graphic, xoffset, yoffset )
+  var found := array{};
+  foreach part in ( multi.house_parts )
+    if ( part.graphic == graphic && part.xoffset == xoffset && part.yoffset == yoffset )
+      found.append( part );
+    endif
+  endforeach
+  return found;
+endfunction
+
+// Every tile of a design event with that graphic at that offset, whatever its z.
+// The design the client is sent carries its offsets the way the multi does, so
+// they line up with the xoffset/yoffset of house_parts.
+function design_tiles_at( ev, graphic, xoffset, yoffset )
+  var found := array{};
+  // the client events come out of UnpackJson, so every number in them is a Double
+  foreach tile in ( ev.tiles )
+    if ( CInt( tile.graphic ) == graphic && CInt( tile.x ) == xoffset && CInt( tile.y ) == yoffset )
+      found.append( tile );
+    endif
+  endforeach
+  return found;
+endfunction
+
+// Asserts that the design holds exactly one part with that graphic at that
+// offset, and that it sits at the wanted z. A part keeps the z it was given
+// while the plane it belongs to is picked from it, so the two are worth telling
+// apart in a failure message.
+function expect_part( multi, graphic, xoffset, yoffset, zoffset )
+  var found := house_parts_at( multi, graphic, xoffset, yoffset );
+  var count := found.size();
+  if ( count != 1 )
+    return ret_error( $"0x{graphic:x} at {xoffset},{yoffset} is in the design {count} times" );
+  endif
+  var z := found[1].z;
+  if ( z != zoffset )
+    return ret_error( $"0x{graphic:x} at {xoffset},{yoffset} sits at z {z}, wanted {zoffset}" );
+  endif
+  return 1;
+endfunction
+
+// Asserts that the design has no part with that graphic at that offset at all.
+function expect_no_part( multi, graphic, xoffset, yoffset )
+  var count := house_parts_at( multi, graphic, xoffset, yoffset ).size();
+  if ( count )
+    return ret_error( $"0x{graphic:x} at {xoffset},{yoffset} is still in the design {count} times" );
+  endif
+  return 1;
+endfunction
+
+// Asserts the design is the size it should be. Almost every command is judged
+// by what it did to the part count, and a bare number in a failure says nothing.
+function expect_parts( multi, wanted, what )
+  var count := multi.house_parts.size();
+  if ( count != wanted )
+    return ret_error( $"the design has {count} parts after {what}, wanted {wanted}" );
+  endif
+  return 1;
+endfunction
+
+// Whether the design the client was sent holds together: what its header claims
+// and what its planes actually carried have to be the same number of tiles.
+function design_is_consistent( ev )
+  var claimed := CInt( ev.numtiles );
+  var got := ev.tiles.size();
+  if ( claimed != got )
+    return ret_error( $"design says {claimed} tiles, its planes carried {got}" );
+  endif
+  return 1;
+endfunction

--- a/testsuite/pol/testpkgs/client/syshook.cfg
+++ b/testsuite/pol/testpkgs/client/syshook.cfg
@@ -2,3 +2,8 @@ SystemHookScript cantradehook
 {
 	CanTrade	CanTradeHook
 }
+
+SystemHookScript closehousehook
+{
+	CloseCustomHouse	CloseCustomHouseHook
+}

--- a/testsuite/pol/testpkgs/client/test_client_boat.src
+++ b/testsuite/pol/testpkgs/client/test_client_boat.src
@@ -158,29 +158,22 @@ exported function boat_pilot_mbr_mth()
     return ret_error( $"Unexpected success when setting pilot of an already-pilotted boat: {res}" );
   endif
 
-  clientcon.sendevent( struct{ todo := "list_equipped_items", arg := char.serial, id := 0 } );
-  var ev := waitForClient( 0, { EVT_LIST_EQUIPPED_ITEMS } );
-  if ( !ev )
-    return ev;
-  endif
-
   var mountpiece := GetEquipmentByLayer( char, LAYER_MOUNT );
 
   if ( !mountpiece )
     return ret_error( "Character does not have an equipped mount piece." );
   endif
 
-  var mountpiece_found := 0;
-
-  foreach item in ( ev.objs )
-    if ( item.serial == mountpiece.serial && item.layer == LAYER_MOUNT )
-      mountpiece_found := 1;
-      break;
-    endif
-  endforeach
-
-  if ( !mountpiece_found )
-    return ret_error( "Character mount piece not found on list of equipped items from client." );
+  // the client is told about the mount piece by a packet it has not necessarily
+  // read yet, so this asks again until it has rather than judging the first
+  // listing it answers with
+  var entry := client_finds_layer( clientcon, 0, char.serial, LAYER_MOUNT );
+  if ( !entry )
+    return entry;
+  endif
+  var worn := CInt( entry.serial );
+  if ( worn != mountpiece.serial )
+    return ret_error( $"the client has 0x{worn:x} on the mount layer, not the mount piece" );
   endif
 
   res := boat.set_pilot( 0 );
@@ -196,26 +189,8 @@ exported function boat_pilot_mbr_mth()
     return ret_error( "Character erroneously has an equipped mount piece." );
   endif
 
-  Clear_Event_Queue();
-  clientcon.sendevent( struct{ todo := "list_equipped_items", arg := char.serial, id := 0 } );
-  ev := waitForClient( 0, { EVT_LIST_EQUIPPED_ITEMS } );
-  if ( !ev )
-    return ev;
-  endif
-
-  mountpiece_found := 0;
-
-  foreach item in ( ev.objs )
-    if ( item.layer == LAYER_MOUNT )
-      mountpiece_found := 1;
-      break;
-    endif
-  endforeach
-
-  if ( mountpiece_found )
-    return ret_error( "Character erroneously has a mount piece found on list of equipped items from client." );
-  endif
-  return 1;
+  // and the same the other way round: the removal is a packet too
+  return client_lost_layer( clientcon, 0, char.serial, LAYER_MOUNT );
 endfunction
 
 exported function boat_pilot_packets()

--- a/testsuite/pol/testpkgs/client/test_client_corpse.src
+++ b/testsuite/pol/testpkgs/client/test_client_corpse.src
@@ -76,9 +76,7 @@ exported function test_corpse_equipment()
   // The corpse_content should only contain the equipped items (and not the goldcoin),
   // as the container has not been opened.
   //
-  Clear_Event_Queue();
-  clientcon.sendevent( struct{ todo := "list_equipped_items", arg := corpse.serial, id := 0 } );
-  if ( !( corpse_equipment := waitForClient( 0, { EVT_LIST_EQUIPPED_ITEMS } ) ) )
+  if ( !( corpse_equipment := list_client_equipment( clientcon, 0, corpse.serial ) ) )
     return cleanup_ret_error( $"Could not list corpse equipment: {corpse_equipment}" );
   endif
 

--- a/testsuite/pol/testpkgs/client/test_client_house.src
+++ b/testsuite/pol/testpkgs/client/test_client_house.src
@@ -1,0 +1,238 @@
+// The custom house design session, end to end: that a client can be put into
+// one, that the 0xD7 commands it sends reach the design, and that the 0xD8 the
+// server sends back describes the same design escript sees.
+//
+// This is the file that proves the design protocol plumbing works at all. The
+// per-command cases live in the other test_client_house_* files.
+
+include "customhouse";
+
+program test_client_house()
+  return house_setup();
+endprogram
+
+// Opening the editor puts the client into design mode and sends it the working
+// design, which at that point is the bare foundation.
+exported function house_enter_and_quit( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  if ( CInt( ev.serial ) != house.serial )
+    return ret_error( $"the design is for 0x{ev.serial:x}, expected 0x{house.serial:x}" );
+  endif
+  if ( !house.house_editing )
+    return ret_error( "the house does not consider itself edited" );
+  endif
+
+  var res := design_is_consistent( ev );
+  if ( !res )
+    return res;
+  endif
+
+  // the design the client was sent is the one house_parts reads back
+  var parts := house.house_parts.size();
+  var tiles := ev.tiles.size();
+  if ( parts != tiles )
+    return ret_error( $"the client was sent {tiles} tiles, house_parts has {parts}" );
+  endif
+
+  res := quit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  if ( house.house_editing )
+    return ret_error( "the house still considers itself edited after a quit" );
+  endif
+  return 1;
+endfunction
+
+// A tile added over the wire lands in the working design, and a synch after it
+// hands the client the design that now holds it.
+//
+// The add is an AddOrReplace: a floor tile put where the design already has one
+// takes its place rather than stacking on it, so the tile count does not move.
+// What changes is which graphic is at the offset - in both views of the design.
+exported function house_add_reaches_design( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+  var revision := CInt( ev.revision );
+
+  var already := design_tiles_at( ev, CH_DIRT, 0, 0 ).size();
+  if ( already )
+    return ret_error( $"the design already had {already} dirt tiles at the centre" );
+  endif
+
+  house_add( 0, CH_DIRT, 0, 0 );
+
+  ev := client_sees_revision( 0, revision + 1 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := design_is_consistent( ev );
+  if ( !res )
+    return res;
+  endif
+
+  // what the client was sent
+  var placed := design_tiles_at( ev, CH_DIRT, 0, 0 ).size();
+  if ( placed != 1 )
+    return ret_error( $"the client was sent {placed} tiles at the added offset" );
+  endif
+
+  // and what escript reads back out of the same design
+  var parts := house_parts_at( house, CH_DIRT, 0, 0 ).size();
+  if ( parts != 1 )
+    return ret_error( $"house_parts has {parts} tiles at the added offset" );
+  endif
+
+  var after := house.house_parts.size();
+  if ( after != before )
+    return ret_error( $"a replacing add moved the part count from {before} to {after}" );
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// A synch asks for the design again without changing it, so the revision the
+// second one carries is the one the first already had.
+exported function house_synch_keeps_revision( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+
+  ev := client_sees_revision( 0, revision );
+  if ( !ev )
+    return ev;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// TODO core bug 10: re-enable once the plane loop indexes by plane instead of by count.
+// A design whose used storeys have a gap loses everything above the gap.
+//
+// CustomHousesSendFull asks NumUsedPlanes() how many planes to send and then
+// loops i from 0 to that number, using i as the plane index as well as the loop
+// counter (customhouses.cpp:1049, :1068) - so it only ever sends planes
+// 0..count-1. That is right while the used planes are a run starting at 0, and
+// wrong as soon as there is a hole in them.
+//
+// This house uses planes 0, 1 and 2 out of the multi it was built from. Putting
+// a tile on storey 4 makes plane 4 used while plane 3 stays empty, so four
+// planes are used, the loop sends 0, 1, 2 and the empty 3, and the storey 4 tile
+// never leaves the server. numtiles is TotalSize() and still counts it, so the
+// packet contradicts itself - which is what design_is_consistent() catches.
+// exported function house_storey_gap_lost( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+
+//   house_select_floor( 0, 4 );
+//   ev := wait_for_design( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+
+//   house_add( 0, CH_ROOF, 0, 0 );
+//   ev := house_settle( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+
+//   // escript sees the tile on the fourth storey
+//   var res := expect_part( house, CH_ROOF, 0, 0, CH_PLANE_Z4 );
+//   if ( !res )
+//     return res;
+//   endif
+
+//   // and the design the client was sent should hold everything it says it does
+//   res := design_is_consistent( ev );
+//   if ( !res )
+//     return res;
+//   endif
+
+//   return quit_design( 0 );
+// endfunction
+
+// TODO core bug 11: re-enable once an oversized plane is split or refused.
+// A plane holding more tiles than its header can describe goes out mis-encoded.
+//
+// Each plane header gives the uncompressed and the compressed length 12 bits
+// each (customhouses.cpp:1078), so a plane tops out at 4095 bytes - 819 tiles at
+// five bytes apiece. Neither length is checked before it is packed, so a bigger
+// plane has its length silently truncated: the client is told a length that is
+// short by whole multiples of 4096, and everything after that plane in the
+// buffer is read from the wrong offset.
+//
+// This one cannot be left running even once it is understood, which is why it is
+// commented out rather than asserting the current behaviour. The test client
+// does check the announced length against what it inflated, so it raises inside
+// the packet handler, and a raise there kills the client thread for the rest of
+// the run - every later case in the package then fails with something that has
+// nothing to do with this.
+//
+// Tiles stack rather than replace on the addhousepart path, so a plane of any
+// size can be built at a single offset. addhousepart writes the current design
+// and refuses while the house is being edited, and the revert enter_design opens
+// with is what pulls it into the working design that gets sent.
+// exported function house_plane_too_large( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//
+//   var parts := array{};
+//   var i := 0;
+//   while ( i < CH_PLANE_MAX_TILES )
+//     var part := struct{};
+//     part.+graphic := CH_ROOF;
+//     part.+xoffset := 0;
+//     part.+yoffset := 0;
+//     part.+z := CH_PLANE_Z1;
+//     parts.append( part );
+//     i := i + 1;
+//   endwhile
+//
+//   var res := house.addhousepart( parts );
+//   if ( !res )
+//     return ret_error( $"could not fill the plane: {res}" );
+//   endif
+//
+//   // the revert inside this hands the client the oversized design
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   res := design_is_consistent( ev );
+//   if ( !res )
+//     return res;
+//   endif
+//
+//   return quit_design( 0 );
+// endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house.src
+++ b/testsuite/pol/testpkgs/client/test_client_house.src
@@ -133,16 +133,16 @@ endfunction
 //
 // CustomHousesSendFull asks NumUsedPlanes() how many planes to send and then
 // loops i from 0 to that number, using i as the plane index as well as the loop
-// counter (customhouses.cpp:1049, :1068) - so it only ever sends planes
-// 0..count-1. That is right while the used planes are a run starting at 0, and
-// wrong as soon as there is a hole in them.
+// counter - so it only ever sends planes 0..count-1. That is right while the
+// used planes are a run starting at 0, and wrong as soon as there is a hole in
+// them.
 //
 // This house uses planes 0, 1 and 2 out of the multi it was built from. Putting
 // a tile on storey 4 makes plane 4 used while plane 3 stays empty, so four
 // planes are used, the loop sends 0, 1, 2 and the empty 3, and the storey 4 tile
 // never leaves the server. numtiles is TotalSize() and still counts it, so the
 // packet contradicts itself - which is what design_is_consistent() catches.
-// exported function house_storey_gap_lost( resmgn )
+// exported function house_storey_gap_sent( resmgn )
 //   var started := house_start( resmgn );
 //   if ( !started )
 //     return started;
@@ -151,31 +151,42 @@ endfunction
 //   if ( !ev )
 //     return ev;
 //   endif
-
+//
 //   house_select_floor( 0, 4 );
 //   ev := wait_for_design( 0 );
 //   if ( !ev )
 //     return ev;
 //   endif
-
+//
 //   house_add( 0, CH_ROOF, 0, 0 );
 //   ev := house_settle( 0 );
 //   if ( !ev )
 //     return ev;
 //   endif
-
+//
 //   // escript sees the tile on the fourth storey
 //   var res := expect_part( house, CH_ROOF, 0, 0, CH_PLANE_Z4 );
 //   if ( !res )
 //     return res;
 //   endif
-
-//   // and the design the client was sent should hold everything it says it does
+//
+//   // and the design the client was sent holds everything it says it does
 //   res := design_is_consistent( ev );
 //   if ( !res )
 //     return res;
 //   endif
-
+//
+//   // and the storey 4 tile is in it
+//   var found := design_tiles_at( ev, CH_ROOF, 0, 0 );
+//   if ( found.size() != 1 )
+//     var count := found.size();
+//     return ret_error( $"the client was sent {count} of the storey 4 tile" );
+//   endif
+//   var tile_z := CInt( found[1].z );
+//   if ( tile_z != CH_PLANE_Z4 )
+//     return ret_error( $"the storey 4 tile reached the client at z {tile_z}" );
+//   endif
+//
 //   return quit_design( 0 );
 // endfunction
 
@@ -183,11 +194,11 @@ endfunction
 // A plane holding more tiles than its header can describe goes out mis-encoded.
 //
 // Each plane header gives the uncompressed and the compressed length 12 bits
-// each (customhouses.cpp:1078), so a plane tops out at 4095 bytes - 819 tiles at
-// five bytes apiece. Neither length is checked before it is packed, so a bigger
-// plane has its length silently truncated: the client is told a length that is
-// short by whole multiples of 4096, and everything after that plane in the
-// buffer is read from the wrong offset.
+// each, so a plane tops out at 4095 bytes - 819 tiles at five bytes apiece.
+// Neither length is checked before it is packed, so a bigger plane has its
+// length silently truncated: the client is told a length that is short by whole
+// multiples of 4096, and everything after that plane in the buffer is read from
+// the wrong offset.
 //
 // This one cannot be left running even once it is understood, which is why it is
 // commented out rather than asserting the current behaviour. The test client
@@ -232,6 +243,31 @@ endfunction
 //   res := design_is_consistent( ev );
 //   if ( !res )
 //     return res;
+//   endif
+//
+//   // every one of them reached the client
+//   var stacked := design_tiles_at( ev, CH_ROOF, 0, 0 ).size();
+//   if ( stacked != CH_PLANE_MAX_TILES )
+//     return ret_error( $"the client was sent {stacked} of the stacked tiles" );
+//   endif
+//
+//   // no plane claims a length its header cannot carry, and the storey they went
+//   // on needed more than one plane of its own
+//   var oversized := 0;
+//   var on_that_floor := 0;
+//   foreach plane in ( ev.planes )
+//     if ( CInt( plane.ulen ) > CH_PLANE_MAX_LEN or CInt( plane.clen ) > CH_PLANE_MAX_LEN )
+//       oversized := oversized + 1;
+//     endif
+//     if ( CInt( plane.index ) == CH_PLANE_INDEX_Z1 )
+//       on_that_floor := on_that_floor + 1;
+//     endif
+//   endforeach
+//   if ( oversized )
+//     return ret_error( $"{oversized} planes are longer than a plane header describes" );
+//   endif
+//   if ( on_that_floor < 2 )
+//     return ret_error( $"the oversized storey went out in {on_that_floor} planes" );
 //   endif
 //
 //   return quit_design( 0 );

--- a/testsuite/pol/testpkgs/client/test_client_house_accept.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_accept.src
@@ -58,14 +58,13 @@ exported function commit_holds_for_accept( resmgn )
     return release_hold( ret_error( "a held commit closed the session anyway" ) );
   endif
 
-  // The tool refuses, but for being open rather than for waiting: mf_SendHousingTool
-  // tests house->editing first and a commit does not clear it, so its own
-  // "waiting for a commit" answer cannot be reached from here at all.
+  // The tool refuses for waiting rather than for being open: a commit leaves
+  // editing set, and mf_SendHousingTool reports the narrower of the two states.
   var tool := SendHousingTool( char, house );
   if ( tool )
     return release_hold( ret_error( "the tool opened a second session on a waiting house" ) );
   endif
-  if ( tool.errortext != "House currently being customized." )
+  if ( tool.errortext != "House currently being waiting for a commit" )
     return release_hold( ret_error( $"the tool refused with {tool.errortext}" ) );
   endif
 
@@ -264,91 +263,94 @@ function wait_for_commit_call( timeout := 10 )
   return ret_error( $"the commit script did not run within {timeout}s" );
 endfunction
 
-// TODO core bug 7: re-enable once AcceptHouseCommit calls the CloseCustomHouse hook.
-// The hook is not called when a session ends in a commit. AcceptHouseCommit
-// (house.cpp:1159) calls CustomHouseStopEditing directly rather than going
-// through UHouse::CustomHousesQuit, and the hook is called from the latter only
-// - so of the three ways a design session can end, the two that throw the
-// changes away are reported and the one that keeps them is not. A shard using
-// the hook to let go of whatever it set up for the session never hears about a
-// house that was actually rebuilt.
-// exported function close_hook_on_commit( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var ev := enter_design( 0, char, house );
-//   if ( !ev )
-//     return ev;
-//   endif
+// A commit on a shard that has a commit script does not call the
+// CloseCustomHouse hook, because misc/customhousecommit.ecl is the notification
+// for that route and is handed the same character and house - calling both would
+// report one commit twice. The core calls the hook only where that script is
+// missing, so nothing is left unsaid either way.
 //
-//   EraseGlobalProperty( "#CloseHouseCall" );
-//   var res := commit_design( 0 );
-//   if ( !res )
-//     return res;
-//   endif
-//   ev := wait_for_design( 0 );
-//   if ( !ev )
-//     return ev;
-//   endif
-//
-//   var call := GetGlobalProperty( "#CloseHouseCall" );
-//   if ( !call )
-//     return ret_error( "the CloseCustomHouse hook was not called on a commit" );
-//   endif
-//   return 1;
-// endfunction
+// The other half of that rule cannot be tested here: the commit script is
+// shard-wide and always present in this test shard, so the no-script route is
+// out of reach. This case pins the half that is reachable, and pins it as
+// deliberate so the silence is not read as an oversight.
+exported function commit_skips_close_hook( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
 
-// TODO core bug 5: re-enable once SendHousingTool checks for a client.
-// SendHousingTool on a character with no client takes the shard down.
-// mf_SendHousingTool (uomod2.cpp:2570) reads chr->client->acctSupports() as its
-// very first test, before the multi is even looked at, and nothing on the way in
-// checks that there is a client - getCharacterParam takes any mobile, npcs
-// included. Every other refusal in that function is a tidy BError, so this is
-// the one parameter nobody thought of.
-// exported function tool_on_a_mobile_with_no_client( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
-//   if ( !npc )
-//     return ret_error( $"could not make the npc: {npc}" );
-//   endif
-//
-//   var res := SendHousingTool( npc, house );
-//   npc.Kill();
-//   if ( res )
-//     return ret_error( "the tool opened for a mobile with no client" );
-//   endif
-//   return 1;
-// endfunction
+  EraseGlobalProperty( "#CloseHouseCall" );
+  EraseGlobalProperty( "#HouseCommitCall" );
+  var res := commit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
 
-// TODO core bug 6: re-enable once cancelediting checks for a client.
-// cancelediting on a character with no client takes the shard down the same way.
-// MTH_CANCEL_EDITING (house.cpp:533) reaches
-// chr->client->gd->custom_house_serial to decide whether that character is the
-// one editing this house, and there is no null check anywhere before it. The
-// method already answers "House is currently not been edited" and "Not enough
-// parameters" as errors, so a mobile with no client belongs in the same list.
-// exported function cancel_by_a_mobile_with_no_client( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var ev := enter_design( 0, char, house );
-//   if ( !ev )
-//     return ev;
-//   endif
-//   var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
-//   if ( !npc )
-//     return ret_error( $"could not make the npc: {npc}" );
-//   endif
-//
-//   var res := house.cancelediting( npc, 1 );
-//   npc.Kill();
-//   if ( res )
-//     return ret_error( "a mobile with no client cancelled the session" );
-//   endif
-//   return quit_design( 0 );
-// endfunction
+  // the commit script is what the shard is told with, and it was
+  var commit_call := GetGlobalProperty( "#HouseCommitCall" );
+  if ( !commit_call )
+    return ret_error( "the commit script was not called on a commit" );
+  endif
+  if ( CInt( commit_call.house ) != house.serial )
+    return ret_error( "the commit script was told about another house" );
+  endif
+
+  // and the hook was not
+  var call := GetGlobalProperty( "#CloseHouseCall" );
+  if ( call )
+    return ret_error( "the CloseCustomHouse hook was called on a commit as well" );
+  endif
+  return 1;
+endfunction
+
+// getCharacterParam takes any mobile, npcs included, and the tool has nowhere to
+// go without a client.
+exported function tool_on_a_mobile_with_no_client( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
+  if ( !npc )
+    return ret_error( $"could not make the npc: {npc}" );
+  endif
+
+  var res := SendHousingTool( npc, house );
+  npc.Kill();
+  if ( res )
+    return ret_error( "the tool opened for a mobile with no client" );
+  endif
+  return 1;
+endfunction
+
+// Which character is editing a house is read off its client, so a mobile with
+// none is not that character and cannot end the session.
+exported function cancel_by_a_mobile_no_client( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
+  if ( !npc )
+    return ret_error( $"could not make the npc: {npc}" );
+  endif
+
+  var res := house.cancelediting( npc, 1 );
+  npc.Kill();
+  if ( res )
+    return ret_error( "a mobile with no client cancelled the session" );
+  endif
+  return quit_design( 0 );
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_accept.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_accept.src
@@ -1,0 +1,354 @@
+// What a commit does when the shard has a commit script, and what the
+// CloseCustomHouse system hook is told.
+//
+// With scripts/misc/customhousecommit.ecl in place the core stops applying a
+// commit itself: it puts the house into "waiting for accept" and hands it to the
+// script, and nothing changes until somebody calls acceptcommit(). That script
+// is shard-wide and every commit in the run goes through it, so it only holds a
+// house when a test has parked something in #HouseCommitHold - the cases here
+// arm it, and cleanup.src disarms it whatever happens.
+
+include "customhouse";
+
+program test_client_house_accept()
+  return house_setup();
+endprogram
+
+// Holding a commit leaves the house waiting: the working design is what it was,
+// the session is still open, and the tool refuses to open a second one.
+exported function commit_holds_for_accept( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var res := arm_commit_hold();
+  if ( !res )
+    return res;
+  endif
+
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  // the commit has to find the tile there, so it waits for it
+  house_add( 0, CH_DIRT, 0, HOUSE_STEP_Y );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return release_hold( ev );
+  endif
+
+  var call := wait_for_commit_call();
+  if ( !call )
+    return release_hold( call );
+  endif
+  if ( CInt( call.character ) != char.serial )
+    return release_hold( ret_error( $"the commit script was passed character {call.character}" ) );
+  endif
+  if ( CInt( call.house ) != house.serial )
+    return release_hold( ret_error( $"the commit script was passed house {call.house}" ) );
+  endif
+
+  // it is handed the design as it stands, which is the working one - the tile
+  // that has not been committed yet is already in what the script counts
+  var parts := house.house_parts.size();
+  if ( CInt( call.parts ) != parts )
+    return release_hold( ret_error( $"the script saw {call.parts} parts, the house has {parts}" ) );
+  endif
+  if ( !house.house_editing )
+    return release_hold( ret_error( "a held commit closed the session anyway" ) );
+  endif
+
+  // The tool refuses, but for being open rather than for waiting: mf_SendHousingTool
+  // tests house->editing first and a commit does not clear it, so its own
+  // "waiting for a commit" answer cannot be reached from here at all.
+  var tool := SendHousingTool( char, house );
+  if ( tool )
+    return release_hold( ret_error( "the tool opened a second session on a waiting house" ) );
+  endif
+  if ( tool.errortext != "House currently being customized." )
+    return release_hold( ret_error( $"the tool refused with {tool.errortext}" ) );
+  endif
+
+  res := release_hold( 1 );
+  if ( !res )
+    return res;
+  endif
+
+  // accepting applies the design and ends the session
+  res := house.acceptcommit( char, 1 );
+  if ( !res )
+    return ret_error( $"acceptcommit refused: {res}" );
+  endif
+  ev := waitForClient( 0, { EVT_HOUSE_EDIT } );
+  if ( !ev )
+    return ret_error( "accepting the commit did not close the session" );
+  endif
+  if ( house.house_editing )
+    return ret_error( "the house still considers itself edited after an accept" );
+  endif
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  return expect_part( house, CH_DIRT, 0, HOUSE_STEP_Y, CH_PLANE_Z );
+endfunction
+
+// Refusing the commit hands the working design back and leaves the session
+// open, so the player can carry on drawing where they left off.
+exported function commit_accept_refused( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var res := arm_commit_hold();
+  if ( !res )
+    return res;
+  endif
+
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  house_add( 0, CH_ROOF, 0, 0 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return release_hold( ev );
+  endif
+
+  var call := wait_for_commit_call();
+  if ( !call )
+    return release_hold( call );
+  endif
+
+  res := release_hold( 1 );
+  if ( !res )
+    return res;
+  endif
+
+  res := house.acceptcommit( char, 0 );
+  if ( !res )
+    return ret_error( $"acceptcommit( 0 ) refused: {res}" );
+  endif
+
+  // the working design comes back, still holding the tile that was not committed
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var kept := design_tiles_at( ev, CH_ROOF, 0, 0 ).size();
+  if ( kept != 1 )
+    return ret_error( $"the design a refused commit sent holds {kept} of the tile" );
+  endif
+  if ( !house.house_editing )
+    return ret_error( "a refused commit closed the session" );
+  endif
+
+  // and the house is not waiting for anything any more
+  res := house.acceptcommit( char, 1 );
+  if ( res )
+    return ret_error( $"acceptcommit answered again after a refusal: {res}" );
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// The CloseCustomHouse hook is told who left which house, and by the time it is
+// called the house has already stopped considering itself edited.
+exported function close_hook_on_quit( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  EraseGlobalProperty( "#CloseHouseCall" );
+  var res := quit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+
+  var call := GetGlobalProperty( "#CloseHouseCall" );
+  if ( !call )
+    return ret_error( "the CloseCustomHouse hook was not called on a quit" );
+  endif
+  if ( call.character != char.serial )
+    return ret_error( $"the hook was passed character {call.character}" );
+  endif
+  if ( call.house != house.serial )
+    return ret_error( $"the hook was passed house {call.house}" );
+  endif
+  if ( call.editing )
+    return ret_error( "the hook was called while the house still called itself edited" );
+  endif
+  return 1;
+endfunction
+
+// A script closing the session with cancelediting goes through the same path a
+// client quit does, so the hook hears about that too.
+exported function close_hook_on_cancel( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  EraseGlobalProperty( "#CloseHouseCall" );
+  var res := house.cancelediting( char, 1 );
+  if ( !res )
+    return ret_error( $"cancelediting refused: {res}" );
+  endif
+
+  var call := GetGlobalProperty( "#CloseHouseCall" );
+  if ( !call )
+    return ret_error( "the CloseCustomHouse hook was not called on a cancel" );
+  endif
+  if ( call.house != house.serial )
+    return ret_error( $"the hook was passed house {call.house}" );
+  endif
+  if ( house.house_editing )
+    return ret_error( "cancelediting left the house being edited" );
+  endif
+
+  // cancelling ends the session the way a quit does, so the end packet and the
+  // design it sends have to come off the queue before the next case opens one
+  ev := waitForClient( 0, { EVT_HOUSE_EDIT } );
+  if ( !ev )
+    return ret_error( "the client was not taken out of design mode by a cancel" );
+  endif
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  return 1;
+endfunction
+
+// Arms the commit script to hold, and proves it is armed before anything relies
+// on it. The property is read by a shard-wide script, so a case that leaves it
+// set would stop every later commit in the run - cleanup.src erases it too.
+function arm_commit_hold()
+  EraseGlobalProperty( "#HouseCommitCall" );
+  SetGlobalProperty( "#HouseCommitHold", 1 );
+  if ( !GetGlobalProperty( "#HouseCommitHold" ) )
+    return ret_error( "could not arm the commit hold" );
+  endif
+  return 1;
+endfunction
+
+// Takes the hold off and hands back whatever it was given, so a case can let go
+// of it on the way out of a failure as well as at the end.
+function release_hold( res )
+  EraseGlobalProperty( "#HouseCommitHold" );
+  return res;
+endfunction
+
+// Commits and waits for the commit script to say it was called. The script is
+// started rather than called, so it does not run in step with the packet that
+// asked for it.
+function wait_for_commit_call( timeout := 10 )
+  house_cmd( 0, CH_COMMIT );
+
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    var call := GetGlobalProperty( "#HouseCommitCall" );
+    if ( call )
+      return call;
+    endif
+    Sleepms( POLL_INTERVAL * 1000 );
+  endwhile
+  return ret_error( $"the commit script did not run within {timeout}s" );
+endfunction
+
+// TODO core bug 7: re-enable once AcceptHouseCommit calls the CloseCustomHouse hook.
+// The hook is not called when a session ends in a commit. AcceptHouseCommit
+// (house.cpp:1159) calls CustomHouseStopEditing directly rather than going
+// through UHouse::CustomHousesQuit, and the hook is called from the latter only
+// - so of the three ways a design session can end, the two that throw the
+// changes away are reported and the one that keeps them is not. A shard using
+// the hook to let go of whatever it set up for the session never hears about a
+// house that was actually rebuilt.
+// exported function close_hook_on_commit( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   EraseGlobalProperty( "#CloseHouseCall" );
+//   var res := commit_design( 0 );
+//   if ( !res )
+//     return res;
+//   endif
+//   ev := wait_for_design( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   var call := GetGlobalProperty( "#CloseHouseCall" );
+//   if ( !call )
+//     return ret_error( "the CloseCustomHouse hook was not called on a commit" );
+//   endif
+//   return 1;
+// endfunction
+
+// TODO core bug 5: re-enable once SendHousingTool checks for a client.
+// SendHousingTool on a character with no client takes the shard down.
+// mf_SendHousingTool (uomod2.cpp:2570) reads chr->client->acctSupports() as its
+// very first test, before the multi is even looked at, and nothing on the way in
+// checks that there is a client - getCharacterParam takes any mobile, npcs
+// included. Every other refusal in that function is a tidy BError, so this is
+// the one parameter nobody thought of.
+// exported function tool_on_a_mobile_with_no_client( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
+//   if ( !npc )
+//     return ret_error( $"could not make the npc: {npc}" );
+//   endif
+//
+//   var res := SendHousingTool( npc, house );
+//   npc.Kill();
+//   if ( res )
+//     return ret_error( "the tool opened for a mobile with no client" );
+//   endif
+//   return 1;
+// endfunction
+
+// TODO core bug 6: re-enable once cancelediting checks for a client.
+// cancelediting on a character with no client takes the shard down the same way.
+// MTH_CANCEL_EDITING (house.cpp:533) reaches
+// chr->client->gd->custom_house_serial to decide whether that character is the
+// one editing this house, and there is no null check anywhere before it. The
+// method already answers "House is currently not been edited" and "Not enough
+// parameters" as errors, so a mobile with no client belongs in the same list.
+// exported function cancel_by_a_mobile_with_no_client( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//   var npc := CreateNpcFromTemplate( ":testclient:test_snooping", house_x, house_y, 0 );
+//   if ( !npc )
+//     return ret_error( $"could not make the npc: {npc}" );
+//   endif
+//
+//   var res := house.cancelediting( npc, 1 );
+//   npc.Kill();
+//   if ( res )
+//     return ret_error( "a mobile with no client cancelled the session" );
+//   endif
+//   return quit_design( 0 );
+// endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_commit.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_commit.src
@@ -1,0 +1,247 @@
+// Committing a design, and what the 0xD7 packet does when it has no session to
+// belong to.
+//
+// A commit is the only command that changes the house rather than the design
+// being drawn on it: it ends the session, makes the working design the current
+// one and hands that design to everybody who can see the house, not just to the
+// client that was editing. Everything else in this file is about the two ways a
+// 0xD7 can arrive without an editing session behind it.
+
+include "customhouse";
+
+program test_client_house_commit()
+  return house_setup();
+endprogram
+
+// A commit ends the session and leaves the house built the way the working
+// design had it - house_parts reads the current design once nobody is editing,
+// so a tile that survives the commit is a tile that really moved over.
+//
+// It commits twice, once to put a tile on the house and once to take it off
+// again, because those are two different journeys through AcceptHouseCommit and
+// the second is the one a player makes when undoing.
+//
+// The size of the design is deliberately not asserted here. A commit runs
+// FillComponents first, which takes every door out of the design and puts it
+// back as an item, so the design a commit leaves is one tile smaller per door
+// than the one that was being edited - the tile a case adds and the tiles the
+// commit machinery moves are not comparable numbers.
+exported function commit_applies_the_design( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  // the front step row, the only place a tile can be put down at z 0 and taken
+  // away again. The commit has to find it there, so it waits for it.
+  house_add( 0, CH_DIRT, 0, HOUSE_STEP_Y );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := commit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  if ( house.house_editing )
+    return ret_error( "the house still considers itself edited after a commit" );
+  endif
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var placed := design_tiles_at( ev, CH_DIRT, 0, HOUSE_STEP_Y ).size();
+  if ( placed != 1 )
+    return ret_error( $"the design a commit sent holds {placed} of the new tile" );
+  endif
+
+  res := expect_part( house, CH_DIRT, 0, HOUSE_STEP_Y, CH_PLANE_Z );
+  if ( !res )
+    return res;
+  endif
+
+  // and commit again to take it back off
+  ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  house_erase( 0, CH_DIRT, 0, HOUSE_STEP_Y, CH_PLANE_Z );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  res := commit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  return expect_no_part( house, CH_DIRT, 0, HOUSE_STEP_Y );
+endfunction
+
+// The design a commit produces goes to everyone who can see the house, which is
+// what makes a rebuilt house appear for the neighbours as well. Nothing is
+// changed here - the point is who is told, not what changed.
+exported function commit_reaches_bystander( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var other := FindAccount( "testclient1" ).getcharacter( 1 );
+  if ( !other )
+    return ret_error( "Could not find the second character" );
+  endif
+  var was := struct{ x := other.x, y := other.y, z := other.z };
+
+  // just outside the house and well inside visual range of it
+  MoveObjectToLocation( other, house_x, house_y + 8, 0, flags := MOVEOBJECT_FORCELOCATION );
+  var ev := waitForClient( 1, { EVT_OWNCREATE } );
+  if ( !ev )
+    return ret_error( "client 1 was not moved next to the house" );
+  endif
+
+  var res := commit_from_inside();
+  MoveObjectToLocation( other, was.x, was.y, was.z, flags := MOVEOBJECT_FORCELOCATION );
+  return res;
+endfunction
+
+// Commits an unchanged design and answers whether both clients were sent it.
+//
+// One commit produces three things - the end of the session for the editor and
+// a design for each client - and the single transmit thread puts them on the
+// wire in an order the test cannot pin down. Every wait helper throws away what
+// it was not asked for, so these have to be gathered in one pass rather than
+// waited for one after another.
+function commit_from_inside()
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  Clear_Event_Queue();
+  house_cmd( 0, CH_COMMIT );
+
+  var ended := 0;
+  var mine := 0;
+  var theirs := 0;
+  var deadline := ReadMillisecondClock() + 10000;
+  while ( ReadMillisecondClock() < deadline )
+    var got := Wait_For_Event( POLL_INTERVAL );
+    if ( !got )
+      continue;
+    endif
+    var id := CInt( got.id );
+    if ( got.type == EVT_HOUSE_EDIT && id == 0 )
+      ended := got;
+    elseif ( got.type == EVT_HOUSE_DESIGN && id == 0 )
+      mine := got;
+    elseif ( got.type == EVT_HOUSE_DESIGN && id == 1 )
+      theirs := got;
+    endif
+    if ( ended && mine && theirs )
+      break;
+    endif
+  endwhile
+
+  if ( !ended )
+    return ret_error( "the editing client was never taken out of design mode" );
+  endif
+  if ( !mine )
+    return ret_error( "the editing client was not sent the committed design" );
+  endif
+  if ( !theirs )
+    return ret_error( "the client standing outside was not sent the committed design" );
+  endif
+
+  if ( CInt( theirs.serial ) != house.serial )
+    return ret_error( $"client 1 was sent a design for 0x{theirs.serial:x}" );
+  endif
+  var here := mine.tiles.size();
+  var there := theirs.tiles.size();
+  if ( here != there )
+    return ret_error( $"client 0 was sent {here} tiles and client 1 {there}" );
+  endif
+  return design_is_consistent( theirs );
+endfunction
+
+// A 0xD7 carrying somebody else's serial is dropped before it reaches any
+// design at all - the core reads the serial out of the packet and compares it
+// with the sender's own.
+exported function commit_ignores_spoofed( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var other := FindAccount( "testclient1" ).getcharacter( 1 );
+  if ( !other )
+    return ret_error( "Could not find the second character" );
+  endif
+
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  house_cmd( 0, CH_ADD, struct{ graphic := CH_ROOF, x := 0, y := 0, serial := other.serial } );
+
+  // The synch this asks for travels the same connection, so by the time it is
+  // answered the spoofed add has already been read and thrown away. The design
+  // is untouched and the revision has not moved.
+  ev := client_sees_revision( 0, revision );
+  if ( !ev )
+    return ev;
+  endif
+  var res := expect_no_part( house, CH_ROOF, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a spoofed add" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// A design command from a client that is not editing anything has no house to
+// find: the core looks the working house up through the sender's own editing
+// state, which a quit cleared. Nothing happens and nothing is answered.
+exported function command_without_a_session( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var res := quit_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  var before := house.house_parts.size();
+
+  Clear_Event_Queue();
+  house_add( 0, CH_ROOF, 0, 0 );
+
+  res := wait_for_no_design( 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_no_part( house, CH_ROOF, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  return expect_parts( house, before, "an add with no session open" );
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_edit.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_edit.src
@@ -502,61 +502,72 @@ exported function house_revert_drops_edits( resmgn )
   return quit_design( 0 );
 endfunction
 
-// TODO core bug 2: re-enable once an unknown stair multiid stops asserting.
-// A stair multiid in range that no multi is defined for takes the shard down.
-// CustomHousesAddMulti checks the id against STAIR_MULTIID_MIN/MAX and hands
-// what passes to AddMultiAtOffset, which asks MultiDefByMultiID
-// (multidef.cpp:224) for the definition - and that opens with
-// passert( multidefs_by_multiid.count( multiid ) != 0 ). The nullptr check that
-// follows it never gets to run, and the test shard sets
-// AssertionFailureAction=shutdown, so the whole run goes down with it. Most of
-// 0x1DB0..0x1DF3 is unused on a stock installation, so any client with the
-// design editor open can do this.
-// exported function house_add_multi_unknown_id( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var ev := enter_design( 0, char, house );
-//   if ( !ev )
-//     return ev;
-//   endif
+// A multiid inside the stair range that the shard has no multi for adds nothing.
+// The range check passes it on and the lookup finds nothing, which is the whole
+// path: most of 0x1DB0..0x1DF3 is unused on a stock installation, so any client
+// with the editor open can name one.
 //
-//   // in range, and the test data only defines the first of the range
-//   house_add_multi( 0, CH_STAIR_MIN + 1, 0, 2 );
-//
-//   ev := wait_for_design( 0 );
-//   if ( !ev )
-//     return ev;
-//   endif
-//   return quit_design( 0 );
-// endfunction
+// Neither this nor the case below is answered with a design - the command only
+// moves the revision on - so both settle with a synch rather than waiting for one.
+exported function house_add_multi_unknown_id( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
 
-// TODO core bug 3: re-enable once CustomHouseDesign::Add checks its bounds.
-// A stair multi placed near the edge of the plot reads and writes past the
-// design. AddMultiAtOffset (customhouses.cpp:377) adds every component through
-// Add(), which - unlike AddOrReplace - has no ValidLocation check, so
-// CustomHouseElements::AddElement indexes data.at( x ).at( y ) with an offset
-// the design does not have and throws std::out_of_range. This runs on the
-// network thread, where nothing catches it, so the shard goes down.
-//
+  // in range, and the test data only defines the first of the range
+  house_add_multi( 0, CH_STAIR_MIN + 1, 0, 2 );
+
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_parts( house, before, "an unknown stair multiid" );
+  if ( !res )
+    return res;
+  endif
+  return quit_design( 0 );
+endfunction
+
 // The test data stair climbs three tiles north of where it is put, so the north
-// edge of the plot is enough: at y -1 its top step is at y -4, one row outside.
-// exported function house_add_multi_out_of_plot( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var ev := enter_design( 0, char, house );
-//   if ( !ev )
-//     return ev;
-//   endif
-//
-//   house_add_multi( 0, CH_STAIR_MIN, 0, HOUSE_MIN_OFF );
-//
-//   ev := wait_for_design( 0 );
-//   if ( !ev )
-//     return ev;
-//   endif
-//   return quit_design( 0 );
-// endfunction
+// edge of the plot is enough: put down at y -3 only its lowest step is inside
+// the design and the nine tiles above it fall outside. What fits is added and
+// the rest is dropped.
+exported function house_add_multi_out_of_plot( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  house_add_multi( 0, CH_STAIR_MIN, 0, HOUSE_MIN_OFF );
+
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var landed := house_parts_at( house, CH_STAIR, 0, HOUSE_MIN_OFF ).size();
+  if ( landed != 1 )
+    return ret_error( $"{landed} of the stair landed on the edge row" );
+  endif
+  var res := expect_parts( house, before + 1, "a stair hanging off the plot" );
+  if ( !res )
+    return res;
+  endif
+  res := design_is_consistent( ev );
+  if ( !res )
+    return res;
+  endif
+  return quit_design( 0 );
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_edit.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_edit.src
@@ -1,0 +1,562 @@
+// The commands a client sends to build with: what each of them puts into the
+// working design, and which of them answer with a design rather than by moving
+// the revision on.
+//
+// The two are worth telling apart. A command that changes the design bumps the
+// revision and leaves the client to ask for the result; one that refuses sends
+// the design back unchanged so the client can undo what it drew. So a case that
+// waits for the wrong one of those either passes on a stale design or times out.
+
+include "customhouse";
+
+program test_client_house_edit()
+  return house_setup();
+endprogram
+
+// A tile lands on the storey being edited, except in the row that hangs off the
+// south side of the multi - the front steps, which are always at z 0.
+exported function house_add_front_step_z( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  house_add( 0, CH_DIRT, 0, HOUSE_MAX_OFF );
+  house_add( 0, CH_DIRT, 0, HOUSE_STEP_Y );
+
+  ev := client_sees_revision( 0, revision + 2 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_part( house, CH_DIRT, 0, HOUSE_MAX_OFF, CH_PLANE_Z1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_part( house, CH_DIRT, 0, HOUSE_STEP_Y, CH_PLANE_Z );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before + 2, "two adds" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Only the stair multiids are accepted. Anything else is refused by sending the
+// working design back, which is how the client is told to draw what the server
+// has rather than what it asked for - and the revision does not move.
+exported function house_add_multi_refused( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  Clear_Event_Queue();
+  house_add_multi( 0, CH_NOT_A_STAIR, 0, 0 );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision )
+    return ret_error( $"a refused multi moved the revision to {got}, wanted {revision}" );
+  endif
+
+  var res := expect_parts( house, before, "a refused multi" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// A stair multi is expanded into its component tiles, each keeping the z it has
+// in the multi on top of the storey being edited. The test data stair is a
+// pyramid climbing north: one tile at the offset it is placed on, then two,
+// three and four on the tiles behind it.
+exported function house_add_multi_stairs( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  house_add_multi( 0, CH_STAIR_MIN, 0, 2 );
+
+  ev := client_sees_revision( 0, revision + 1 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_parts( house, before + CH_STAIR_PARTS, "a stair multi" );
+  if ( !res )
+    return res;
+  endif
+
+  // one tile deeper into the pyramid with every step north
+  var wanted := 1;
+  var y := 2;
+  while ( wanted <= 4 )
+    var found := house_parts_at( house, CH_STAIR, 0, y ).size();
+    if ( found != wanted )
+      return ret_error( $"the stair has {found} tiles at y {y}, wanted {wanted}" );
+    endif
+    wanted := wanted + 1;
+    y := y - 1;
+  endwhile
+
+  // and the lowest step sits on the storey the client was editing
+  res := expect_part( house, CH_STAIR, 0, 2, CH_PLANE_Z1 );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Picking a storey moves the character onto it, sends the design back and
+// decides where the next add lands. A number outside 1..4 is read as 1.
+exported function house_pick_storey( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  var res := select_floor_at_z( 2, CH_PLANE_Z2, revision );
+  if ( !res )
+    return res;
+  endif
+
+  // and that is the storey an add now goes to
+  house_add( 0, CH_DIRT, -1, -1 );
+  ev := client_sees_revision( 0, revision + 1 );
+  if ( !ev )
+    return ev;
+  endif
+  res := expect_part( house, CH_DIRT, -1, -1, CH_PLANE_Z2 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before + 1, "an add on the second storey" );
+  if ( !res )
+    return res;
+  endif
+
+  res := select_floor_at_z( 3, CH_PLANE_Z3, revision + 1 );
+  if ( !res )
+    return res;
+  endif
+  // out of range, so back to the first storey
+  res := select_floor_at_z( 9, CH_PLANE_Z1, revision + 1 );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Picks a storey and answers whether the character was put on it. The storey a
+// house is being edited on outlives the session - nothing resets it - so a case
+// that touches it has to leave the first one selected again.
+function select_floor_at_z( floor, zoffset, revision )
+  Clear_Event_Queue();
+  house_select_floor( 0, floor );
+
+  var ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision )
+    return ret_error( $"picking storey {floor} moved the revision to {got}" );
+  endif
+
+  var wanted := house.z + zoffset;
+  if ( char.z != wanted )
+    return ret_error( $"storey {floor} left the character at z {char.z}, wanted {wanted}" );
+  endif
+  return 1;
+endfunction
+
+// A roof tile carries a z of its own, counted from the storey being edited.
+exported function house_roof_places_at_z( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, -1, 0, -3 );
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, -2, 0, 12 );
+
+  ev := client_sees_revision( 0, revision + 3 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_part( house, CH_ROOF, 0, 0, CH_PLANE_Z1 + 3 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_part( house, CH_ROOF, -1, 0, CH_PLANE_Z1 - 3 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_part( house, CH_ROOF, -2, 0, CH_PLANE_Z1 + 12 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before + 3, "three roof tiles" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// A roof z is only taken as it comes when it is a multiple of 3 within -3..12.
+// Anything else is read as -3 rather than refused.
+exported function house_roof_clamps_z( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+
+  // not a multiple of 3, above the ceiling, below the floor
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, -1, 5 );
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, -1, -1, 15 );
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, -2, -1, -6 );
+
+  ev := client_sees_revision( 0, revision + 3 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var x := 0;
+  while ( x >= -2 )
+    var res := expect_part( house, CH_ROOF, x, -1, CH_PLANE_Z1 - 3 );
+    if ( !res )
+      return res;
+    endif
+    x := x - 1;
+  endwhile
+
+  return quit_design( 0 );
+endfunction
+
+// Removing a roof takes the tile out and moves the revision on; asking for one
+// that is not there answers with the design instead, leaving the revision alone.
+exported function house_roof_remove( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  // the removal has to find what the add put there, so it waits for it
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, -1, 2, 3 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  house_roof( 0, CH_DELETE_ROOF, CH_ROOF, -1, 2, CH_PLANE_Z1 + 3 );
+  ev := client_sees_revision( 0, revision + 2 );
+  if ( !ev )
+    return ev;
+  endif
+  var res := expect_no_part( house, CH_ROOF, -1, 2 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a roof put in and taken out again" );
+  if ( !res )
+    return res;
+  endif
+
+  Clear_Event_Queue();
+  house_roof( 0, CH_DELETE_ROOF, CH_ROOF, -1, 2, CH_PLANE_Z1 + 3 );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision + 2 )
+    return ret_error( $"removing nothing moved the revision to {got}" );
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Clearing throws the whole working design away and lays the multi down again,
+// so what is left is the house as it was built and nothing else.
+exported function house_clear_leaves_house( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+
+  house_add( 0, CH_ROOF, 0, 0 );
+  ev := client_sees_revision( 0, revision + 1 );
+  if ( !ev )
+    return ev;
+  endif
+
+  // a clear answers with the design it left behind, so there is nothing to ask
+  // for afterwards
+  house_cmd( 0, CH_CLEAR );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var cleared := house.house_parts.size();
+
+  var res := expect_no_part( house, CH_ROOF, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_part( house, CH_FOUNDATION, CH_FOUNDATION_X, CH_FOUNDATION_Y, CH_PLANE_Z );
+  if ( !res )
+    return res;
+  endif
+
+  // clearing what is already the bare multi has nothing left to take away
+  house_cmd( 0, CH_CLEAR );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  res := expect_parts( house, cleared, "a second clear" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// A backup is a design put aside, and a restore is the client asking for it
+// back. Neither is a change, so neither moves the revision - a restore hands
+// the client a design whose content moved while its revision did not.
+exported function house_backup_restore( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  // A backup is the one command that leaves no trace at all - it answers with
+  // nothing and does not move the revision - so which design it caught can only
+  // be told apart afterwards, by what a restore brings back. That makes it the
+  // one place where the order the commands are applied in has to be pinned down
+  // rather than assumed: each of the three is settled before the next goes out.
+  house_add( 0, CH_ROOF, 0, 0 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  house_cmd( 0, CH_BACKUP );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  house_add( 0, CH_ROOF, 0, 1 );
+  ev := client_sees_revision( 0, revision + 2 );
+  if ( !ev )
+    return ev;
+  endif
+  var res := expect_parts( house, before + 2, "two adds around a backup" );
+  if ( !res )
+    return res;
+  endif
+
+  Clear_Event_Queue();
+  house_cmd( 0, CH_RESTORE );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision + 2 )
+    return ret_error( $"a restore moved the revision to {got}" );
+  endif
+
+  // the tile from before the backup is there, the one from after it is not
+  res := expect_part( house, CH_ROOF, 0, 0, CH_PLANE_Z1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_no_part( house, CH_ROOF, 0, 1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before + 1, "a restore" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Reverting goes back to the design the house is really built from, throwing
+// away everything the session did. It is not a change either, so the revision
+// stays where it was.
+exported function house_revert_drops_edits( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  house_add( 0, CH_ROOF, 0, 0 );
+  house_add( 0, CH_ROOF, 0, 1 );
+
+  ev := client_sees_revision( 0, revision + 2 );
+  if ( !ev )
+    return ev;
+  endif
+
+  Clear_Event_Queue();
+  house_cmd( 0, CH_REVERT );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision + 2 )
+    return ret_error( $"a revert moved the revision to {got}" );
+  endif
+
+  var res := expect_no_part( house, CH_ROOF, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_no_part( house, CH_ROOF, 0, 1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a revert" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// TODO core bug 2: re-enable once an unknown stair multiid stops asserting.
+// A stair multiid in range that no multi is defined for takes the shard down.
+// CustomHousesAddMulti checks the id against STAIR_MULTIID_MIN/MAX and hands
+// what passes to AddMultiAtOffset, which asks MultiDefByMultiID
+// (multidef.cpp:224) for the definition - and that opens with
+// passert( multidefs_by_multiid.count( multiid ) != 0 ). The nullptr check that
+// follows it never gets to run, and the test shard sets
+// AssertionFailureAction=shutdown, so the whole run goes down with it. Most of
+// 0x1DB0..0x1DF3 is unused on a stock installation, so any client with the
+// design editor open can do this.
+// exported function house_add_multi_unknown_id( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   // in range, and the test data only defines the first of the range
+//   house_add_multi( 0, CH_STAIR_MIN + 1, 0, 2 );
+//
+//   ev := wait_for_design( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+//   return quit_design( 0 );
+// endfunction
+
+// TODO core bug 3: re-enable once CustomHouseDesign::Add checks its bounds.
+// A stair multi placed near the edge of the plot reads and writes past the
+// design. AddMultiAtOffset (customhouses.cpp:377) adds every component through
+// Add(), which - unlike AddOrReplace - has no ValidLocation check, so
+// CustomHouseElements::AddElement indexes data.at( x ).at( y ) with an offset
+// the design does not have and throws std::out_of_range. This runs on the
+// network thread, where nothing catches it, so the shard goes down.
+//
+// The test data stair climbs three tiles north of where it is put, so the north
+// edge of the plot is enough: at y -1 its top step is at y -4, one row outside.
+// exported function house_add_multi_out_of_plot( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   house_add_multi( 0, CH_STAIR_MIN, 0, HOUSE_MIN_OFF );
+//
+//   ev := wait_for_design( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+//   return quit_design( 0 );
+// endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_erase.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_erase.src
@@ -3,12 +3,11 @@
 // paving an emptied ground floor with dirt again, and pulling a whole staircase
 // when one of its steps is named.
 //
-// Erase is the one command that both sends a design and moves the revision on,
-// and it does them in that order - so the design a client is handed after an
-// erase already holds the change while its revision is still the one from
-// before, and it stays that way because the packet is cached. Every case here
-// therefore waits for the design an erase sends and reads the content out of
-// it, or out of house_parts; only erase_revision_lags looks at the number.
+// Erase is the one command that both moves the revision on and sends a design,
+// so the design a client is handed after an erase carries the change and the
+// new revision together. Every case here waits for that design and reads the
+// content out of it, or out of house_parts; only erase_revision_advances looks
+// at the number.
 
 include "customhouse";
 
@@ -17,7 +16,7 @@ program test_client_house_erase()
 endprogram
 
 // A tile above the ground floor comes straight back out, and the design that
-// answers the erase is the new one under the old revision.
+// answers the erase is the new one.
 exported function erase_removes_tile( resmgn )
   var started := house_start( resmgn );
   if ( !started )
@@ -251,17 +250,14 @@ exported function erase_graphic_mismatch( resmgn )
   return quit_design( 0 );
 endfunction
 
-// What an erase leaves the client believing about the revision, which is not
-// what the house is on.
+// The revision the client is told after an erase is the one the house is on.
 //
-// CustomHousesErase sends the design and then increments, so the packet carries
-// the number from before the erase. CustomHousesSendFull keeps that packet in
-// WorkingCompressed and replays it for every later synch, so asking again does
-// not help either: the client goes on being told the old revision until some
-// other command throws the cached packet away. Since the revision is what a
-// client uses to decide whether the design it holds is still good, this is
-// asserted here as what happens today rather than as what should.
-exported function erase_revision_lags( resmgn )
+// CustomHousesErase increments before it builds the design, and the packet it
+// builds is what CustomHousesSendFull keeps in WorkingCompressed and replays
+// for every later synch - so the number is right the first time and stays right
+// until the next edit. The revision is what a client uses to decide whether the
+// design it holds is still good, so every step here reads it back.
+exported function erase_revision_advances( resmgn )
   var started := house_start( resmgn );
   if ( !started )
     return started;
@@ -273,7 +269,7 @@ exported function erase_revision_lags( resmgn )
   var revision := CInt( ev.revision );
 
   // an add moves the revision and throws the cached packet away, so the design
-  // that answers the next synch is built fresh and counts properly
+  // that answers the next synch is built fresh
   house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
   ev := house_settle( 0 );
   if ( !ev )
@@ -284,15 +280,16 @@ exported function erase_revision_lags( resmgn )
     return ret_error( $"an add left the client at revision {got}, wanted {revision + 1}" );
   endif
 
-  // the erase moves it again, and tells the client the number from before
+  // the erase moves it again, and the design it answers with carries the new one
+  var wanted := revision + 2;
   house_erase( 0, CH_ROOF, 0, 0, CH_PLANE_Z1 + 3 );
   ev := wait_for_design( 0 );
   if ( !ev )
     return ev;
   endif
   got := CInt( ev.revision );
-  if ( got != revision + 1 )
-    return ret_error( $"the design an erase answers with is at revision {got}" );
+  if ( got != wanted )
+    return ret_error( $"the design an erase answers with is at revision {got}, wanted {wanted}" );
   endif
 
   // and asking for it again answers with the very same packet
@@ -301,12 +298,11 @@ exported function erase_revision_lags( resmgn )
     return ev;
   endif
   got := CInt( ev.revision );
-  if ( got != revision + 1 )
-    return ret_error( $"a synch after an erase answered revision {got}" );
+  if ( got != wanted )
+    return ret_error( $"a synch after an erase answered revision {got}, wanted {wanted}" );
   endif
 
-  // the house was two revisions on all along: one more edit invalidates the
-  // cached packet and the number the client is told jumps by two
+  // one more edit invalidates the cached packet, and the number moves by one
   house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
   ev := house_settle( 0 );
   if ( !ev )

--- a/testsuite/pol/testpkgs/client/test_client_house_erase.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_erase.src
@@ -320,34 +320,22 @@ exported function erase_revision_lags( resmgn )
   return quit_design( 0 );
 endfunction
 
-// TODO core bug 1: re-enable once z_to_custom_house_table returns a signed type.
-// A z above every design plane takes the shard down. The erase command hands
-// the z the client sent to DeleteStairs and EraseGraphicAt, and both start with
-// z_to_custom_house_table( z ) (customhouses.cpp:79), whose "no such plane"
-// answer is -1 - returned as a char, which is unsigned on ARM, so every Android
-// and Raspberry Pi build reads it as 255. The floor_num == -1 guard therefore
-// never trips and both index Elements[255] of a six-element array, which throws
-// or segfaults depending on what happens to follow it in memory. This one runs
-// on the network thread, where nothing catches it either way.
-//
-// The same defect is reachable from the script side, see
-// test_customhouse_part_z_no_plane in testpkgs/house/test_custom_parts.src.
-// exported function erase_z_no_plane( resmgn )
-//   var started := house_start( resmgn );
-//   if ( !started )
-//     return started;
-//   endif
-//   var ev := enter_design( 0, char, house );
-//   if ( !ev )
-//     return ev;
-//   endif
-//
-//   // the planes stop at 80, so 100 is below none of them
-//   house_erase( 0, CH_BOARD, 0, 0, 100 );
-//
-//   ev := wait_for_design( 0 );
-//   if ( !ev )
-//     return ev;
-//   endif
-//   return quit_design( 0 );
-// endfunction
+exported function erase_z_no_plane( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+
+  // the planes stop at 80, so 100 is below none of them
+  house_erase( 0, CH_BOARD, 0, 0, 100 );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  return quit_design( 0 );
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_house_erase.src
+++ b/testsuite/pol/testpkgs/client/test_client_house_erase.src
@@ -1,0 +1,353 @@
+// Taking tiles back out of a working design: what the erase command reaches,
+// what it refuses to touch, and the two things it does on its own account -
+// paving an emptied ground floor with dirt again, and pulling a whole staircase
+// when one of its steps is named.
+//
+// Erase is the one command that both sends a design and moves the revision on,
+// and it does them in that order - so the design a client is handed after an
+// erase already holds the change while its revision is still the one from
+// before, and it stays that way because the packet is cached. Every case here
+// therefore waits for the design an erase sends and reads the content out of
+// it, or out of house_parts; only erase_revision_lags looks at the number.
+
+include "customhouse";
+
+program test_client_house_erase()
+  return house_setup();
+endprogram
+
+// A tile above the ground floor comes straight back out, and the design that
+// answers the erase is the new one under the old revision.
+exported function erase_removes_tile( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  house_erase( 0, CH_ROOF, 0, 0, CH_PLANE_Z1 + 3 );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var left := design_tiles_at( ev, CH_ROOF, 0, 0 ).size();
+  if ( left )
+    return ret_error( $"the design an erase answers with still holds {left} of the tile" );
+  endif
+
+  var res := expect_no_part( house, CH_ROOF, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a roof put in and erased" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// The tiles the house stands on cannot be taken away. Anything at z 0 inside
+// the footprint is refused by sending the design back untouched, and that
+// refusal comes before the revision is moved.
+exported function erase_foundation_refused( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+  var before := house.house_parts.size();
+
+  Clear_Event_Queue();
+  house_erase( 0, CH_FOUNDATION, CH_FOUNDATION_X, CH_FOUNDATION_Y, CH_PLANE_Z );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision )
+    return ret_error( $"a refused erase moved the revision to {got}" );
+  endif
+
+  var res := expect_part( house, CH_FOUNDATION, CH_FOUNDATION_X, CH_FOUNDATION_Y, CH_PLANE_Z );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a refused erase" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// The front step row is outside the footprint the foundation check covers, so
+// what is put there at z 0 can be taken away again.
+exported function erase_front_step( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  // the erase has to find what the add put there, so it waits for it
+  house_add( 0, CH_DIRT, 0, HOUSE_STEP_Y );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  house_erase( 0, CH_DIRT, 0, HOUSE_STEP_Y, CH_PLANE_Z );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_no_part( house, CH_DIRT, 0, HOUSE_STEP_Y );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a step put down and erased" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Emptying a tile of the first storey does not leave a hole in the house: the
+// core paves it with a dirt tile again, so the design keeps the size it had.
+exported function erase_repaves_the_floor( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  house_erase( 0, CH_BOARD, 0, 0, CH_PLANE_Z1 );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_no_part( house, CH_BOARD, 0, 0 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_part( house, CH_DIRT, 0, 0, CH_PLANE_Z1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "a floor board erased" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// Naming one step of a staircase erases the whole run of it. DeleteStairs works
+// out which way the stair climbs from the graphic and walks the pyramid back
+// down, so the ten tiles the multi laid down all go in one command.
+exported function erase_takes_the_whole_stair( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  house_add_multi( 0, CH_STAIR_MIN, 0, 2 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var res := expect_parts( house, before + CH_STAIR_PARTS, "a stair multi" );
+  if ( !res )
+    return res;
+  endif
+
+  // the lowest step, which is the one a client can see to click on
+  house_erase( 0, CH_STAIR, 0, 2, CH_PLANE_Z1 );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var y := 2;
+  while ( y >= -1 )
+    res := expect_no_part( house, CH_STAIR, 0, y );
+    if ( !res )
+      return res;
+    endif
+    y := y - 1;
+  endwhile
+  res := expect_parts( house, before, "a stair erased" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// An erase names a graphic as well as a place, and the wrong graphic finds
+// nothing to take away. The command is not refused for it - the design goes
+// back to the client and the revision moves on all the same.
+exported function erase_graphic_mismatch( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var before := house.house_parts.size();
+
+  house_erase( 0, CH_DIRT, 0, 0, CH_PLANE_Z1 );
+
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+
+  var res := expect_part( house, CH_BOARD, 0, 0, CH_PLANE_Z1 );
+  if ( !res )
+    return res;
+  endif
+  res := expect_parts( house, before, "an erase that matched nothing" );
+  if ( !res )
+    return res;
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// What an erase leaves the client believing about the revision, which is not
+// what the house is on.
+//
+// CustomHousesErase sends the design and then increments, so the packet carries
+// the number from before the erase. CustomHousesSendFull keeps that packet in
+// WorkingCompressed and replays it for every later synch, so asking again does
+// not help either: the client goes on being told the old revision until some
+// other command throws the cached packet away. Since the revision is what a
+// client uses to decide whether the design it holds is still good, this is
+// asserted here as what happens today rather than as what should.
+exported function erase_revision_lags( resmgn )
+  var started := house_start( resmgn );
+  if ( !started )
+    return started;
+  endif
+  var ev := enter_design( 0, char, house );
+  if ( !ev )
+    return ev;
+  endif
+  var revision := CInt( ev.revision );
+
+  // an add moves the revision and throws the cached packet away, so the design
+  // that answers the next synch is built fresh and counts properly
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  var got := CInt( ev.revision );
+  if ( got != revision + 1 )
+    return ret_error( $"an add left the client at revision {got}, wanted {revision + 1}" );
+  endif
+
+  // the erase moves it again, and tells the client the number from before
+  house_erase( 0, CH_ROOF, 0, 0, CH_PLANE_Z1 + 3 );
+  ev := wait_for_design( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  got := CInt( ev.revision );
+  if ( got != revision + 1 )
+    return ret_error( $"the design an erase answers with is at revision {got}" );
+  endif
+
+  // and asking for it again answers with the very same packet
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  got := CInt( ev.revision );
+  if ( got != revision + 1 )
+    return ret_error( $"a synch after an erase answered revision {got}" );
+  endif
+
+  // the house was two revisions on all along: one more edit invalidates the
+  // cached packet and the number the client is told jumps by two
+  house_roof( 0, CH_SELECT_ROOF, CH_ROOF, 0, 0, 3 );
+  ev := house_settle( 0 );
+  if ( !ev )
+    return ev;
+  endif
+  got := CInt( ev.revision );
+  if ( got != revision + 3 )
+    return ret_error( $"the house came back at revision {got}, wanted {revision + 3}" );
+  endif
+
+  return quit_design( 0 );
+endfunction
+
+// TODO core bug 1: re-enable once z_to_custom_house_table returns a signed type.
+// A z above every design plane takes the shard down. The erase command hands
+// the z the client sent to DeleteStairs and EraseGraphicAt, and both start with
+// z_to_custom_house_table( z ) (customhouses.cpp:79), whose "no such plane"
+// answer is -1 - returned as a char, which is unsigned on ARM, so every Android
+// and Raspberry Pi build reads it as 255. The floor_num == -1 guard therefore
+// never trips and both index Elements[255] of a six-element array, which throws
+// or segfaults depending on what happens to follow it in memory. This one runs
+// on the network thread, where nothing catches it either way.
+//
+// The same defect is reachable from the script side, see
+// test_customhouse_part_z_no_plane in testpkgs/house/test_custom_parts.src.
+// exported function erase_z_no_plane( resmgn )
+//   var started := house_start( resmgn );
+//   if ( !started )
+//     return started;
+//   endif
+//   var ev := enter_design( 0, char, house );
+//   if ( !ev )
+//     return ev;
+//   endif
+//
+//   // the planes stop at 80, so 100 is below none of them
+//   house_erase( 0, CH_BOARD, 0, 0, 100 );
+//
+//   ev := wait_for_design( 0 );
+//   if ( !ev )
+//     return ev;
+//   endif
+//   return quit_design( 0 );
+// endfunction

--- a/testsuite/pol/testpkgs/client/test_client_item_move.src
+++ b/testsuite/pol/testpkgs/client/test_client_item_move.src
@@ -1387,16 +1387,16 @@ function wear_item_succeeded( byref err, item_serial, layer, player_serial, equi
     return err;
   endif
 
-  clientcon.sendevent( struct{ todo := "list_equipped_items", arg := player_serial, id := 0 } );
-  var ev := waitForClient( 0, { EVT_LIST_EQUIPPED_ITEMS } );
-  if ( !ev )
-    return ev;
+  // the client learns what it is wearing from a packet it has not necessarily
+  // read yet, so this asks again until the layer is filled rather than judging
+  // the first listing it answers with
+  var entry := client_finds_layer( clientcon, 0, player_serial, layer );
+  if ( !entry )
+    return entry;
   endif
-
-  if ( !ev.objs.find( @( equipped_item ) {
-    return equipped_item.serial == item_serial;
-  } ) )
-    return ret_error( $"Item 0x{item_serial:x} not listed in equipment for player serial 0x{player_serial:x}" );
+  var worn := CInt( entry.serial );
+  if ( worn != item_serial )
+    return ret_error( $"Layer {layer} of 0x{player_serial:x} holds 0x{worn:x}, not 0x{item_serial:x}" );
   endif
 
   return 1;

--- a/testsuite/pol/testpkgs/client/test_client_range.src
+++ b/testsuite/pol/testpkgs/client/test_client_range.src
@@ -151,33 +151,43 @@ exported function multi_update_range( resmngr )
   while ( !waitForClient( 0, { EVT_OWNCREATE } ) )
   endwhile
   char.facing := 1;
-  Clear_Event_Queue();
-  clientcon.sendevent( struct{ todo := "move", arg := 2, id := 0 } );
+
+  // The distance is measured against char.x, so nothing may be in flight when
+  // it is read: walk one step at a time and drain to quiet before the next.
   var i := 10;
-  while ( --i > 0 )
-    var ev := waitForClient( 0, { EVT_MOVED, EVT_NEW_ITEM } );
-    if ( !ev )
-      return ev;
-    endif
-    if ( ev.type == EVT_MOVED )
-      if ( !ev.ack )
-        return ret_error( "failed to move" );
+  var found := 0;
+  while ( --i > 0 && !found )
+    Clear_Event_Queue();
+    clientcon.sendevent( struct{ todo := "move", arg := 2, id := 0 } );
+
+    var acked := 0;
+    var quiet := ReadMillisecondClock() + QUIET_SECS * 1000;
+    while ( ReadMillisecondClock() < quiet )
+      var ev := Wait_For_Event( POLL_INTERVAL );
+      if ( !ev )
+        continue;
       endif
-      clientcon.sendevent( struct{ todo := "move", arg := 2, id := 0 } );
-      continue;
-    endif
-    if ( ev["serial"] == multi.serial )
-      var x := ev["pos"][1] - char.x;
-      if ( x != 22 ) // (18 visual range + 4)
-        return ret_error( $"update distance failed: {x}" );
+      quiet := ReadMillisecondClock() + QUIET_SECS * 1000;
+      if ( ev.type == EVT_MOVED && CInt( ev.id ) == 0 )
+        if ( !ev.ack )
+          return ret_error( "failed to move" );
+        endif
+        acked := 1;
+      elseif ( ev.type == EVT_NEW_ITEM && CInt( ev.id ) == 0 && CInt( ev.serial ) == multi.serial )
+        found := ev;
       endif
-      break;
+    endwhile
+    if ( !acked )
+      return ret_error( "the client never acknowledged the move" );
     endif
   endwhile
-  while ( waitForClient( 0, {}, 1 ) )
-  endwhile
-  if ( i == 0 )
+
+  if ( !found )
     return ret_error( "multi was never visible" );
+  endif
+  var x := CInt( found.pos[1] ) - char.x;
+  if ( x != 22 ) // los_size() 18 + the multi's own max_radius 4
+    return ret_error( $"update distance failed: {x}" );
   endif
   return 1;
 endfunction
@@ -221,4 +231,3 @@ exported function update_range_change( resmngr )
   endif
   return 1;
 endfunction
-

--- a/testsuite/pol/testpkgs/house/test_custom_parts.src
+++ b/testsuite/pol/testpkgs/house/test_custom_parts.src
@@ -5,11 +5,7 @@
 // reachable with a client attached - those cases live in the testclient package.
 // Everything here talks to the current design, which is what house.house_parts
 // reads back while the house is not being edited.
-//
-// Some cases here are written but commented out, because they fail against the
-// core as it stands. Each is headed by a line beginning "TODO core bug <n>", so
-// `grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs` finds all of them, here and
-// in the testclient package, and says what has to change first.
+
 use uo;
 use os;
 
@@ -305,41 +301,33 @@ exported function test_customhouse_tool_params( resources )
   return 1;
 endfunction
 
-// TODO core bug 5: re-enable once SendHousingTool checks for a client.
-// SendHousingTool reads chr->client->acctSupports() before it checks that there
-// is a client at all (uomod2.cpp:2579), so an offline character takes the shard
-// down with a null dereference. The same shape as house.cpp:533 in cancelediting.
-// exported function test_customhouse_tool_offline( resources )
-//   var multi := make_custom_house( resources );
-//   if ( !multi )
-//     return multi;
-//   endif
-//
-//   var char := createAccountWithChar( "housingtool_offline", "mypass" );
-//   if ( !char )
-//     return char;
-//   endif
-//   var res := SendHousingTool( char, multi );
-//   if ( res )
-//     return ret_error( $"SendHousingTool answered for an offline character: {res}" );
-//   endif
-//   return 1;
-// endfunction
+// The tool needs a client to send itself to, and an offline character has none.
+exported function test_customhouse_tool_offline( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
 
-// TODO core bug 3: re-enable once CustomHouseDesign::Add checks its bounds.
-// CustomHouseDesign::Add() indexes its plane with .at() and never checks the
-// offset the way AddOrReplace() does (customhouses.cpp:144), so a part outside
-// the plot throws std::out_of_range. The executor catches it, which kills this
-// script instead of answering an error.
-// exported function test_customhouse_part_no_bounds( resources )
-//   var multi := make_custom_house( resources );
-//   if ( !multi )
-//     return multi;
-//   endif
-//
-//   var res := multi.addhousepart( MARKER, 99, 99, 0 );
-//   if ( res )
-//     return ret_error( $"addhousepart outside the plot answered {res}" );
-//   endif
-//   return check_count( multi, PARTS );
-// endfunction
+  var char := createAccountWithChar( "housingtool_offline", "mypass" );
+  if ( !char )
+    return char;
+  endif
+  var res := SendHousingTool( char, multi );
+  if ( res )
+    return ret_error( $"SendHousingTool answered for an offline character: {res}" );
+  endif
+  return 1;
+endfunction
+
+// An offset outside the plot is dropped rather than indexing past the design.
+// addhousepart answers 1 either way, so the count is what says the part went
+// nowhere.
+exported function test_customhouse_part_no_bounds( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  multi.addhousepart( MARKER, 99, 99, 0 );
+  return check_count( multi, PARTS );
+endfunction

--- a/testsuite/pol/testpkgs/house/test_custom_parts.src
+++ b/testsuite/pol/testpkgs/house/test_custom_parts.src
@@ -1,0 +1,354 @@
+// The script side of a custom house design: what addhousepart/erasehousepart do
+// to the current design, and which of the design methods refuse to run.
+//
+// The design a client edits over the wire is the working design, and it is only
+// reachable with a client attached - those cases live in the testclient package.
+// Everything here talks to the current design, which is what house.house_parts
+// reads back while the house is not being edited.
+//
+// Some cases here are written but commented out, because they fail against the
+// core as it stands. Each is headed by a line beginning "TODO core bug <n>", so
+// `grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs` finds all of them, here and
+// in the testclient package, and says what has to change first.
+use uo;
+use os;
+
+include "testutil";
+
+// the dirt plot behind objtype 0x12002 (multi 0x13ea) is 32 tiles, all at z 0,
+// and that is the whole design a freshly customized house starts from
+const PARTS := 32;
+// the graphic that plot is paved with, and one that appears nowhere in it
+const DIRT := 0x31F4;
+const MARKER := 0x1;
+
+// an offset inside the plot, and the 2x2 hole in its northwest corner
+const HOLE_X := -1;
+const HOLE_Y := -1;
+
+program test_custom_house_parts()
+  return 1;
+endprogram
+
+function make_custom_house( resources )
+  var multi := ResourceManager::CreateMultiAtLocation( resources, 100, 75, 0, 0x12002 );
+  if ( !multi )
+    return multi;
+  endif
+  multi.setcustom( 1 );
+  return multi;
+endfunction
+
+// every part with that graphic at that offset, whatever its z
+function parts_at( multi, graphic, xoffset, yoffset )
+  return multi.house_parts.filter( @( e ) {
+    return ( e.graphic == graphic && e.xoffset == xoffset && e.yoffset == yoffset );
+  } );
+endfunction
+
+function check_count( multi, expected )
+  var count := multi.house_parts.size();
+  if ( count != expected )
+    return ret_error( $"expected {expected} parts got {count}" );
+  endif
+  return 1;
+endfunction
+
+// addhousepart calls Add(), not AddOrReplace(): the same graphic at the same
+// place stacks up instead of replacing, and each erase takes one of them away
+exported function test_customhouse_part_stacks( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"first addhousepart failed: {res}" );
+  endif
+  res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"second addhousepart failed: {res}" );
+  endif
+  res := check_count( multi, PARTS + 2 );
+  if ( !res )
+    return res;
+  endif
+  var stacked := parts_at( multi, MARKER, HOLE_X, HOLE_Y ).size();
+  if ( stacked != 2 )
+    return ret_error( $"expected both copies at the offset, got {stacked}" );
+  endif
+
+  res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"erasehousepart failed: {res}" );
+  endif
+  res := check_count( multi, PARTS + 1 );
+  if ( !res )
+    return res;
+  endif
+  stacked := parts_at( multi, MARKER, HOLE_X, HOLE_Y ).size();
+  if ( stacked != 1 )
+    return ret_error( $"expected one copy left, got {stacked}" );
+  endif
+  return 1;
+endfunction
+
+// z picks a plane rather than a height: z_to_custom_house_table takes the plane
+// below the value it is given, so a part added at z 3 sits on plane 0 and keeps
+// its own z, and erasing it only has to name a z on the same plane
+exported function test_customhouse_part_z_plane( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 3 );
+  if ( !res )
+    return ret_error( $"addhousepart at z 3 failed: {res}" );
+  endif
+  var added := parts_at( multi, MARKER, HOLE_X, HOLE_Y );
+  if ( added.size() != 1 )
+    return ret_error( $"expected the part at z 3, got {added.size()}" );
+  endif
+  if ( added[1].z != 3 )
+    return ret_error( $"part did not keep its z: {added[1].z}" );
+  endif
+
+  // z 0 and z 3 are both plane 0, so this erase finds it
+  res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"erase from the same plane failed: {res}" );
+  endif
+  return check_count( multi, PARTS );
+endfunction
+
+// TODO core bug 1: re-enable once z_to_custom_house_table returns a signed type.
+// A z that maps to no plane at all should be dropped with the call still
+// answering 1, and erasing what was never added should answer 0.
+//
+// z_to_custom_house_table (customhouses.cpp:79) returns char, and its "no such
+// plane" answer is -1. Where char is unsigned - ARM, so every Android and
+// Raspberry Pi shard - that -1 arrives as 255, so the floor_num == -1 guard in
+// Add (:147), AddOrReplace (:158), Erase (:189) and EraseGraphicAt (:216) never
+// trips and all four index Elements[255] of a six-element array. It reads
+// whatever follows the array, so it throws std::out_of_range or takes the shard
+// down with it depending on what is next to it in memory.
+// exported function test_customhouse_part_z_no_plane( resources )
+//   var multi := make_custom_house( resources );
+//   if ( !multi )
+//     return multi;
+//   endif
+//
+//   // the planes stop at 80, so 100 is below none of them
+//   var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 100 );
+//   if ( !res )
+//     return ret_error( $"addhousepart at z 100 answered {res}" );
+//   endif
+//   var res2 := check_count( multi, PARTS );
+//   if ( !res2 )
+//     return res2;
+//   endif
+//
+//   // and erasing what was never added answers 0
+//   res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 100 );
+//   if ( res )
+//     return ret_error( $"erasehousepart at z 100 answered {res}" );
+//   endif
+//   return 1;
+// endfunction
+
+// erasehousepart matches on graphic and offset - a wrong graphic, or the right
+// graphic at the wrong place, changes nothing
+exported function test_customhouse_erase_mismatch( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"addhousepart failed: {res}" );
+  endif
+
+  res := multi.erasehousepart( MARKER + 1, HOLE_X, HOLE_Y, 0 );
+  if ( res )
+    return ret_error( $"erase of a graphic that is not there answered {res}" );
+  endif
+  res := multi.erasehousepart( MARKER, HOLE_X + 1, HOLE_Y, 0 );
+  if ( res )
+    return ret_error( $"erase at the wrong offset answered {res}" );
+  endif
+  var res2 := check_count( multi, PARTS + 1 );
+  if ( !res2 )
+    return res2;
+  endif
+
+  res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"erasehousepart failed: {res}" );
+  endif
+  return check_count( multi, PARTS );
+endfunction
+
+// nothing guards the foundation on this path: a script can erase the tiles the
+// multi laid down, which over the wire the core refuses to do
+exported function test_customhouse_erase_dirt( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := multi.erasehousepart( DIRT, 1, 1, 0 );
+  if ( !res )
+    return ret_error( $"erase of a foundation tile answered {res}" );
+  endif
+  var res2 := check_count( multi, PARTS - 1 );
+  if ( !res2 )
+    return res2;
+  endif
+  var left := parts_at( multi, DIRT, 1, 1 ).size();
+  if ( left )
+    return ret_error( $"foundation tile still there: {left}" );
+  endif
+  return 1;
+endfunction
+
+// setcustom(0) leaves the design alone, setcustom(1) builds it again from the
+// multi - so a round trip is how a script throws a design away
+exported function test_customhouse_setcustom_off( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( !res )
+    return ret_error( $"addhousepart failed: {res}" );
+  endif
+  var res2 := check_count( multi, PARTS + 1 );
+  if ( !res2 )
+    return res2;
+  endif
+
+  multi.setcustom( 0 );
+  multi.setcustom( 1 );
+  res2 := check_count( multi, PARTS );
+  if ( !res2 )
+    return res2;
+  endif
+  var leftover := parts_at( multi, MARKER, HOLE_X, HOLE_Y ).size();
+  if ( leftover )
+    return ret_error( $"the added part survived the reset: {leftover}" );
+  endif
+  return 1;
+endfunction
+
+// none of the design surface answers on a house that was never made custom
+exported function test_customhouse_not_custom( resources )
+  var multi := ResourceManager::CreateMultiAtLocation( resources, 100, 75, 0, 0x12002 );
+  if ( !multi )
+    return multi;
+  endif
+
+  if ( multi.house_parts )
+    return ret_error( $"house_parts answered on a plain house: {multi.house_parts}" );
+  endif
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 0 );
+  if ( res )
+    return ret_error( $"addhousepart answered on a plain house: {res}" );
+  endif
+  res := multi.erasehousepart( DIRT, 1, 1, 0 );
+  if ( res )
+    return ret_error( $"erasehousepart answered on a plain house: {res}" );
+  endif
+  res := multi.acceptcommit( 0, 1 );
+  if ( res )
+    return ret_error( $"acceptcommit answered on a plain house: {res}" );
+  endif
+  res := multi.cancelediting( 0, 1 );
+  if ( res )
+    return ret_error( $"cancelediting answered on a plain house: {res}" );
+  endif
+  return 1;
+endfunction
+
+// a custom house nobody is editing is neither waiting for a commit nor editable
+exported function test_customhouse_commit_state( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  // the member is house_editing: a plain "editing" reads back as an
+  // uninitialized object, which is falsy and so passes this on its own
+  if ( multi.house_editing )
+    return ret_error( "a house nobody opened reports itself as being edited" );
+  endif
+  var res := multi.acceptcommit( 0, 1 );
+  if ( res )
+    return ret_error( $"acceptcommit answered while not waiting: {res}" );
+  endif
+  res := multi.cancelediting( 0, 1 );
+  if ( res )
+    return ret_error( $"cancelediting answered while not editing: {res}" );
+  endif
+  return 1;
+endfunction
+
+// SendHousingTool wants a character and a multi, in that order
+exported function test_customhouse_tool_params( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  var res := SendHousingTool( "not a character", multi );
+  if ( res )
+    return ret_error( $"SendHousingTool took a string as the character: {res}" );
+  endif
+  res := SendHousingTool( 0, multi );
+  if ( res )
+    return ret_error( $"SendHousingTool took 0 as the character: {res}" );
+  endif
+  return 1;
+endfunction
+
+// TODO core bug 5: re-enable once SendHousingTool checks for a client.
+// SendHousingTool reads chr->client->acctSupports() before it checks that there
+// is a client at all (uomod2.cpp:2579), so an offline character takes the shard
+// down with a null dereference. The same shape as house.cpp:533 in cancelediting.
+// exported function test_customhouse_tool_offline( resources )
+//   var multi := make_custom_house( resources );
+//   if ( !multi )
+//     return multi;
+//   endif
+//
+//   var char := createAccountWithChar( "housingtool_offline", "mypass" );
+//   if ( !char )
+//     return char;
+//   endif
+//   var res := SendHousingTool( char, multi );
+//   if ( res )
+//     return ret_error( $"SendHousingTool answered for an offline character: {res}" );
+//   endif
+//   return 1;
+// endfunction
+
+// TODO core bug 3: re-enable once CustomHouseDesign::Add checks its bounds.
+// CustomHouseDesign::Add() indexes its plane with .at() and never checks the
+// offset the way AddOrReplace() does (customhouses.cpp:144), so a part outside
+// the plot throws std::out_of_range. The executor catches it, which kills this
+// script instead of answering an error.
+// exported function test_customhouse_part_no_bounds( resources )
+//   var multi := make_custom_house( resources );
+//   if ( !multi )
+//     return multi;
+//   endif
+//
+//   var res := multi.addhousepart( MARKER, 99, 99, 0 );
+//   if ( res )
+//     return ret_error( $"addhousepart outside the plot answered {res}" );
+//   endif
+//   return check_count( multi, PARTS );
+// endfunction

--- a/testsuite/pol/testpkgs/house/test_custom_parts.src
+++ b/testsuite/pol/testpkgs/house/test_custom_parts.src
@@ -123,40 +123,31 @@ exported function test_customhouse_part_z_plane( resources )
   return check_count( multi, PARTS );
 endfunction
 
-// TODO core bug 1: re-enable once z_to_custom_house_table returns a signed type.
 // A z that maps to no plane at all should be dropped with the call still
 // answering 1, and erasing what was never added should answer 0.
-//
-// z_to_custom_house_table (customhouses.cpp:79) returns char, and its "no such
-// plane" answer is -1. Where char is unsigned - ARM, so every Android and
-// Raspberry Pi shard - that -1 arrives as 255, so the floor_num == -1 guard in
-// Add (:147), AddOrReplace (:158), Erase (:189) and EraseGraphicAt (:216) never
-// trips and all four index Elements[255] of a six-element array. It reads
-// whatever follows the array, so it throws std::out_of_range or takes the shard
-// down with it depending on what is next to it in memory.
-// exported function test_customhouse_part_z_no_plane( resources )
-//   var multi := make_custom_house( resources );
-//   if ( !multi )
-//     return multi;
-//   endif
-//
-//   // the planes stop at 80, so 100 is below none of them
-//   var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 100 );
-//   if ( !res )
-//     return ret_error( $"addhousepart at z 100 answered {res}" );
-//   endif
-//   var res2 := check_count( multi, PARTS );
-//   if ( !res2 )
-//     return res2;
-//   endif
-//
-//   // and erasing what was never added answers 0
-//   res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 100 );
-//   if ( res )
-//     return ret_error( $"erasehousepart at z 100 answered {res}" );
-//   endif
-//   return 1;
-// endfunction
+exported function test_customhouse_part_z_no_plane( resources )
+  var multi := make_custom_house( resources );
+  if ( !multi )
+    return multi;
+  endif
+
+  // the planes stop at 80, so 100 is below none of them
+  var res := multi.addhousepart( MARKER, HOLE_X, HOLE_Y, 100 );
+  if ( !res )
+    return ret_error( $"addhousepart at z 100 answered {res}" );
+  endif
+  var res2 := check_count( multi, PARTS );
+  if ( !res2 )
+    return res2;
+  endif
+
+  // and erasing what was never added answers 0
+  res := multi.erasehousepart( MARKER, HOLE_X, HOLE_Y, 100 );
+  if ( res )
+    return ret_error( $"erasehousepart at z 100 answered {res}" );
+  endif
+  return 1;
+endfunction
 
 // erasehousepart matches on graphic and offset - a wrong graphic, or the right
 // graphic at the wrong place, changes nothing

--- a/testsuite/pol/testpkgs/restart/test_house.src
+++ b/testsuite/pol/testpkgs/restart/test_house.src
@@ -83,3 +83,68 @@ exported function load_save_house_custom()
   endif
   return 1;
 endfunction
+
+// A design that was built on rather than left as the multi laid it down. The
+// case above only counts the parts, which a save that lost a graphic, an offset
+// or a z would still pass - every tile is written as one line of four numbers
+// (CustomHouseDesign::printProperties) and read back by position, so the tiles
+// this one puts down are picked to tell those four apart.
+exported function load_save_house_design()
+  // graphic, x, y, z. The z picks the plane the tile is filed under and is kept
+  // as it is given: 7 is the first storey, 30 belongs to the plane that starts
+  // at 27, and 0 is the ground the house stands on.
+  var parts := { { 0x31F4, 2, -2, 7 }, { 0x5C2, -2, 3, 30 }, { 0x64, 1, -3, 0 } };
+
+  if ( testrun == 1 )
+    var house := CreateMultiAtLocation( 70, 70, 0, 0x12000 );
+    if ( !house )
+      return ret_error( $"failed to create house {house}" );
+    endif
+    house.name := "load_save_house_design";
+    SetGlobalProperty( "test_storage_house_design", house.serial );
+    house.setcustom( 1 );
+    var before := len( house.house_parts );
+
+    foreach part in parts
+      var res := house.addhousepart( part[1], part[2], part[3], part[4] );
+      if ( !res )
+        return ret_error( $"addhousepart {part[1]} answered {res}" );
+      endif
+    endforeach
+    if ( len( house.house_parts ) != before + len( parts ) )
+      return ret_error( $"the parts did not go in: {len( house.house_parts )}" );
+    endif
+    SetGlobalProperty( "test_storage_house_design_count", len( house.house_parts ) );
+  else
+
+    var serial := GetGlobalProperty( "test_storage_house_design" );
+    if ( !serial )
+      return ret_error( "Global property not found" );
+    endif
+    var house := SystemFindObjectBySerial( serial );
+    if ( !house )
+      return ret_error( $"House with serial {serial:#x} does not exists: {house}" );
+    endif
+
+    var wanted := GetGlobalProperty( "test_storage_house_design_count" );
+    var got := len( house.house_parts );
+    if ( got != wanted )
+      return ret_error( $"{got} parts survived the restart, saved {wanted}" );
+    endif
+
+    foreach part in parts
+      var found := 0;
+      foreach it in ( house.house_parts )
+        if ( it.graphic == part[1] && it.xoffset == part[2] && it.yoffset == part[3] &&
+             it.z == part[4] )
+          found := found + 1;
+        endif
+      endforeach
+      if ( found != 1 )
+        var where := $"{part[1]} at {part[2]},{part[3]},{part[4]}";
+        return ret_error( $"part {where} came back {found} times" );
+      endif
+    endforeach
+  endif
+  return 1;
+endfunction

--- a/testsuite/testclient/pyuo/pyuo/brain.py
+++ b/testsuite/testclient/pyuo/pyuo/brain.py
@@ -166,6 +166,9 @@ class Event:
   EVT_TRADE = 20
   EVT_CLILOC = 21
   EVT_PARTY = 22
+  EVT_HOUSE_DESIGN = 23
+  EVT_HOUSE_EDIT = 24
+  EVT_HOUSE_REV = 25
 
   EVT_EXIT = 100
   EVT_LIST_OBJS = 101
@@ -270,3 +273,9 @@ class Event:
       return "cliloc"
     elif self.type==Event.EVT_PARTY:
       return "party"
+    elif self.type==Event.EVT_HOUSE_DESIGN:
+      return "house_design"
+    elif self.type==Event.EVT_HOUSE_EDIT:
+      return "house_edit"
+    elif self.type==Event.EVT_HOUSE_REV:
+      return "house_rev"

--- a/testsuite/testclient/pyuo/pyuo/client.py
+++ b/testsuite/testclient/pyuo/pyuo/client.py
@@ -638,6 +638,9 @@ class Client(threading.Thread):
     ## Serial of the mobile currently traded with, None when not trading
     self.trade = None
 
+    ## Serial of the house whose design is being edited, None when not editing
+    self.house = None
+
   @status('disconnected')
   def connect(self, host, port, user, pwd):
     '''! Connnects to the server, returns a list of gameservers
@@ -1046,6 +1049,12 @@ class Client(threading.Thread):
       self.brain.event(brain.Event(brain.Event.EVT_OPEN_PAPERDOLL, serial = pkt.serial, text=pkt.text, flags=pkt.flags))
     elif isinstance(pkt, packets.SecureTradingPacket):
       self.handleSecureTradingPacket(pkt)
+    elif isinstance(pkt, packets.CustomHouseDesignPacket):
+      self.log.info("House 0x%X design rev %d: %d tiles in %d planes",
+          pkt.serial, pkt.revision, pkt.numtiles, pkt.planecount)
+      self.brain.event(brain.Event(brain.Event.EVT_HOUSE_DESIGN, serial=pkt.serial,
+        revision=pkt.revision, numtiles=pkt.numtiles, planecount=pkt.planecount,
+        planes=pkt.planes, tiles=pkt.tiles))
     else:
       self.log.warn("Unhandled packet {}".format(pkt.__class__))
 
@@ -1264,6 +1273,14 @@ class Client(threading.Thread):
     elif pkt.sub == packets.GeneralInfoPacket.SUB_PARTY:
       self.brain.event(brain.Event(brain.Event.EVT_PARTY, partycmd=pkt.partycmd,
         serial=pkt.serial, members=pkt.members, msg=pkt.msg))
+    elif pkt.sub == packets.GeneralInfoPacket.SUB_HOUSE_REV:
+      self.brain.event(brain.Event(brain.Event.EVT_HOUSE_REV, serial=pkt.serial,
+        revision=pkt.rev))
+    elif pkt.sub == packets.GeneralInfoPacket.SUB_CUSTOMHOUSE:
+      editing = pkt.action == packets.GeneralInfoPacket.CUSTOMHOUSE_BEGIN
+      self.house = pkt.serial if editing else None
+      self.brain.event(brain.Event(brain.Event.EVT_HOUSE_EDIT, serial=pkt.serial,
+        action=pkt.action, editing=editing))
     elif pkt.sub == packets.GeneralInfoPacket.SUB_CLOSEGUMP:
       if pkt.gumpid in self.gumps:
         self.gumps.remove(pkt.gumpid)
@@ -1523,6 +1540,19 @@ class Client(threading.Thread):
     '''
     po = packets.GeneralInfoPacket()
     po.fill(po.SUB_PARTY, partycmd, *args)
+    self.queue(po)
+
+  @logincomplete
+  def houseCommand(self, sub, *args, serial=None):
+    '''! Sends a custom house design command
+    @param sub int: one of the CustomHouseCommandPacket.SUB_* constants
+    @param *args: what that subcommand carries, see CustomHouseCommandPacket.fill()
+    @param serial int: whose editing session to address. The player's own by
+                       default - the core drops anything else as spoofed, which
+                       is what a test asking for another serial is checking.
+    '''
+    po = packets.CustomHouseCommandPacket()
+    po.fill(self.player.serial if serial is None else serial, sub, *args)
     self.queue(po)
 
   @logincomplete

--- a/testsuite/testclient/pyuo/pyuo/client.py
+++ b/testsuite/testclient/pyuo/pyuo/client.py
@@ -1167,10 +1167,19 @@ class Client(threading.Thread):
   def handleDrawGamePlayerPacket(self, pkt):
     assert self.player.serial == pkt.serial
     assert self.player.graphic == pkt.graphic
-    assert self.player.x == pkt.x
-    assert self.player.y == pkt.y
-    assert self.player.z == pkt.z
-    #assert self.player.facing == pkt.direction
+
+    # The core telling the player where it really is, and the only facing update
+    # it ever gets: the one thing handleMovePacket's guess can resync against.
+    resync = ( self.player.x != pkt.x or self.player.y != pkt.y
+        or self.player.z != pkt.z or self.player.facing != pkt.direction )
+    if resync:
+      self.log.info("Position corrected: %s,%s,%s facing %s -> %d,%d,%d facing %d",
+          self.player.x, self.player.y, self.player.z, self.player.facing,
+          pkt.x, pkt.y, pkt.z, pkt.direction)
+    self.player.x = pkt.x
+    self.player.y = pkt.y
+    self.player.z = pkt.z
+    self.player.facing = pkt.direction
 
     self.player.color = pkt.hue
     self.player.status = pkt.flag
@@ -1302,11 +1311,14 @@ class Client(threading.Thread):
     with self.moveLock:
       # Match first move packet to be ackowledged
       mpkt = self.unmoves.popleft()
-      assert pkt.sequence == pkt.sequence
+      assert mpkt.sequence == pkt.sequence
 
       if not ack:
         # Reset sequence counter after a reject
         self.moveid = -1
+        # The core silently drops the requests still in flight, so keeping them
+        # queued would match every later ack against the wrong request.
+        self.unmoves.clear()
 
     oldx = self.player.x
     oldy = self.player.y
@@ -1315,7 +1327,9 @@ class Client(threading.Thread):
 
     if ack:
       # Need to calculate (guess) the new position, since this
-      # packets does not cointain position information
+      # packets does not cointain position information. A request whose
+      # direction is not the one we face only turns on the spot. z comes from
+      # the map and cannot be guessed, so it is kept until a 0x20 corrects it.
       if mpkt.direction == self.player.facing:
         # Moving in front of me, doing one step
         if mpkt.direction == Direction.N:

--- a/testsuite/testclient/pyuo/pyuo/packets.py
+++ b/testsuite/testclient/pyuo/pyuo/packets.py
@@ -580,7 +580,10 @@ class DrawGamePlayerPacket(Packet):
     self.x = self.dushort()
     self.y = self.dushort()
     self.dushort() # unknown
-    self.direction = self.dschar()
+    # the high bit is the running flag, the facing is the low three bits
+    direction = self.duchar()
+    self.running = bool(direction & 0x80)
+    self.direction = direction & 0x07
     self.z = self.dschar()
 
 
@@ -1098,7 +1101,10 @@ class UpdatePlayerPacket(Packet):
     self.x = self.dushort()
     self.y = self.dushort()
     self.z = self.dschar()
-    self.facing = self.dschar()
+    # the high bit is the running flag of the mobile's last move
+    facing = self.duchar()
+    self.running = bool(facing & 0x80)
+    self.facing = facing & 0x07
     self.color = self.dushort()
     self.flag = self.duchar()
     self.notoriety = self.duchar()

--- a/testsuite/testclient/pyuo/pyuo/packets.py
+++ b/testsuite/testclient/pyuo/pyuo/packets.py
@@ -1559,8 +1559,15 @@ class GeneralInfoPacket(Packet):
   SUB_HOUSE_REV = 0x1d
   ## Enable map-diff files
   SUB_MAPDIFF = 0x18
+  ## Enter or leave the custom house design editor
+  SUB_CUSTOMHOUSE = 0x20
   ## Boat movement
   SUB_BOATMOVE = 0x33
+
+  ## SUB_CUSTOMHOUSE: the server put the client into design mode
+  CUSTOMHOUSE_BEGIN = 0x04
+  ## SUB_CUSTOMHOUSE: the server took the client back out of it
+  CUSTOMHOUSE_END = 0x05
 
   ## Party subcommands, both directions, see PKTBI_BF_06 in the core
   ## Client: add a member by serial (0 asks for a target cursor)
@@ -1783,6 +1790,13 @@ class GeneralInfoPacket(Packet):
       self.serial = self.duint()
       self.rev = self.duint()
 
+    elif self.sub == self.SUB_CUSTOMHOUSE:
+      self.serial = self.duint()
+      self.action = self.duchar()
+      self.dushort()
+      self.duint()
+      self.duchar()
+
     elif self.sub == self.SUB_BOATMOVE:
       self.serial = self.duint()
       self.direction = self.duchar()
@@ -1952,6 +1966,186 @@ class AOSTooltipPacket(Packet):
     self.eulen()
     for serial in self.serials:
       self.euint(serial)
+
+
+class CustomHouseCommandPacket(Packet):
+  ''' A command for the custom house design editor, see PKTBI_D7 in the core
+
+  Only meaningful while the server has put this client into design mode: the
+  core looks the house up by the sending character's serial and drops the
+  packet when that character is not editing one.
+  '''
+
+  cmd = 0xd7
+
+  ## Keep the working design aside, so RESTORE can bring it back
+  SUB_BACKUP = 0x02
+  ## Put the kept design back into the working design
+  SUB_RESTORE = 0x03
+  ## Make the working design the one the house really has
+  SUB_COMMIT = 0x04
+  ## Take a tile out of the working design
+  SUB_ERASE = 0x05
+  ## Put a tile into the working design
+  SUB_ADD = 0x06
+  ## Close the editor
+  SUB_QUIT = 0x0c
+  ## Put a whole stair multi into the working design
+  SUB_ADD_MULTI = 0x0d
+  ## Ask for the working design to be sent again
+  SUB_SYNCH = 0x0e
+  ## Throw the working design away, leaving the foundation
+  SUB_CLEAR = 0x10
+  ## Pick the storey being edited, 1 to 4
+  SUB_SELECT_FLOOR = 0x12
+  ## Put in a roof tile, which carries a z of its own
+  SUB_SELECT_ROOF = 0x13
+  ## Take out a roof tile
+  SUB_DELETE_ROOF = 0x14
+  ## Throw the working design away, going back to the committed one
+  SUB_REVERT = 0x1a
+
+  ## Subcommands that carry nothing but the serial and the subcommand itself
+  NO_ARGS = (SUB_BACKUP, SUB_RESTORE, SUB_COMMIT, SUB_QUIT, SUB_SYNCH,
+             SUB_CLEAR, SUB_REVERT)
+  ## Subcommands laid out as CH_ADD: a tile and an offset
+  TILE_AT = (SUB_ADD, SUB_ADD_MULTI)
+  ## Subcommands laid out as CH_ERASE: a tile, an offset and a z
+  TILE_AT_Z = (SUB_ERASE, SUB_SELECT_ROOF, SUB_DELETE_ROOF)
+
+  ## Trailing byte the real client sends, which the core never reads
+  TRAILER = 0x07
+
+  def fill(self, serial, sub, *args):
+    '''!
+    @param serial int: The editing character's serial. The core refuses the
+                       packet when it does not match the sender, so a wrong one
+                       is how a test drives the spoof check.
+    @param sub int: The subcommand, see SUB_ constants
+    @param *args: Variable number of arguments, depending on sub:
+                  - NO_ARGS subcommands: none
+                  - SUB_ADD/SUB_ADD_MULTI: graphic int, x int, y int
+                  - SUB_ERASE/SUB_SELECT_ROOF/SUB_DELETE_ROOF:
+                    graphic int, x int, y int, z int
+                  - SUB_SELECT_FLOOR: floor int
+    '''
+    self.serial = serial
+    self.sub = sub
+    # header, then the payload, then the trailing byte
+    self.length = 9 + 1
+
+    def checkArgLen(expLen):
+      if len(args) != expLen:
+        raise TypeError("Subcommand {:02x} takes {} positional argument(s) "
+            "but {} were given".format(self.sub, expLen, len(args)))
+
+    if self.sub in self.NO_ARGS:
+      checkArgLen(0)
+
+    elif self.sub in self.TILE_AT:
+      checkArgLen(3)
+      self.graphic, self.x, self.y = args
+      self.length += 15
+
+    elif self.sub in self.TILE_AT_Z:
+      checkArgLen(4)
+      self.graphic, self.x, self.y, self.z = args
+      self.length += 20
+
+    elif self.sub == self.SUB_SELECT_FLOOR:
+      checkArgLen(1)
+      self.floor = args[0]
+      self.length += 5
+
+    else:
+      raise NotImplementedError('Subcommand {:02x} not implemented to send'.format(self.sub))
+
+  def eu32signed(self, val):
+    ''' Adds an offset as the u32 the core reads back into an s32 '''
+    self.euint(val & 0xffffffff)
+
+  def encodeChild(self):
+    self.eulen()
+    self.euint(self.serial)
+    self.eushort(self.sub)
+
+    if self.sub in self.TILE_AT or self.sub in self.TILE_AT_Z:
+      self.euchar(0)
+      self.euchar(0)
+      self.euchar(0)
+      self.eushort(self.graphic)
+      self.euchar(0)
+      self.eu32signed(self.x)
+      self.euchar(0)
+      self.eu32signed(self.y)
+      if self.sub in self.TILE_AT_Z:
+        self.euchar(0)
+        self.eu32signed(self.z)
+
+    elif self.sub == self.SUB_SELECT_FLOOR:
+      self.euint(0)
+      self.euchar(self.floor)
+
+    self.euchar(self.TRAILER)
+
+
+class CustomHouseDesignPacket(Packet):
+  ''' A whole custom house design, see CustomHousesSendFull() in the core
+
+  The tiles are split into planes - one per storey - each zlib compressed on
+  its own behind a packed header. Only mode 0 is ever sent, which is five bytes
+  per tile.
+  '''
+
+  cmd = 0xd8
+
+  ## Bytes a mode 0 tile takes: graphic, then the three offsets
+  BYTES_PER_TILE = 5
+
+  def decodeChild(self):
+    self.length = self.dushort()
+    self.compressiontype = self.duchar()
+    self.unk = self.duchar()
+    self.serial = self.duint()
+    self.revision = self.duint()
+    ## How many tiles the server says the design has
+    self.numtiles = self.dushort()
+    self.planebuffer_len = self.dushort()
+    self.planecount = self.duchar()
+    ## One dict per plane: index, mode, ulen, clen and its own tile list
+    self.planes = []
+    ## Every tile of every plane, as dicts of graphic/x/y/z
+    self.tiles = []
+
+    # the plane count byte is itself part of the buffer the length covers
+    read = 1
+    while read < self.planebuffer_len:
+      header = self.duint()
+      read += 4
+      # the two lengths are 12 bit, split with their high nibble in the low byte
+      plane = {
+        'mode': (header >> 28) & 0xf,
+        'index': (header >> 24) & 0xf,
+        'ulen': ((header >> 16) & 0xff) | ((header & 0xf0) << 4),
+        'clen': ((header >> 8) & 0xff) | ((header & 0x0f) << 8),
+        'tiles': [],
+      }
+      if plane['mode'] != 0:
+        raise NotImplementedError("House plane mode {} not implemented".format(plane['mode']))
+
+      # an empty plane is sent as a header alone, the core zeroes clen for it
+      if plane['clen']:
+        raw = zlib.decompress(self.rpb(plane['clen']))
+        read += plane['clen']
+        if len(raw) != plane['ulen']:
+          raise RuntimeError("House plane {} inflated to {} bytes, header said {}".format(
+              plane['index'], len(raw), plane['ulen']))
+        for i in range(0, len(raw), self.BYTES_PER_TILE):
+          graphic, x, y, z = struct.unpack('>Hbbb', raw[i:i+self.BYTES_PER_TILE])
+          plane['tiles'].append({'graphic': graphic, 'x': x, 'y': y, 'z': z})
+
+      self.planes.append(plane)
+      self.tiles.extend(plane['tiles'])
 
 
 class NewObjectInfoPacket(Packet):

--- a/testsuite/testclient/pyuo/testclient.py
+++ b/testsuite/testclient/pyuo/testclient.py
@@ -166,6 +166,21 @@ class TestBrain(brain.Brain):
         if arg.get('canloot', None) is not None:
           args.append(int(arg['canloot']))
         self.client.party(int(arg['partycmd']), *args)
+      elif todo=="house":
+        # the arguments a house command takes, in the order the packet wants
+        # them: a graphic, an offset, then a z, or a floor number on its own
+        args=[]
+        if arg.get('graphic', None) is not None:
+          args.append(int(arg['graphic']))
+          args.append(int(arg['x']))
+          args.append(int(arg['y']))
+        if arg.get('z', None) is not None:
+          args.append(int(arg['z']))
+        if arg.get('floor', None) is not None:
+          args.append(int(arg['floor']))
+        serial=arg.get('serial', None)
+        self.client.houseCommand(int(arg['sub']), *args,
+          serial = None if serial is None else int(serial))
       elif todo=="target":
         res=self.client.waitForTarget(5)
         targettype=None
@@ -482,6 +497,23 @@ class PolServer:
       res['name']=ev.name
       res['hp']=ev.hp
       res['maxhp']=ev.maxhp
+    elif ev.type==Event.EVT_HOUSE_DESIGN:
+      # what the header claims and what the planes actually carried are both
+      # here on purpose: a design that disagrees with itself is the kind of
+      # thing only decoding the packet can catch
+      res['serial']=ev.serial
+      res['revision']=ev.revision
+      res['numtiles']=ev.numtiles
+      res['planecount']=ev.planecount
+      res['planes']=[{k:v for k,v in p.items() if k != 'tiles'} for p in ev.planes]
+      res['tiles']=ev.tiles
+    elif ev.type==Event.EVT_HOUSE_EDIT:
+      res['serial']=ev.serial
+      res['action']=ev.action
+      res['editing']=ev.editing
+    elif ev.type==Event.EVT_HOUSE_REV:
+      res['serial']=ev.serial
+      res['revision']=ev.revision
     else:
       raise NotImplementedError("Unknown event {}",format(ev.type))
 


### PR DESCRIPTION
# Custom house design editor — defects found while writing test coverage

Found while building client-driven coverage for the `0xD7`
design editor and the `0xD8` design packet (`testsuite/pol/testpkgs/client/test_client_house*.src`).

**Nine of the eleven are fixed.** Defects 10 and 11 are open — the
`0xD8` plane loop is left as it was — and **defect 7 is fixed far more narrowly than it was
written**, see that section. Every case for a fixed defect is live; the two for defects 10 and
11 are commented out behind a `TODO core bug <n>` marker, so
`grep -rn "TODO core bug [0-9]" testsuite/pol/testpkgs` finds exactly those two. The write-ups
below are kept as they were found; the line under each says where it stands.

| # | Defect | Severity | Reachable from | Verified by | Fixed |
|---|---|---|---|---|---|
| 1 | `z_to_custom_house_table` returns `char`; `-1` reads as `255` where `char` is unsigned | Crash | Client packet, script | Running (shard died) | yes |
| 2 | `MultiDefByMultiID` asserts on an unknown multiid | Crash | Client packet | Reading | yes |
| 3 | `CustomHouseDesign::Add` has no bounds check | Crash | Client packet, script, save file | Reading | yes |
| 4 | Cached design packet keeps a stale revision | Protocol | Client packet | Running | yes |
| 5 | `SendHousingTool` dereferences `chr->client` unchecked | Crash | Script | Reading | yes |
| 6 | `cancelediting` dereferences `chr->client` unchecked | Crash | Script | Reading | yes |
| 7 | `CloseCustomHouse` hook never fires on a commit | Behaviour | Client packet | Reading | partly — see below |
| 8 | `SendHousingTool`'s "waiting for a commit" refusal is unreachable | Dead code | — | Running | yes |
| 9 | `ReplaceDirtFloor` bounds test uses `height` where the rest of the file uses `height - 1` | Dead code | — | Reading | yes |
| 10 | The design packet loses whole storeys when the used floors have a gap | Protocol | Client packet | Running | **no** |
| 11 | Plane header lengths are packed into 12 bits with no bounds check | Protocol | Large design | Reading | **no** |

---

## 1. `z_to_custom_house_table` returns `char`, so its `-1` becomes `255` on ARM

**Files:** `pol-core/pol/multi/customhouses.cpp:79`, declared `customhouses.h:157`

```cpp
char CustomHouseDesign::z_to_custom_house_table( char z )
{
  unsigned char i;
  for ( i = 0; i < CUSTOM_HOUSE_NUM_PLANES; i++ )
  {
    if ( z == custom_house_z_xlate_table[i] )
      return i;
    if ( z < custom_house_z_xlate_table[i] )
      return i - 1;
  }
  return -1;
}
```

The "no such plane" answer is `-1`, but the return type is plain `char`, whose signedness is
implementation defined. **It is unsigned on ARM** — every Android and Raspberry Pi build — so
callers receive `255`.

Every caller guards with `if ( floor_num == -1 )`, and on those platforms that guard is dead:

| Caller | Line |
|---|---|
| `CustomHouseDesign::Add` | `customhouses.cpp:146` |
| `CustomHouseDesign::AddOrReplace` | `customhouses.cpp:157` |
| `CustomHouseDesign::Erase` | `customhouses.cpp:188` |
| `CustomHouseDesign::EraseGraphicAt` | `customhouses.cpp:215` |
| `CustomHouseDesign::DeleteStairs` | `customhousehelp.cpp:99` |

Each then indexes `Elements[255]` of a six-element array. It is undefined behaviour, so it
throws `std::out_of_range` or segfaults depending on what follows the array in memory. x86 is
unaffected, which is why this has survived.

**Reachable from the wire.** `CustomHousesErase` reads the z straight out of the client packet
as a `u8` (`customhouses.cpp:771`) and hands it to `DeleteStairs` and `EraseGraphicAt`;
`CustomHousesRoofRemove` does the same (`:981`). Any z above 80 — the last plane — maps to no
plane. Both run on the network thread, where nothing catches the exception, so the shard goes
down either way.

Also reachable from script through `addhousepart` / `erasehousepart` with any z above 80. There
the executor catches the exception, so the *script* dies rather than the shard, with an error
that says nothing about where it came from.

**Reproduce** (on an unsigned-`char` platform): with a custom house,

```
multi.addhousepart( 0x31F4, 0, 0, 100 );
```

or, over the wire, a `0xD7` sub `0x05` (erase) naming any z above 80.

**Fix:** return `int` (or `s8`) instead of `char`. One line, and the existing `== -1` guards
then work as written.

**Fixed** as described — `z_to_custom_house_table` returns `int` and takes a `u8`, and
`custom_house_z_xlate_table` is `u8` too. Pinned by `test_customhouse_part_z_no_plane`
(`testpkgs/house/test_custom_parts.src`) and `erase_z_no_plane`
(`test_client_house_erase.src`).

---

## 2. `MultiDefByMultiID` asserts on an unknown multiid, and a client packet chooses the id

**Files:** `pol-core/pol/multi/multidef.cpp:248`, `customhouses.cpp:732`, `customhouses.cpp:377`

```cpp
const MultiDef* MultiDefByMultiID( u16 multiid )
{
  passert( multidef_buffer.multidefs_by_multiid.count( multiid ) != 0 );
  ...
  return nullptr;
}
```

`CustomHousesAddMulti` (`customhouses.cpp:732`) accepts any multiid in
`STAIR_MULTIID_MIN..STAIR_MULTIID_MAX` (`0x1DB0..0x1DF3`) and passes it to `AddMultiAtOffset`
(`:377`), which opens with `MultiDefByMultiID( multiid )`. There is no check that the id names a
multi the shard actually has.

`INC_PASSERT=1` (`cmake/compile_defs.cmake`), so the assertion is live in release builds, and a
shard configured with `AssertionFailureAction=shutdown` goes down. The `multidef == nullptr`
branch immediately below the call — which logs a proper error and returns — is unreachable.

Most of `0x1DB0..0x1DF3` is unused on a stock installation, so **any client with the design
editor open can shut the shard down with a single packet**.

**Reproduce:** enter the design editor and send `0xD7` sub `0x0D` with a multiid in that range
that has no entry in `multis.cfg`.

**Fix:** the safe query already exists next to it — `MultiDefByMultiIDExists( u16 )` at
`multidef.cpp:244`. Either call that in `AddMultiAtOffset` before `MultiDefByMultiID`, or drop
the `passert` and let the existing nullptr handling do its job.

**Fixed** by dropping the `passert`, so the `multidef == nullptr` branch that logs and returns
is reached. Pinned by `house_add_multi_unknown_id` (`test_client_house_edit.src`), which
asserts the design is unchanged.

---

## 3. `CustomHouseDesign::Add` has no bounds check

**Files:** `pol-core/pol/multi/customhouses.cpp:144`, `customhousehelp.cpp:230`

`AddOrReplace` (`:155`) checks `ValidLocation( xidx, yidx )` before touching the element store.
`Add` (`:144`) does not, and `CustomHouseElements::AddElement` (`customhousehelp.cpp:230`)
indexes with `.at()`:

```cpp
void CustomHouseElements::AddElement( const CUSTOM_HOUSE_ELEMENT& elem )
{
  u32 x = elem.xoffset + xoff;
  u32 y = elem.yoffset + yoff;
  data.at( x ).at( y ).push_back( elem );
}
```

Three ways in:

- **From the wire.** `CustomHousesAddMulti` → `AddMultiAtOffset` (`:377`) feeds unvalidated
  client x/y, plus each component's own relative offset, straight into `Add()`. A stair multi
  placed near the edge of the plot puts its top step outside the design. This runs on the
  network thread, where the exception is not caught.
- **From script.** `addhousepart` with an out-of-plot offset throws; the executor catches it, so
  the script dies instead of getting a `BError`.
- **From a save file.** `readProperties` (`:405`) rebuilds the design from `Current`/`Working`/
  `Backup` lines through the same path, so a hand-edited or corrupted world save takes the shard
  down at load.

**Fix:** the same `ValidLocation` check `AddOrReplace` already does, in `Add`.

**Fixed** as described. Pinned by `house_add_multi_out_of_plot` (`test_client_house_edit.src`),
which asserts the one step that fits lands and the nine that do not are dropped, and by
`test_customhouse_part_no_bounds` (`testpkgs/house/test_custom_parts.src`).

---

## 4. An erase or a clear leaves the client permanently one revision behind

**Files:** `pol-core/pol/multi/customhouses.cpp:998`, `:762`, `:807`

`CustomHousesSendFull` (`:998`) caches the packet it builds in `WorkingCompressed` /
`CurrentCompressed` and, on the next call, replays it byte for byte:

```cpp
  case HOUSE_DESIGN_WORKING:
    if ( house->WorkingCompressed.empty() )   // no design stored, create below
    { ... }
    else                                      // send stored packet
    {
      Core::networkManager.clientTransmit->AddToQueue( client, &house->WorkingCompressed[0], ... );
      return;
    }
```

The revision is part of that packet. `CustomHousesErase` (`:762`) and `CustomHousesClear`
(`:807`) both **send the design and then increment**:

```cpp
  if ( chr && chr->client )
    CustomHousesSendFull( house, chr->client, HOUSE_DESIGN_WORKING );

  house->revision++;                          // :804 for erase, :826 for clear
```

So the packet is built and cached carrying the number from *before* the change, and every later
synch replays that same cached packet. The client is not merely told a stale revision once — it
goes on being told the stale one until some other command invalidates the cache, at which point
the number appears to jump by two.

The revision is what a client uses to decide whether the copy of the design it holds is still
good, so an erase leaves it believing an out-of-date design is current.

**Reproduce:** in a design session, add a tile, synch (revision N). Erase a tile, and every
synch from then on still answers N until the next add.

**Fix:** increment the revision before building the packet in both handlers. Every other
command that changes the design (`CustomHousesAdd` `:729`, `AddMulti` `:759`, `RoofSelect`
`:970`, `RoofRemove` `:995`) already increments without sending, so only these two are affected.

**Fixed** as described. The case that used to pin the old behaviour, `erase_revision_lags`, is
now `erase_revision_advances` (`test_client_house_erase.src`) and walks the number through an
add, an erase, a synch and a second add.

---

## 5. `SendHousingTool` dereferences `chr->client` before checking it

**File:** `pol-core/pol/module/uomod2.cpp:2570`

```cpp
BObjectImp* UOExecutorModule::mf_SendHousingTool()
{
  ...
  if ( !( getCharacterParam( 0, chr ) && getMultiParam( 1, multi ) ) )
    return new BError( "Invalid parameter type" );
  if ( !chr->client->acctSupports( Plib::ExpansionVersion::AOS ) )   // :2579
    return new BError( "Charater does not have AOS enabled." );
```

`getCharacterParam` accepts any mobile, NPCs included, and an offline player has no client
either. The very first thing the function does with the character is dereference `chr->client`,
before the multi is even looked at. Every other refusal in the function is a tidy `BError`, so
this is the one parameter nobody covered.

**Reproduce:** `SendHousingTool( npc, house )`.

**Fix:** `if ( !chr->has_active_client() ) return new BError( "No client attached." );` ahead of
the expansion test.

**Fixed** as described. Pinned by `tool_on_a_mobile_with_no_client`
(`test_client_house_accept.src`, an npc) and `test_customhouse_tool_offline`
(`testpkgs/house/test_custom_parts.src`, an offline player).

---

## 6. `cancelediting` dereferences `chr->client` before checking it

**File:** `pol-core/pol/multi/house.cpp:533`

```cpp
  case MTH_CANCEL_EDITING:
  {
    ...
    if ( ex.getCharacterParam( 0, chr ) && ex.getParam( 1, drop_changes ) )
    {
      if ( chr->client->gd->custom_house_serial == serial )   // :533
```

Same shape as defect 5: the method already answers `"House is not custom"`, `"House is currently not
been edited"`, `"Not enough parameters"` and `"Character is not editing this house"` as errors,
and a mobile with no client belongs in that list rather than in a null dereference.

**Reproduce:** with a house being edited, `house.cancelediting( npc, 1 )`.

**Fix:** a `has_active_client()` test before the comparison, answering the existing
`"Character is not editing this house"`.

**Fixed** as described. Pinned by `cancel_by_a_mobile_no_client`
(`test_client_house_accept.src`), which also asserts the session is still open afterwards.

---

## 7. The `CloseCustomHouse` hook never fires on a commit — half a defect

**The finding as originally written is too broad.** The obvious fix — calling the hook from
`AcceptHouseCommit`, so it fires on every commit — is the wrong one. Two things say so:

- **The hook's documented scope is a quit, not the end of a session.** `scripttypes.xml` says
  "When called: When mobiles quits house editing", and the changelog entry that introduced it in
  2011 says "called after client quits editing, or when house.cancelediting() is called". The
  write-up below assumed a scope the hook never had.
- **The commit route already has a callback, handed the same two arguments.**
  `CustomHousesCommit` starts `misc/customhousecommit.ecl` with `(chr, house)` and leaves the
  house waiting for an accept. Firing the hook as well means a shard hooking both hears about one
  commit **twice** — and one that uses the hook to release per-session state releases it twice.

**What is a real gap** is the other branch: a shard with **no** `misc/customhousecommit.ecl`.
There `CustomHousesCommit` falls straight through to `AcceptHouseCommit`, and nothing at all is
called — no commit script, and no hook. That shard has no way to hear that a design session
ended in a commit.

**Fixed** by calling the hook from `CustomHousesCommit` only on that fall-through path, after
`AcceptHouseCommit`. The scripted route is untouched, so no shard starts getting a duplicate.
Note the fall-through also covers a commit script that exists but fails to start, which is right
for the same reason — the script never ran, so nothing was said.

**The fixed branch is not covered by the suite.** The commit script is shard-wide, cannot be
unloaded, and this test shard always has one, so the no-script route is out of reach without
deleting the `.ecl` mid-run — which would change the shard for every later case that commits.
`commit_skips_close_hook` in `testsuite/pol/testpkgs/client/test_client_house_accept.src` covers
the half that is reachable: with a commit script present the script is called and the hook is
not, asserted as deliberate so the silence is not read as an oversight again.

---

### The original write-up


**Files:** `pol-core/pol/multi/house.cpp:1159`, `customhouses.cpp:1151`

The hook is called from `UHouse::CustomHousesQuit` only (`customhouses.cpp:1173`).
`AcceptHouseCommit` (`house.cpp:1159`) ends the session by calling `CustomHouseStopEditing`
directly instead of going through `CustomHousesQuit`, so of the three ways a design session can
end, the two that throw the changes away are reported to the hook and the one that keeps them is
not.

A shard using the hook to release whatever it set up for the session — the usual reason to hook
it — never hears about a house that was actually rebuilt.

**Reproduce:** register a `CloseCustomHouse` hook, open the editor, commit. The hook is silent;
quitting or `cancelediting` calls it.

**Fix:** call the hook from `AcceptHouseCommit` as well, or route its accept branch through the
same helper.



---

## 8. `SendHousingTool`'s "waiting for a commit" refusal cannot be reached

**File:** `pol-core/pol/module/uomod2.cpp:2570`

```cpp
  if ( house->editing )
    return new BError( "House currently being customized." );
  if ( house->IsWaitingForAccept() )
    return new BError( "House currently being waiting for a commit" );
```

A commit that goes to a commit script sets `waiting_for_accept` but does not clear `editing`
(`CustomHousesCommit`, `customhouses.cpp`), so a house waiting for an accept always matches the
first test. The second `BError` is unreachable, and the caller gets a message describing the
wrong state.

Minor, but it makes the two states indistinguishable from script.

**Fixed** by testing `IsWaitingForAccept()` first, so the narrower state is the one reported.
`commit_holds_for_accept` (`test_client_house_accept.src`) now asserts that message.

---

## 9. `ReplaceDirtFloor` bounds test uses `height` where the rest of the file uses `height - 1`

**File:** `pol-core/pol/multi/customhouses.cpp:237`

```cpp
  if ( xoffset + xoff == 0 || yoffset + yoff == 0 ||
       Clib::clamp_convert<u32>( yoffset + yoff ) == height )
    return;
```

Every other bound in the file treats `height - 1` as the last row — the design is one row taller
than the multi to hold the front steps. As written the test can never be true for a location
that passes `ValidLocation` (which caps at `height - 1`), so today it is dead rather than wrong.
Worth aligning while the file is open, since a future change to either bound would make the two
disagree silently.

**Fixed** to `height - 1`, which is what the comment next to it describes: the front step row is
now really left unpaved. Nothing in the suite reached it either way — the front step row is
forced to z 0 and `ReplaceDirtFloor` is only called for z 7.

---

## 10. The design packet loses whole storeys when the used floors have a gap

**File:** `pol-core/pol/multi/customhouses.cpp:1049`, `:1068`

```cpp
  unsigned char planes = pdesign->NumUsedPlanes();
  ...
  msg->buffer->planecount = planes;
  buffer_len = 1;
  for ( int i = 0; i < planes; i++ )
  {
    data = pdesign->Compress( i, &ulen, &clen );
    ...
    planeheader |= ( ( i & 0xF ) << 24 );
```

`NumUsedPlanes()` is a **count** of the non-empty floors, not the highest index in use:

```cpp
unsigned char CustomHouseDesign::NumUsedPlanes() const
{
  unsigned char size = 0;
  for ( int floor_size : floor_sizes )
    if ( floor_size > 0 )
      size++;
  return size;
}
```

The loop then uses that count as the bound on the plane *index*, so it only ever sends floors
`0 .. count-1`. As long as the used floors are a contiguous run from 0 that happens to be right;
the moment there is a gap it sends an empty plane in place of a used one and drops everything
above.

Reachable from the editor: a house with the foundation (floor 0), a ground floor (floor 1) and
the multi's own roof (floor 2) has three floors used. Build on storey 4 without putting anything
on storey 3 and floor 4 becomes used, so `planes` is 4 and the loop sends floors 0, 1, 2 and the
*empty* floor 3 — the storey 4 tiles never reach the client at all. `msg->numtiles` is
`TotalSize()`, which still counts them, so the packet contradicts itself: the header claims more
tiles than the planes carry.

**Reproduce:** in a design session, select storey 4 (`0xD7` sub `0x12`, floor 4), add a tile, then
synch. The design that comes back claims one more tile than its planes hold, and the tile is
missing.

**Fix:** iterate the planes by index over `CUSTOM_HOUSE_NUM_PLANES`, skipping the empty ones and
emitting each used floor under its own index; `planecount` should then be the number of plane
headers actually written.

**Confirmed by running.** `house_storey_gap_sent` in
`testsuite/pol/testpkgs/client/test_client_house.src` selects storey 4, adds one tile and asks
for the design; escript reads the tile back through `house_parts`, and the packet comes back
saying `design says 141 tiles, its planes carried 140`.

**Open.** `house_storey_gap_sent` stays commented out until it is closed.

Two notes for whoever takes it on. `planecount` has to become the number of plane headers
actually written rather than `NumUsedPlanes()`, or the header and the buffer disagree in the
other direction. And `design_is_consistent()` in `customhouse.inc` already checks `planecount`
against the number of planes decoded — that holds under the current core, since the loop writes
exactly `NumUsedPlanes()` headers, so it is free to keep and it is what will catch the count
going wrong.

---

## 11. Plane header lengths are packed into 12 bits with no bounds check

**File:** `pol-core/pol/multi/customhouses.cpp:1078`

```cpp
    planeheader |= ( ( ulen & 0xFF ) << 16 );
    planeheader |= ( ( clen & 0xFF ) << 8 );
    planeheader |= ( ( ( ulen >> 4 ) & 0xF0 ) | ( ( clen >> 8 ) & 0xF ) );
```

Both lengths get 12 bits, so each caps at 4095 — 819 tiles per plane at 5 bytes each. Neither is
checked. A plane past that silently truncates: the client is told a compressed length shorter
than what was written, reads that many bytes, and every plane after it in the buffer is read from
the wrong offset.

Whether it is reachable depends on how large a single storey a shard allows; it is not reachable
with the test shard's multis, and the suite's largest plane is 305 bytes against the 4095 ceiling.

**Fix:** the protocol answer is to split an oversized plane across several plane headers, which
the format allows — the plane index is 4 bits and nothing requires one plane per storey. Worth
keeping a refusal or a `POLLOG_ERRORLN` as the backstop even then, so a plane that still does not
fit cannot go out mis-encoded.

A test client does not need to know: a decoder driven by `planebuffer_len` rather than by an
assumed plane count, which flattens every plane's tiles into one list, reassembles a split design
without changes. The one in `testsuite/testclient/pyuo/pyuo/packets.py`
(`CustomHouseDesignPacket`) is written that way.

**Open.** `house_plane_too_large` stays commented out until it is closed.

Three notes for whoever takes it on. `Compress()` needs a tile range
(`floor, firsttile, maxtiles, …`) so one floor can be emitted a chunk at a time. The chunk wants
to be a tile count comfortably under `4095 / 5 = 819` — 800 leaves the compressed length room,
since zlib may grow what it is given and both lengths share the same 12-bit ceiling. And it
cannot be done on its own: the plane loop has to index by plane before a floor can be split
across headers, so **defect 10 has to be settled in the same change**.

---

## The cases

Every defect above has a test case. All are live except the two for defects 10 and 11, which stay
commented out behind a `TODO core bug <n>` marker — `grep -rn "TODO core bug [0-9]"
testsuite/pol/testpkgs` finds exactly those two:

- `house_add_multi_unknown_id` (defect 2), `house_add_multi_out_of_plot` (defect 3) —
  `test_client_house_edit.src`
- `erase_z_no_plane` (defect 1), `erase_revision_advances` (defect 4) —
  `test_client_house_erase.src`
- `test_customhouse_part_z_no_plane` (defect 1), `test_customhouse_part_no_bounds` (defect 3),
  `test_customhouse_tool_offline` (defect 5) —
  `testsuite/pol/testpkgs/house/test_custom_parts.src`
- `tool_on_a_mobile_with_no_client` (defect 5), `cancel_by_a_mobile_no_client` (defect 6),
  `commit_skips_close_hook` (defect 7, the scripted route — the fixed no-script route is
  unreachable from the suite), `commit_holds_for_accept` (defect 8) —
  `test_client_house_accept.src`
- `house_storey_gap_sent` (defect 10), `house_plane_too_large` (defect 11) —
  `test_client_house.src`, both **commented out**. `house_storey_gap_sent` fails cleanly and
  harms nothing;
  `house_plane_too_large` cannot be left running at all, because the test client checks the
  announced uncompressed length against what it inflated and raises inside the packet handler,
  which kills the client thread and takes every later case in the package with it.

Defect 9 has no case: the row it guards can only be reached at z 0, and `ReplaceDirtFloor` is
only called for z 7, so the branch stays unreachable from the wire either way.
