### PR TITLE
Fix default font/color constant mix-ups for system messages

### DIFF
--- a/docs/docs.polserver.com/pol100/clilocem.xml
+++ b/docs/docs.polserver.com/pol100/clilocem.xml
@@ -6,7 +6,7 @@
     <filedesc>Functions for sending Cliloc (Client Localized) messages to the Client.</filedesc>
     <datemodified>08/31/2015</datemodified>
     <constant>const _DEFAULT_CLFONT  := 3;</constant>
-    <constant>const _DEFAULT_CLCOLOR := 0x3B2;</constant>
+    <constant>const _DEFAULT_CLCOLOR := 946;</constant>
   </fileheader>
 
   <function name="SendSysMessageCL"> 

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,14 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-15-2026</datemodified>
+		<datemodified>08-16-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>08-16-2026</date>
+			<author>AsYlum:</author>
+			<change type="Changed">the default system message text color is now 946 (was 1000).</change>
+		</entry>
 		<entry>
 			<date>08-15-2026</date>
 			<author>Turley:</author>

--- a/docs/docs.polserver.com/pol100/unicodeem.xml
+++ b/docs/docs.polserver.com/pol100/unicodeem.xml
@@ -6,7 +6,7 @@
     <filedesc>Functions that allow messages to be sent to clients in any unicode language UO supports.</filedesc>
     <datemodified>02/10/2009</datemodified>
     <constant>const _DEFAULT_UCFONT  := 3;</constant>
-    <constant>const _DEFAULT_UCCOLOR := 0x3B2;</constant>
+    <constant>const _DEFAULT_UCCOLOR := 946;</constant>
     <constant>// Constants for PrintTextAbove*</constant>
     <constant>const JOURNAL_UC_PRINT_NAME    := 0x00; // Implicit.  Print's the object's description / npc's name in the journal.</constant>
     <constant>const JOURNAL_UC_PRINT_YOU_SEE := 0x01; // Will print "You see:" in the journal.</constant>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -189,7 +189,7 @@
 <constant>// Don't use these outside this file, use FONT_* from client.inc</constant>
 <constant>//  (and I don't know what for color)</constant>
 <constant>const _DEFAULT_TEXT_FONT     := 3;</constant>
-<constant>const _DEFAULT_TEXT_COLOR    := 1000;</constant>
+<constant>const _DEFAULT_TEXT_COLOR    := 946;</constant>
 <constant>const _DEFAULT_TEXT_REQUIREDCMD    := 0;</constant>
 <constant> </constant>
 <constant>// Realms</constant>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,6 @@
 -- POL100.3.0 --
+08-16-2026 AsYlum:
+    Changed: the default system message text color is now 946 (was 1000).
 08-15-2026 Turley:
     Fixed: polcore.memory_usage was always 0 on macOS
 08-15-2026 Nando:

--- a/pol-core/plib/uconst.h
+++ b/pol-core/plib/uconst.h
@@ -62,7 +62,7 @@ enum MOVEMODE : u8
 #define MAX_WEIGHT 65535L
 
 const unsigned short DEFAULT_TEXT_FONT = 3;
-const unsigned short DEFAULT_TEXT_COLOR = 0x3B2;
+const unsigned short DEFAULT_TEXT_COLOR = 946;
 const unsigned short DEFAULT_TEXT_REQUIREDCMD = 0;
 }  // namespace Pol::Plib
 

--- a/pol-core/pol/clfunc.h
+++ b/pol-core/pol/clfunc.h
@@ -43,7 +43,7 @@ void private_say_above_cl( Mobile::Character* chr, const UObject* obj, unsigned 
 void send_sysmessage_cl_affix( Network::Client* client, unsigned int cliloc_num,
                                const std::string& affix, bool prepend = false,
                                const std::string& arguments = "",
-                               unsigned short font = Plib::DEFAULT_TEXT_COLOR,
+                               unsigned short font = Plib::DEFAULT_TEXT_FONT,
                                unsigned short color = Plib::DEFAULT_TEXT_COLOR );
 void say_above_cl_affix( UObject* obj, unsigned int cliloc_num, const std::string& affix,
                          bool prepend = false, const std::string& arguments = "",

--- a/pol-core/pol/ufuncstd.h
+++ b/pol-core/pol/ufuncstd.h
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "plib/uconst.h"
+
 namespace Pol::Network
 {
 class Client;
@@ -19,8 +21,9 @@ class Character;
 
 namespace Pol::Core
 {
-void send_sysmessage( Network::Client* client, const std::string& text, unsigned short font = 3,
-                      unsigned short color = 0x3B2 );
+void send_sysmessage( Network::Client* client, const std::string& text,
+                      unsigned short font = Plib::DEFAULT_TEXT_FONT,
+                      unsigned short color = Plib::DEFAULT_TEXT_COLOR );
 void send_nametext( Network::Client* client, const Mobile::Character* chr, const std::string& str );
 }  // namespace Pol::Core
 

--- a/pol-core/support/scripts/cliloc.em
+++ b/pol-core/support/scripts/cliloc.em
@@ -7,7 +7,7 @@
 // CONSTANTS
 //
 const _DEFAULT_CLFONT  := 3;
-const _DEFAULT_CLCOLOR := 0x3B2;
+const _DEFAULT_CLCOLOR := 946;
 // format-on
 
 //

--- a/pol-core/support/scripts/unicode.em
+++ b/pol-core/support/scripts/unicode.em
@@ -13,7 +13,7 @@ const JOURNAL_UC_PRINT_YOU_SEE := 0x01; // Will print "You see:" in the journal.
 
 // Don't use these outside this file, use FONT_* from client.inc
 const _DEFAULT_UCFONT             := 3;
-const _DEFAULT_UCCOLOR            := 0x3B2;
+const _DEFAULT_UCCOLOR            := 946;
 const _DEFAULT_UCTEXT_REQUIREDCMD := 0;
 // format-on
 

--- a/pol-core/support/scripts/uo.em
+++ b/pol-core/support/scripts/uo.em
@@ -201,7 +201,7 @@ const RACE_GARGOYLE := 2;
 // Don't use these outside this file, use FONT_* from client.inc
 //  (and I don't know what for color)
 const _DEFAULT_TEXT_FONT        := 3;
-const _DEFAULT_TEXT_COLOR       := 1000;
+const _DEFAULT_TEXT_COLOR       := 946;
 const _DEFAULT_TEXT_REQUIREDCMD := 0;
 
 // Realms


### PR DESCRIPTION
- Unifies the default system message text color to 946 (was 1000 in uo.em, out of sync with the core's actual default).
- Fixes send_sysmessage() (the std::string overload) and send_sysmessage_cl_affix(), which both defaulted their font parameter to the color constant instead of the font constant — messages sent through those paths without an explicit font (e.g. "Unknown command:", justice-region enter/leave text, party invite/decline/join notices) rendered in the wrong font.
- Updates cliloc.em/unicode.em's color constants to decimal (946) for readability, matching uconst.h/uo.em.
- Syncs the escript API docs (uoem.xml, clilocem.xml, unicodeem.xml) to the corrected values.