### PR TITLE
Fix Accessible() for the contents of a shown container

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,15 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-22-2026</datemodified>
+		<datemodified>08-23-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>08-23-2026</date>
+			<author>AsYlum:</author>
+			<change type="Fixed">uo::Accessible() returned 0 for the contents of a container opened with<br/>
+uo::SendOpenSpecialContainer(), a bank box for instance.</change>
+		</entry>
 		<entry>
 			<date>08-22-2026</date>
 			<author>AsYlum:</author>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -4,7 +4,7 @@
 <ESCRIPT>
   <fileheader fname="UO.em">
     <filedesc>Functions that interact with and alter UO game world data, including server-client messages.</filedesc>
-    <datemodified>08/09/2026</datemodified>
+    <datemodified>08/23/2026</datemodified>
 
 <constant>// CreateMulti flags</constant>
 <constant>// only for house creation:</constant>
@@ -1216,7 +1216,7 @@ const TE_STYLE_NUMERICAL:= 2;</code></explain>
   <explain>An item on the ground, within "range" squares (defaults to "DefaultAccessibleRange" from servspecopt). Use ACCESSIBLE_IGNOREDISTANCE to avoid this check. </explain>
   <explain>An item equipped by the character </explain>
   <explain>An item inside the character's backpack </explain>
-  <explain>A temporarily accessible item </explain>
+  <explain>A temporarily accessible item: one inside a container the character was shown with SendOpenSpecialContainer(), a bank box for instance. Such a container stands nowhere, so no distance is measured against it - having been shown it is what puts its contents in reach, and that ends as soon as the character moves. </explain>
   <explain>Notes: Does not check that character has line-of-sight to item. </explain>
   <return>0 if item does not fall into one of the above categories, 1 if the item does. </return>
   <error>none</error>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,7 @@
 -- POL100.3.0 --
+08-23-2026 AsYlum:
+    Fixed: uo::Accessible() returned 0 for the contents of a container opened with
+           uo::SendOpenSpecialContainer(), a bank box for instance.
 08-22-2026 AsYlum:
     Added: PolCore().log_memory_usage( sections := uninit ), PolCore().log_script_memory()
            and PolCore().log_script_variables( script ), the memory reports that used to be

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -1173,9 +1173,11 @@ bool Character::can_access( const Items::Item* item, int range ) const
   if ( range == -1 )
     range = Core::settingsManager.ssopt.default_accessible_range;
 
-  const bool within_range =
-      ( range < -1 ) || item->in_range( this, Clib::clamp_convert<u16>( range ) );
-  if ( within_range && ( find_legal_item( this, item->serial ) != nullptr ) )
+  // Being shown a container is what puts its contents in reach, and a bank box is the case that
+  // matters: it stands nowhere, so a plain distance test refuses it on the realm comparison before
+  // any coordinate is measured. Same question the lift, drop and double-click paths ask.
+  const bool within_reach = ( range < -1 ) || can_reach( item, Clib::clamp_convert<u16>( range ) );
+  if ( within_reach && ( find_legal_item( this, item->serial ) != nullptr ) )
     return true;
 
   return false;

--- a/testsuite/pol/testpkgs/client/test_client_remote_cont.src
+++ b/testsuite/pol/testpkgs/client/test_client_remote_cont.src
@@ -235,6 +235,76 @@ exported function bankbox_needs_no_position()
   return res;
 endfunction
 
+// Accessible() is the script-side form of the same question, and it has to answer the same way as
+// the paths a client takes. A bank box stands nowhere, so measuring a distance to it says it is
+// impossibly far -- realms first, since it is in none. The answer used to come out right only
+// because opening the box wrote the character's own coordinates onto it; being shown it is what
+// puts its contents in reach now.
+exported function bankbox_contents_are_accessible()
+  var area := FindStorageArea( "clientbank" );
+  if ( !area )
+    area := CreateStorageArea( "clientbank" );
+    if ( !area )
+      return ret_error( $"Could not make the storage area: {area}" );
+    endif
+  endif
+
+  var cont := CreateRootItemInStorageArea( area, "accessbox", 0xE75 );
+  if ( !cont )
+    return ret_error( $"Could not make the bank box: {cont}" );
+  endif
+
+  var res := 1;
+  var item := CreateItemInContainer( cont, 0x1F03, 1 );
+  if ( !item )
+    res := ret_error( $"Could not make the contents: {item}" );
+  else
+    var home := struct{ x := char.x, y := char.y, z := char.z, realm := char.realm };
+    do
+      // Nothing has been shown yet, so the box is out of reach however close its owner stands.
+      if ( Accessible( char, item ) != 0 )
+        res := ret_error( "the contents of an unopened bank box are accessible" );
+        break;
+      endif
+
+      var opened := SendOpenSpecialContainer( char, cont );
+      if ( !opened )
+        res := ret_error( $"SendOpenSpecialContainer failed: {opened}" );
+        break;
+      endif
+
+      if ( Accessible( char, item ) != 1 )
+        res := ret_error( "the contents of an open bank box are not accessible" );
+        break;
+      endif
+      if ( Accessible( char, cont ) != 1 )
+        res := ret_error( "an open bank box is not accessible" );
+        break;
+      endif
+      // The one range that never asked where anything was, so it has to keep working as well.
+      if ( Accessible( char, item, ACCESSIBLE_IGNOREDISTANCE ) != 1 )
+        res := ret_error( "ACCESSIBLE_IGNOREDISTANCE did not reach into an open bank box" );
+        break;
+      endif
+
+      // Membership rather than a standing grant: moving ends it, which is what stops a bank box
+      // from being reachable from the far side of the shard.
+      MoveObjectToLocation( char, 100, 100, 0, realm := "britannia2",
+                            flags := MOVEOBJECT_FORCELOCATION );
+      if ( Accessible( char, item ) != 0 )
+        res := ret_error( "the bank box was still accessible after the character moved away" );
+      endif
+    dowhile ( false );
+
+    MoveObjectToLocation( char, home.x, home.y, home.z, realm := home.realm,
+                          flags := MOVEOBJECT_FORCELOCATION );
+    DestroyItem( item );
+  endif
+
+  DestroyRootItemInStorageArea( area, "accessbox" );
+  return res;
+endfunction
+
 // The other half of standing nowhere: being told about it. When something a client can see changes
 // its name, the core announces the new revision so the client drops its cached tooltip. It finds
 // who to tell by walking the region the object stands in - which answers nobody for a bank box, so


### PR DESCRIPTION
uo::Accessible() returned 0 for anything inside a container opened with uo::SendOpenSpecialContainer(), a bank box being the usual one.

Such a container stands nowhere, so Character::can_access() refused it on the realm comparison inside Pos4d::in_range() before any coordinate was looked at. It only ever passed because opening the box used to write the character's own coordinates onto it; that forging was removed, and every client-facing path (lift, drop, double-click) was moved to Character::can_reach(), which grants reach for a container the character was shown. can_access() was missed.

can_reach() falls through to the same in_range() for anything not shown, so world, backpack and worn items are unaffected, and the find_legal_item() half - which is what refuses the contents of a locked container - is untouched.