### PR TITLE
Load npcdesc.cfg and itemdesc.cfg recursively or as suffix

### DIFF
--- a/pol-core/clib/fileutil.cpp
+++ b/pol-core/clib/fileutil.cpp
@@ -22,17 +22,22 @@
 
 namespace Pol::Clib
 {
-std::string normalized_dir_form( const std::string& istr )
+std::string normalized_path_form( const std::string& istr )
 {
   std::string str = istr;
 
+  std::string::size_type bslashpos;
+  while ( std::string::npos != ( bslashpos = str.find( '\\' ) ) )
   {
-    std::string::size_type bslashpos;
-    while ( std::string::npos != ( bslashpos = str.find( '\\' ) ) )
-    {
-      str.replace( bslashpos, 1, 1, '/' );
-    }
+    str.replace( bslashpos, 1, 1, '/' );
   }
+
+  return str;
+}
+
+std::string normalized_dir_form( const std::string& istr )
+{
+  std::string str = normalized_path_form( istr );
 
   if ( str.empty() )
   {

--- a/pol-core/clib/fileutil.h
+++ b/pol-core/clib/fileutil.h
@@ -25,6 +25,7 @@ void RemoveFile( const std::string& fname );
 std::string FullPath( const char* filename );
 std::string GetTrueName( const char* filename );
 std::string GetFilePart( const char* filename );
+std::string normalized_path_form( const std::string& str );
 std::string normalized_dir_form( const std::string& str );
 int make_dir( const char* dir );  // recursive
 int strip_one( std::string& direc );

--- a/pol-core/plib/pkg.cpp
+++ b/pol-core/plib/pkg.cpp
@@ -508,4 +508,35 @@ std::string GetPackageCfgPath( const Package* pkg, const std::string& filename )
 
   return filepath;
 }
+
+std::vector<std::string> GetPackageCfgPaths( const Package* pkg, const std::string& name_or_suffix )
+{
+  std::string suffix = "." + name_or_suffix;
+
+  std::string scan_root;
+  if ( pkg == nullptr )
+  {
+    scan_root = "config/";
+  }
+  else
+  {
+    scan_root = pkg->dir();
+  }
+
+  std::vector<std::string> paths;
+
+  for ( const auto& p : fs::recursive_directory_iterator( scan_root ) )
+  {
+    if ( !p.is_regular_file() )
+      continue;
+
+    auto filename = p.path().filename().string();
+    if ( filename == name_or_suffix || filename.ends_with( suffix ) )
+    {
+      paths.push_back( Clib::normalized_path_form( p.path().string() ) );
+    }
+  }
+
+  return paths;
+}
 }  // namespace Pol::Plib

--- a/pol-core/plib/pkg.h
+++ b/pol-core/plib/pkg.h
@@ -101,6 +101,7 @@ void load_packages( const std::string& basedir, bool quiet = false );
 void replace_packages();
 void check_package_deps();
 std::string GetPackageCfgPath( const Package* pkg, const std::string& filename );
+std::vector<std::string> GetPackageCfgPaths( const Package* pkg, const std::string& suffix );
 }  // namespace Plib
 }  // namespace Pol
 #endif

--- a/pol-core/pol/item/equipmnt.cpp
+++ b/pol-core/pol/item/equipmnt.cpp
@@ -181,9 +181,10 @@ void allocate_intrinsic_equipment_serials()
 /// must be called at startup
 void load_npc_intrinsic_equip()
 {
-  if ( Clib::FileExists( "config/npcdesc.cfg" ) )
+  std::vector<std::string> filenames = Plib::GetPackageCfgPaths( nullptr, "npcdesc.cfg" );
+  for ( auto& filename : filenames )
   {
-    Clib::ConfigFile cf( "config/npcdesc.cfg" );
+    Clib::ConfigFile cf( filename.c_str() );
     Clib::ConfigElem elem;
     while ( cf.read( elem ) )
     {
@@ -191,11 +192,11 @@ void load_npc_intrinsic_equip()
       Items::create_intrinsic_shield_from_npctemplate( elem, nullptr );
     }
   }
+
   for ( const auto& pkg : Plib::systemstate.packages )
   {
-    std::string filename = Plib::GetPackageCfgPath( pkg, "npcdesc.cfg" );
-
-    if ( Clib::FileExists( filename.c_str() ) )
+    std::vector<std::string> pkg_filenames = Plib::GetPackageCfgPaths( pkg, "npcdesc.cfg" );
+    for ( auto& filename : pkg_filenames )
     {
       Clib::ConfigFile cf( filename.c_str() );
       Clib::ConfigElem elem;

--- a/pol-core/pol/item/itemdesc.cpp
+++ b/pol-core/pol/item/itemdesc.cpp
@@ -1336,8 +1336,8 @@ void read_itemdesc_file( const char* filename, Plib::Package* pkg = nullptr )
 
 void load_package_itemdesc( Plib::Package* pkg )
 {
-  std::string filename = GetPackageCfgPath( pkg, "itemdesc.cfg" );
-  if ( Clib::FileExists( filename.c_str() ) )
+  std::vector<std::string> filenames = Plib::GetPackageCfgPaths( pkg, "itemdesc.cfg" );
+  for ( auto& filename : filenames )
   {
     read_itemdesc_file( filename.c_str(), pkg );
   }
@@ -1403,8 +1403,12 @@ void write_objtypes_txt()
 
 void load_itemdesc()
 {
-  if ( Clib::FileExists( "config/itemdesc.cfg" ) )
-    read_itemdesc_file( "config/itemdesc.cfg" );
+  std::vector<std::string> filenames = Plib::GetPackageCfgPaths( nullptr, "itemdesc.cfg" );
+  for ( auto& filename : filenames )
+  {
+    read_itemdesc_file( filename.c_str() );
+  }
+
   for ( auto& pkg : Plib::systemstate.packages )
     load_package_itemdesc( pkg );
 

--- a/pol-core/pol/module/polsystemmod.cpp
+++ b/pol-core/pol/module/polsystemmod.cpp
@@ -103,6 +103,10 @@ BObjectRef PackageObjImp::get_member( const char* membername )
   }
   if ( stricmp( membername, "npcdesc" ) == 0 )
   {
+    // TODO: what to do here?
+    // - do we care only about npcdesc.cfg in root or the prefixed/nested ones as well?
+    // - what's even the point of this member and if there is one why there isn't itemdesc.cfg one
+    //   as well?
     const Plib::Package* pkg = value().Ptr();
     std::string filepath = Plib::GetPackageCfgPath( pkg, "npcdesc.cfg" );
     return BObjectRef( new BLong( Clib::FileExists( filepath ) ) );

--- a/pol-core/pol/npctemplates.cpp
+++ b/pol-core/pol/npctemplates.cpp
@@ -91,103 +91,40 @@ bool FindNpcTemplate( const char* template_name, Clib::ConfigElem& elem )
   return false;
 }
 
-// FIXME inefficient.  Templates should be read in once, and reused.
-bool FindNpcTemplate( const char* template_name, Clib::ConfigFile& cf, Clib::ConfigElem& elem )
-{
-  try
-  {
-    const Plib::Package* pkg;
-    std::string npctemplate;
-    if ( !Plib::pkgdef_split( template_name, nullptr, &pkg, &npctemplate ) )
-      return false;
-
-    std::string filename =
-        Plib::GetPackageCfgPath( const_cast<Plib::Package*>( pkg ), "npcdesc.cfg" );
-
-    cf.open( filename.c_str() );
-    while ( cf.read( elem ) )
-    {
-      if ( !elem.type_is( "NpcTemplate" ) )
-        continue;
-
-      std::string orig_rest = elem.rest();
-      if ( pkg != nullptr )
-      {
-        std::string newrest = ":" + pkg->name() + ":" + npctemplate;
-        elem.set_rest( newrest.c_str() );
-      }
-      const char* rest = elem.rest();
-      if ( rest != nullptr && *rest != '\0' )
-      {
-        if ( stricmp( orig_rest.c_str(), npctemplate.c_str() ) == 0 )
-          return true;
-      }
-      else
-      {
-        std::string tname = elem.remove_string( "TemplateName" );
-        if ( stricmp( tname.c_str(), npctemplate.c_str() ) == 0 )
-          return true;
-      }
-    }
-    return false;
-  }
-  catch ( const char* msg )
-  {
-    ERROR_PRINTLN( "NPC Creation ({}) Failed: {}", template_name, msg );
-  }
-  catch ( std::string& str )
-  {
-    ERROR_PRINTLN( "NPC Creation ({}) Failed: {}", template_name, str );
-  }  // egcs has some trouble realizing 'exception' should catch
-  catch ( std::runtime_error& re )  // runtime_errors, so...
-  {
-    ERROR_PRINTLN( "NPC Creation ({}) Failed: {}", template_name, re.what() );
-  }
-  catch ( std::exception& ex )
-  {
-    ERROR_PRINTLN( "NPC Creation ({}) Failed: {}", template_name, ex.what() );
-  }
-#ifndef WIN32
-  catch ( ... )
-  {
-  }
-#endif
-  return false;
-}
-
 void read_npc_templates( Plib::Package* pkg )
 {
-  std::string filename = GetPackageCfgPath( pkg, "npcdesc.cfg" );
-  if ( !Clib::FileExists( filename ) )
-    return;
+  std::vector<std::string> filenames = Plib::GetPackageCfgPaths( pkg, "npcdesc.cfg" );
 
-  Clib::ConfigFile cf( filename.c_str() );
-  Clib::ConfigElem elem;
-  while ( cf.read( elem ) )
+  for ( auto& filename : filenames )
   {
-    if ( elem.type_is( "NpcTemplate" ) )
+    Clib::ConfigFile cf( filename.c_str() );
+    Clib::ConfigElem elem;
+    while ( cf.read( elem ) )
     {
-      // first determine the NPC template name.
-      std::string namebase;
-      const char* rest = elem.rest();
-      if ( rest != nullptr && *rest != '\0' )
+      if ( elem.type_is( "NpcTemplate" ) )
       {
-        namebase = rest;
-      }
-      else
-      {
-        namebase = elem.remove_string( "TemplateName" );
-      }
-      std::string descname;
-      if ( pkg != nullptr )
-      {
-        descname = ":" + pkg->name() + ":" + namebase;
-        elem.set_rest( descname.c_str() );
-      }
-      else
-        descname = namebase;
+        // first determine the NPC template name.
+        std::string namebase;
+        const char* rest = elem.rest();
+        if ( rest != nullptr && *rest != '\0' )
+        {
+          namebase = rest;
+        }
+        else
+        {
+          namebase = elem.remove_string( "TemplateName" );
+        }
+        std::string descname;
+        if ( pkg != nullptr )
+        {
+          descname = ":" + pkg->name() + ":" + namebase;
+          elem.set_rest( descname.c_str() );
+        }
+        else
+          descname = namebase;
 
-      gamestate.npc_template_elems[descname] = NpcTemplateElem( cf, elem );
+        gamestate.npc_template_elems[descname] = NpcTemplateElem( cf, elem );
+      }
     }
   }
 }

--- a/pol-core/pol/npctmpl.cpp
+++ b/pol-core/pol/npctmpl.cpp
@@ -126,9 +126,10 @@ std::shared_ptr<NpcTemplate> create_npc_template( const Clib::ConfigElem& elem,
 
 void load_npc_templates()
 {
-  if ( Clib::FileExists( "config/npcdesc.cfg" ) )
+  std::vector<std::string> filenames = Plib::GetPackageCfgPaths( nullptr, "npcdesc.cfg" );
+  for ( auto& filename : filenames )
   {
-    Clib::ConfigFile cf( "config/npcdesc.cfg" );
+    Clib::ConfigFile cf( filename.c_str() );
     Clib::ConfigElem elem;
     while ( cf.read( elem ) )
     {
@@ -138,9 +139,8 @@ void load_npc_templates()
 
   for ( auto pkg : Plib::systemstate.packages )
   {
-    std::string filename = Plib::GetPackageCfgPath( pkg, "npcdesc.cfg" );
-
-    if ( Clib::FileExists( filename.c_str() ) )
+    std::vector<std::string> pkg_filenames = Plib::GetPackageCfgPaths( pkg, "npcdesc.cfg" );
+    for ( auto& filename : pkg_filenames )
     {
       Clib::ConfigFile cf( filename.c_str() );
       Clib::ConfigElem elem;

--- a/pol-core/pol/npctmpl.h
+++ b/pol-core/pol/npctmpl.h
@@ -58,7 +58,6 @@ public:
 
 std::shared_ptr<NpcTemplate> find_npc_template( const Clib::ConfigElem& elem );
 bool FindNpcTemplate( const char* template_name, Clib::ConfigElem& elem );
-bool FindNpcTemplate( const char* template_name, Clib::ConfigFile& cf, Clib::ConfigElem& elem );
 
 class NpcTemplateConfigSource : public Clib::ConfigSource
 {

--- a/testsuite/pol/testpkgs/config/itemdesc.cfg
+++ b/testsuite/pol/testpkgs/config/itemdesc.cfg
@@ -1,0 +1,5 @@
+Item 0x202001
+{
+    Name     config_root_item
+    Graphic  0xeed
+}

--- a/testsuite/pol/testpkgs/config/items/itemdesc.cfg
+++ b/testsuite/pol/testpkgs/config/items/itemdesc.cfg
@@ -1,0 +1,5 @@
+Item 0x202003
+{
+    Name     config_nested_item
+    Graphic  0xeed
+}

--- a/testsuite/pol/testpkgs/config/items/prefixed.itemdesc.cfg
+++ b/testsuite/pol/testpkgs/config/items/prefixed.itemdesc.cfg
@@ -1,0 +1,5 @@
+Item 0x202004
+{
+    Name     config_nested_prefixed_item
+    Graphic  0xeed
+}

--- a/testsuite/pol/testpkgs/config/npcdesc.cfg
+++ b/testsuite/pol/testpkgs/config/npcdesc.cfg
@@ -1,0 +1,20 @@
+NPCTemplate config_root_npc
+{
+    Name                config_root_npc
+    MoveMode            L
+
+    ObjType             0x190
+    Color               1002
+    TrueColor           1002
+    Gender              0
+    STR                 200
+    INT                 200
+    DEX                 200
+    HITS                200
+    MANA                200
+    STAM                200
+
+    AttackAttribute     Wrestling
+    AttackDelay         80
+    AttackDamage        1d5
+}

--- a/testsuite/pol/testpkgs/config/npcs/npcdesc.cfg
+++ b/testsuite/pol/testpkgs/config/npcs/npcdesc.cfg
@@ -1,0 +1,20 @@
+NPCTemplate config_nested_npc
+{
+    Name                config_nested_npc
+    MoveMode            L
+
+    ObjType             0x190
+    Color               1002
+    TrueColor           1002
+    Gender              0
+    STR                 200
+    INT                 200
+    DEX                 200
+    HITS                200
+    MANA                200
+    STAM                200
+
+    AttackAttribute     Wrestling
+    AttackDelay         80
+    AttackDamage        1d5
+}

--- a/testsuite/pol/testpkgs/config/npcs/prefixed.npcdesc.cfg
+++ b/testsuite/pol/testpkgs/config/npcs/prefixed.npcdesc.cfg
@@ -1,0 +1,20 @@
+NPCTemplate config_nested_prefixed_npc
+{
+    Name                config_nested_prefixed_npc
+    MoveMode            L
+
+    ObjType             0x190
+    Color               1002
+    TrueColor           1002
+    Gender              0
+    STR                 200
+    INT                 200
+    DEX                 200
+    HITS                200
+    MANA                200
+    STAM                200
+
+    AttackAttribute     Wrestling
+    AttackDelay         80
+    AttackDamage        1d5
+}

--- a/testsuite/pol/testpkgs/config/pkg.cfg
+++ b/testsuite/pol/testpkgs/config/pkg.cfg
@@ -1,0 +1,2 @@
+Name config
+Enabled 1

--- a/testsuite/pol/testpkgs/config/prefixed.itemdesc.cfg
+++ b/testsuite/pol/testpkgs/config/prefixed.itemdesc.cfg
@@ -1,0 +1,5 @@
+Item 0x202002
+{
+    Name     config_root_prefixed_item
+    Graphic  0xeed
+}

--- a/testsuite/pol/testpkgs/config/prefixed.npcdesc.cfg
+++ b/testsuite/pol/testpkgs/config/prefixed.npcdesc.cfg
@@ -1,0 +1,20 @@
+NPCTemplate config_root_prefixed_npc
+{
+    Name                config_root_prefixed_npc
+    MoveMode            L
+
+    ObjType             0x190
+    Color               1002
+    TrueColor           1002
+    Gender              0
+    STR                 200
+    INT                 200
+    DEX                 200
+    HITS                200
+    MANA                200
+    STAM                200
+
+    AttackAttribute     Wrestling
+    AttackDelay         80
+    AttackDamage        1d5
+}

--- a/testsuite/pol/testpkgs/config/test_npcdesc.src
+++ b/testsuite/pol/testpkgs/config/test_npcdesc.src
@@ -1,0 +1,44 @@
+use uo;
+use os;
+
+include "testutil";
+
+program test_npcdesc()
+  return 1;
+endprogram
+
+exported function create_npcs( resources )
+  var templates := array{
+    ":config:config_root_npc",
+    ":config:config_root_prefixed_npc",
+    ":config:config_nested_npc",
+    ":config:config_nested_prefixed_npc"
+  };
+
+  foreach template in templates
+    var npc := resources.CreateNPCFromTemplate( template, 52, 100, 0 );
+    if ( !npc )
+      return ret_error( "Could not create NPC " + template + ": " + npc );
+    endif
+  endforeach
+
+  return 1;
+endfunction
+
+exported function create_items( resources )
+  var objtypes := array{
+    0x202001,
+    0x202002,
+    0x202003,
+    0x202004
+  };
+
+  foreach objtype in objtypes
+    var item := resources.CreateItemAtLocation( 0, 0, 0, objtype );
+    if ( !item )
+      return ret_error( "Could not create item " + objtype + ": " + item );
+    endif
+  endforeach
+
+  return 1;
+endfunction


### PR DESCRIPTION
This PR adds ability to load additional npcdesc/itemdesc config files which should help reducing clutter.

Files that should be loaded (order is undefined atm):
- `config/npcdesc.cfg` (current)
- `config/**/*.npcdesc.cfg`
- `<pkg>/npcdesc.cfg` (current)
- `<pkg>/**/*.npcdesc.cfg`

Notes:
- `bool FindNpcTemplate( const char* template_name, Clib::ConfigFile& cf, Clib::ConfigElem& elem )` Doesn't seem to be used anywhere anymore, so instead of porting it i removed it.
- `pol-core/pol/module/polsystemmod.cpp` member `npcdesc` - not sure what to do here
- it's bit weird that these are getting iterated in multiple places, but I'm not brave enough to touch on that