### PR TITLE
Fix Distance(), DistanceEuclidean() and GetRegionName() for objects standing nowhere

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,24 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>08-23-2026</datemodified>
+		<datemodified>09-03-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>09-03-2026</date>
+			<author>AsYlum:</author>
+			<change type="Fixed">uo::Distance() returned 65535 for the contents of a container opened with<br/>
+uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.</change>
+			<change type="Fixed">uo::DistanceEuclidean() ignored realms, so two objects in different realms<br/>
+measured as if they stood in the same one, and one standing nowhere measured<br/>
+from (0,0). It now answers as uo::Distance() does, 65535 when there is nothing<br/>
+to measure between the two.</change>
+			<change type="Fixed">both reported an item held on a cursor as impossibly far from the character<br/>
+holding it.</change>
+			<change type="Fixed">uo::GetRegionName() crashed the server when handed an object standing in no<br/>
+realm - one in a storage area, on a cursor, or a worn container. It returns an<br/>
+error now.</change>
+		</entry>
 		<entry>
 			<date>08-23-2026</date>
 			<author>AsYlum:</author>

--- a/docs/docs.polserver.com/pol100/uoem.xml
+++ b/docs/docs.polserver.com/pol100/uoem.xml
@@ -4,7 +4,7 @@
 <ESCRIPT>
   <fileheader fname="UO.em">
     <filedesc>Functions that interact with and alter UO game world data, including server-client messages.</filedesc>
-    <datemodified>08/23/2026</datemodified>
+    <datemodified>09/03/2026</datemodified>
 
 <constant>// CreateMulti flags</constant>
 <constant>// only for house creation:</constant>
@@ -518,9 +518,11 @@ endif</code></explain>
 <function name="GetRegionName">
   <prototype>GetRegionName( object )</prototype>
   <parameter name="object" value="top level UObject (item/character/npc/etc)" />
-  <explain>Get name of [justice] region that Object is in.</explain>
+  <explain>Get name of [justice] region that Object is in. An item is resolved through whatever holds it, and one on a cursor through the character holding it.</explain>
+  <explain>Notes: An object standing in no realm, in a storage area for instance, has no region and gets an error.</explain>
   <return>String value of "Region Name" on success</return>
   <error>"Invalid Parameter"</error>
+  <error>"Object has no position in the world"</error>
   <error>"No Region defined at this Location"</error>
   <relatedcfg>regions.cfg</relatedcfg>
 </function>
@@ -1406,6 +1408,8 @@ endprogram</code>
         uses the world-position of its ultimate-parent container. </explain>
   <explain>Notes: This distance is defined as the greater of the x-distance and the y-distance. z-distance 
        is not taken into account.  (This is neither Pythagorean distance nor Manhattan distance) </explain>
+  <explain>Notes: Two objects with nothing to measure between them are 65535 apart - different realms, or one of them standing nowhere at all, such as in a storage area. Objects sharing a holder are 0 apart, and an item on a cursor is measured from the character holding it. </explain>
+  <explain>Notes: The contents of a container shown with SendOpenSpecialContainer(), a bank box for instance, are 0 away from that character until they move, as Accessible() also reports. A container standing in the world is measured normally. </explain>
   <return>Integer - calculated distance on success</return>
   <error>"Invalid parameter type"</error>
   <related>UObject</related>
@@ -3157,7 +3161,8 @@ const CHARPROFILE_NO_EDITABLE_TEXT := array;</code></explain>
   <parameter name="obj2" value="UObject Reference" />
   <explain>Determines the distance between two objects.  If either object is in a container, 
         uses the world-position of its ultimate-parent container. </explain>
-  <explain>Notes: This distance is defined as sqrt(pow(object1.x-object2.x,2)+pow(object1.y-object2.y,2)) </explain>
+  <explain>Notes: This distance is the straight line between the two positions, so it agrees with Distance() only along the axes. </explain>
+  <explain>Notes: The special cases are the same as Distance(). </explain>
   <return>Double - calculated distance on success</return>
   <error>"Invalid parameter type"</error>
   <related>UObject</related>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,16 @@
 -- POL100.3.0 --
+09-03-2026 AsYlum:
+    Fixed: uo::Distance() returned 65535 for the contents of a container opened with
+           uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.
+    Fixed: uo::DistanceEuclidean() ignored realms, so two objects in different realms
+           measured as if they stood in the same one, and one standing nowhere measured
+           from (0,0). It now answers as uo::Distance() does, 65535 when there is nothing
+           to measure between the two.
+    Fixed: both reported an item held on a cursor as impossibly far from the character
+           holding it.
+    Fixed: uo::GetRegionName() crashed the server when handed an object standing in no
+           realm - one in a storage area, on a cursor, or a worn container. It returns an
+           error now.
 08-23-2026 AsYlum:
     Fixed: uo::Accessible() returned 0 for the contents of a container opened with
            uo::SendOpenSpecialContainer(), a bank box for instance.

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -71,6 +71,7 @@
 #include <cmath>
 #include <cstddef>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdlib.h>
@@ -3001,28 +3002,79 @@ BObjectImp* UOExecutorModule::mf_AssignRectToWeatherRegion()
   return new BError( "Weather region not found" );
 }
 
+namespace
+{
+/// What both distance functions report when there is nothing to measure, matching pol_distance().
+constexpr u16 NO_DISTANCE = std::numeric_limits<u16>::max();
+
+/// Whose coordinates stand for this object's: its top level owner, or the character holding it if
+/// it is on a cursor, which toplevel_owner() stops short of.
+UObject* measured_from( UObject* obj )
+{
+  UObject* top = obj->toplevel_owner();
+  // isitem(), not isa( CLASS_ITEM ): exact class equality is false for containers and weapons.
+  if ( top->isitem() )
+  {
+    // Named, because get_if() is deleted on a temporary and location() answers by value.
+    const Items::Location loc = static_cast<Item*>( top )->location();
+    if ( const auto* on_cursor = loc.get_if<Items::OnCursor>() )
+      return on_cursor->holder;
+  }
+  return top;
+}
+
+/// Whether the two have comparable coordinates. has_world_position() rather than a realm, which an
+/// item on a cursor takes from its holder and a detached one from where it last stood.
+bool same_world( const UObject* obj1, const UObject* obj2 )
+{
+  return obj1->has_world_position() && obj2->has_world_position() &&
+         obj1->pos().realm() == obj2->pos().realm();
+}
+
+/// How far apart two objects with no coordinates are: 0 when one thing holds both, or when the
+/// character was shown the container -- the reach can_reach() and Accessible() grant.
+u16 distance_when_nowhere( const UObject* obj1, const UObject* obj2 )
+{
+  if ( obj1 == obj2 )
+    return 0;
+  if ( obj1->ismobile() && static_cast<const Character*>( obj1 )->shown_a_container( obj2 ) )
+    return 0;
+  if ( obj2->ismobile() && static_cast<const Character*>( obj2 )->shown_a_container( obj1 ) )
+    return 0;
+  return NO_DISTANCE;
+}
+}  // namespace
+
 BObjectImp* UOExecutorModule::mf_Distance()
 {
   UObject* obj1;
   UObject* obj2;
-  if ( getUObjectParam( 0, obj1 ) && getUObjectParam( 1, obj2 ) )
-    return new BLong( obj1->distance_to( obj2->toplevel_pos() ) );
-  return new BError( "Invalid parameter type" );
+  if ( !getUObjectParam( 0, obj1 ) || !getUObjectParam( 1, obj2 ) )
+    return new BError( "Invalid parameter type" );
+
+  // Geometry first: a chest handed to SendOpenSpecialContainer() really does stand in the world.
+  const UObject* from = measured_from( obj1 );
+  const UObject* to = measured_from( obj2 );
+  if ( same_world( from, to ) )
+    return new BLong( from->pos2d().pol_distance( to->pos2d() ) );
+
+  return new BLong( distance_when_nowhere( from, to ) );
 }
 
 BObjectImp* UOExecutorModule::mf_DistanceEuclidean()
 {
   UObject* obj1;
   UObject* obj2;
-  if ( getUObjectParam( 0, obj1 ) && getUObjectParam( 1, obj2 ) )
-  {
-    const UObject* tobj1 = obj1->toplevel_owner();
-    const UObject* tobj2 = obj2->toplevel_owner();
-    return new Double( sqrt( pow( (double)( tobj1->x() - tobj2->x() ), 2 ) +
-                             pow( (double)( tobj1->y() - tobj2->y() ), 2 ) ) );
-  }
+  if ( !getUObjectParam( 0, obj1 ) || !getUObjectParam( 1, obj2 ) )
+    return new BError( "Invalid parameter type" );
 
-  return new BError( "Invalid parameter type" );
+  const UObject* from = measured_from( obj1 );
+  const UObject* to = measured_from( obj2 );
+  if ( same_world( from, to ) )
+    return new Double( std::hypot( static_cast<double>( from->x() ) - to->x(),
+                                   static_cast<double>( from->y() ) - to->y() ) );
+
+  return new Double( static_cast<double>( distance_when_nowhere( from, to ) ) );
 }
 
 BObjectImp* UOExecutorModule::mf_CoordinateDistance()
@@ -3563,21 +3615,27 @@ BObjectImp* UOExecutorModule::mf_GetRegionName( /* objref */ )
 
   if ( getUObjectParam( 0, obj ) )
   {
+    // Whatever holds it is what stands in a region.
+    UObject* top = measured_from( obj );
+
     JusticeRegion* justice_region;
-    if ( obj->isa( UOBJ_CLASS::CLASS_ITEM ) )
-      obj = obj->toplevel_owner();
-
-    if ( obj->isa( UOBJ_CLASS::CLASS_CHARACTER ) )
+    if ( top->ismobile() )
     {
-      Character* chr = static_cast<Character*>( obj );
+      Character* chr = static_cast<Character*>( top );
 
-      if ( chr->logged_in() )
+      // Only a player has a client caching its region; an NPC is logged_in() from creation.
+      if ( chr->has_active_client() && chr->client->gd != nullptr )
         justice_region = chr->client->gd->justice_region;
       else
         justice_region = gamestate.justicedef->getregion( chr->pos() );
     }
     else
-      justice_region = gamestate.justicedef->getregion( obj->pos() );
+    {
+      // A region is a painted patch of one realm, so only something standing in one has one.
+      if ( !top->has_world_position() )
+        return new BError( "Object has no position in the world" );
+      justice_region = gamestate.justicedef->getregion( top->pos() );
+    }
 
     if ( justice_region == nullptr )
       return new BError( "No Region defined at this Location" );

--- a/testsuite/pol/testpkgs/client/test_client_item_move.src
+++ b/testsuite/pol/testpkgs/client/test_client_item_move.src
@@ -1250,6 +1250,61 @@ exported function gotten_item_is_saved()
   return res;
 endfunction
 
+// An item on a cursor keeps no coordinates of its own -- toplevel_owner() stops short of the
+// character holding it -- while standing exactly where that character does.
+exported function gotten_item_stands_with_holder()
+  var item := CreateItemAtLocation( char.x, char.y, char.z, 0x1F03 );
+  if ( !item )
+    return ret_error( $"Could not create item: {item}" );
+  endif
+
+  item.movable := 1;
+
+  var err;
+  if ( !lift_item_succeeded( err, item.serial ) )
+    destroy_lifted_item( item );
+    return err;
+  endif
+
+  var res := 1;
+  do
+    var pol := Distance( char, item );
+    if ( pol != 0 )
+      res := ret_error( $"Distance to a gotten item: {pol}, expected 0" );
+      break;
+    endif
+    // reversed, because a script may name the character second
+    pol := Distance( item, char );
+    if ( pol != 0 )
+      res := ret_error( $"Distance from a gotten item: {pol}, expected 0" );
+      break;
+    endif
+
+    var euclid := DistanceEuclidean( char, item );
+    if ( euclid > 0.0001 or euclid < -0.0001 )
+      res := ret_error( $"DistanceEuclidean to a gotten item: {euclid}, expected 0.0" );
+      break;
+    endif
+
+    // The holder stands in a region, so the item does too.
+    var item_region := GetRegionName( item );
+    var char_region := GetRegionName( char );
+    if ( item_region != char_region )
+      res := ret_error( $"Region of a gotten item: '{item_region}', expected its holder's "
+                        + $"'{char_region}'" );
+    endif
+  dowhile ( false );
+
+  if ( res == 1 )
+    if ( !drop_item_succeeded( err, item.serial, 0xFF, 0xFF, 0, char.backpack.serial ) )
+      res := err;
+    endif
+  endif
+
+  destroy_lifted_item( item );
+  return res;
+endfunction
+
 // A corpse renders what its owner wore at death. UO has no "move within a container", so dragging
 // one of those items to another spot in the loot window is a lift and a drop like any other -- and
 // the corpse has to still be wearing it afterwards.

--- a/testsuite/pol/testpkgs/client/test_client_remote_cont.src
+++ b/testsuite/pol/testpkgs/client/test_client_remote_cont.src
@@ -7,6 +7,9 @@ include "communication";
 
 var char;
 
+// What both object based distance functions report when there is nothing to measure.
+const NO_DISTANCE := 65535;
+
 var clientcon := getClientConnection();
 
 program chartests()
@@ -25,10 +28,8 @@ endprogram
 // comparison that would otherwise refuse anything in a different realm. So a character standing
 // in britannia2 can see a container in britannia if and only if it is still listed as remote.
 exported function remote_container_ends_on_move()
-  // Placed exactly where the character stands, because SendOpenSpecialContainer writes the
-  // character's position onto whatever it is handed. Anywhere else and that write would leave the
-  // container filed in a zone its coordinates no longer name, which is a defect of its own and not
-  // the one under test here.
+  // Placed on top of the character only so the first check has a plain answer. The assertion that
+  // carries the test is the one after the move, which membership alone can answer.
   var cont := CreateItemAtLocation( char.x, char.y, char.z, 0x200E75, 1, char.realm );
   if ( !cont )
     return ret_error( "Failed to create container: " + cont );
@@ -302,6 +303,122 @@ exported function bankbox_contents_are_accessible()
   endif
 
   DestroyRootItemInStorageArea( area, "accessbox" );
+  return res;
+endfunction
+
+// Both functions at once, since they may only differ over a measurable pair. Every expectation
+// here is a whole number of tiles, but the euclidean one answers with a double.
+function check_distance( obj1, obj2, expected, what )
+  var pol := Distance( obj1, obj2 );
+  if ( pol != expected )
+    return ret_error( $"Distance to {what}: {pol}, expected {expected}" );
+  endif
+
+  var euclid := DistanceEuclidean( obj1, obj2 );
+  var diff := euclid - expected;
+  if ( diff < 0 )
+    diff := -diff;
+  endif
+  if ( diff > 0.0001 )
+    return ret_error( $"DistanceEuclidean to {what}: {euclid}, expected {expected}" );
+  endif
+
+  return 1;
+endfunction
+
+// A bank box stands nowhere, so there are no coordinates to compare against it until the box is
+// shown -- and a script that measures before it reaches has to agree with Accessible().
+exported function bankbox_contents_are_at_hand()
+  var area := FindStorageArea( "clientbank" );
+  if ( !area )
+    area := CreateStorageArea( "clientbank" );
+    if ( !area )
+      return ret_error( $"Could not make the storage area: {area}" );
+    endif
+  endif
+
+  var cont := CreateRootItemInStorageArea( area, "distbox", 0xE75 );
+  if ( !cont )
+    return ret_error( $"Could not make the bank box: {cont}" );
+  endif
+
+  var res := 1;
+  var item := CreateItemInContainer( cont, 0x1F03, 1 );
+  if ( !item )
+    res := ret_error( $"Could not make the contents: {item}" );
+  else
+    var home := struct{ x := char.x, y := char.y, z := char.z, realm := char.realm };
+    do
+      // Nothing has been shown yet, so the box is nowhere however close its owner stands.
+      if ( !( res := check_distance( char, item, NO_DISTANCE, "an unopened bank box" ) ) )
+        break;
+      endif
+
+      var opened := SendOpenSpecialContainer( char, cont );
+      if ( !opened )
+        res := ret_error( $"SendOpenSpecialContainer failed: {opened}" );
+        break;
+      endif
+
+      if ( !( res := check_distance( char, item, 0, "the contents of an open bank box" ) ) )
+        break;
+      endif
+      // the box itself, which is its own top level owner
+      if ( !( res := check_distance( char, cont, 0, "an open bank box" ) ) )
+        break;
+      endif
+      // and the character may be named second
+      if ( !( res := check_distance( item, char, 0, "an open bank box, reversed" ) ) )
+        break;
+      endif
+
+      // Membership rather than a standing grant, exactly as Accessible() has it: moving ends the
+      // reach, and with it the answer.
+      MoveObjectToLocation( char, 100, 100, 0, realm := "britannia2",
+                            flags := MOVEOBJECT_FORCELOCATION );
+      res := check_distance( char, item, NO_DISTANCE,
+                             "a bank box the character has walked away from" );
+    dowhile ( false );
+
+    MoveObjectToLocation( char, home.x, home.y, home.z, realm := home.realm,
+                          flags := MOVEOBJECT_FORCELOCATION );
+    DestroyItem( item );
+  endif
+
+  DestroyRootItemInStorageArea( area, "distbox" );
+  return res;
+endfunction
+
+// SendOpenSpecialContainer() takes a chest standing in the world as happily as a bank box, and
+// such a chest goes on being measured: being shown it is no answer for a pair that has one.
+exported function shown_worldbox_still_measures()
+  var cont := CreateItemAtLocation( char.x + 4, char.y, char.z, 0x200E75, 1, char.realm );
+  if ( !cont )
+    return ret_error( $"Could not make the container: {cont}" );
+  endif
+
+  var res := 1;
+  var item := CreateItemInContainer( cont, 0x1F03, 1 );
+  if ( !item )
+    res := ret_error( $"Could not make the contents: {item}" );
+  else
+    do
+      var opened := SendOpenSpecialContainer( char, cont );
+      if ( !opened )
+        res := ret_error( $"SendOpenSpecialContainer failed: {opened}" );
+        break;
+      endif
+
+      if ( !( res := check_distance( char, cont, 4, "a shown container standing in the world" ) ) )
+        break;
+      endif
+      res := check_distance( char, item, 4, "the contents of a shown container in the world" );
+    dowhile ( false );
+
+    DestroyItem( item );
+  endif
+
+  DestroyItem( cont );
   return res;
 endfunction
 

--- a/testsuite/pol/testpkgs/map/test_geometry.src
+++ b/testsuite/pol/testpkgs/map/test_geometry.src
@@ -1,9 +1,17 @@
-// The geometry helpers of the uo module. These are pure functions of their
-// arguments, so they need no world state and their results are exact.
+// The geometry helpers of the uo module. Mostly pure functions of their
+// arguments, so they need no world state and their results are exact -- the
+// object based ones need the objects to stand somewhere, or nowhere on purpose.
 use uo;
 use os;
+use storage;
 
 include "testutil";
+
+// The other realm the test shard generates.
+const OTHER_REALM := "britannia2";
+
+// What both object based functions report when there is nothing to measure.
+const NO_DISTANCE := 65535;
 
 program geometry()
   return 1;
@@ -101,6 +109,83 @@ exported function object_distance( resmngr )
   return 1;
 endfunction
 
+// Coordinates are measured against a realm, so two in different realms are not
+// two points at all and there is no distance between them to report.
+exported function object_distance_across_realms( resmngr )
+  var here := resmngr.CreateItemAtLocation( 50, 50, 0, 0x4ae );
+  var there := resmngr.CreateItemAtLocation( 50, 50, 0, 0x4ae, 1, OTHER_REALM );
+  if ( !here || !there )
+    return ret_error( $"failed to create items: {here}, {there}" );
+  endif
+
+  var res := check_no_distance( here, there, "the same coordinates in two realms" );
+  if ( !res )
+    return res;
+  endif
+
+  // and it really is the realm that decides, not the matching coordinates
+  var elsewhere := resmngr.CreateItemAtLocation( 60, 50, 0, 0x4ae, 1, OTHER_REALM );
+  if ( !elsewhere )
+    return ret_error( $"failed to create item: {elsewhere}" );
+  endif
+
+  return check_no_distance( here, elsewhere, "different coordinates in two realms" );
+endfunction
+
+// A root item of a storage area is filed rather than placed: it has no
+// coordinates of its own, and neither has anything inside it.
+exported function object_distance_from_nowhere( resmngr )
+  var area := FindStorageArea( "geometry" );
+  if ( !area )
+    area := CreateStorageArea( "geometry" );
+    if ( !area )
+      return ret_error( $"Could not make the storage area: {area}" );
+    endif
+  endif
+
+  var root := CreateRootItemInStorageArea( area, "nowherebox", 0xE75 );
+  if ( !root )
+    return ret_error( $"Could not make the root item: {root}" );
+  endif
+
+  var item := resmngr.CreateItemAtLocation( 50, 50, 0, 0x4ae );
+  // Not through the resource manager: these live inside a root this function
+  // destroys itself, and cleaning them up afterwards would find them gone.
+  var coin := CreateItemInContainer( root, 0x0eed, 1 );
+  var coin2 := CreateItemInContainer( root, 0x0eed, 1 );
+
+  var res := 1;
+  do
+    if ( !item || !coin || !coin2 )
+      res := ret_error( $"failed to create items: {item}, {coin}, {coin2}" );
+      break;
+    endif
+
+    if ( !( res := check_no_distance( item, root, "a storage root" ) ) )
+      break;
+    endif
+    // measured from the box, so its contents answer exactly as it does
+    if ( !( res := check_no_distance( item, coin, "the contents of a storage root" ) ) )
+      break;
+    endif
+
+    // Two things one thing holds are in the same place, wherever that is.
+    if ( !( res := check_distance( coin, coin2, 0, "two items in one storage root" ) ) )
+      break;
+    endif
+    res := check_distance( root, root, 0, "a storage root and itself" );
+  dowhile ( false );
+
+  if ( coin )
+    DestroyItem( coin );
+  endif
+  if ( coin2 )
+    DestroyItem( coin2 );
+  endif
+  DestroyRootItemInStorageArea( area, "nowherebox" );
+  return res;
+endfunction
+
 // the facing is the compass direction from one point to another, 0 is north
 // and it counts clockwise
 exported function facing()
@@ -189,6 +274,25 @@ endfunction
 /**
  * Helper functions
  */
+
+// Both functions at once, since they may only differ over a measurable pair.
+function check_distance( obj1, obj2, expected, what )
+  var actual := Distance( obj1, obj2 );
+  if ( actual != expected )
+    return ret_error( $"Distance to {what}: {actual}, expected {expected}" );
+  endif
+  return check_near( DistanceEuclidean( obj1, obj2 ), expected,
+                     $"DistanceEuclidean to {what}" );
+endfunction
+
+// and both ways round, because a script may name either one first
+function check_no_distance( obj1, obj2, what )
+  var res := check_distance( obj1, obj2, NO_DISTANCE, what );
+  if ( !res )
+    return res;
+  endif
+  return check_distance( obj2, obj1, NO_DISTANCE, $"{what}, reversed" );
+endfunction
 
 function check_near( actual, expected, what )
   var diff := actual - expected;

--- a/testsuite/pol/testpkgs/misc/test_uoregion.src
+++ b/testsuite/pol/testpkgs/misc/test_uoregion.src
@@ -1,5 +1,6 @@
 use uo;
 use os;
+use storage;
 
 include "testutil";
 
@@ -9,6 +10,9 @@ include "testutil";
 const JR_X := 134;
 const JR_Y := 134;
 const JR_NAME := "TestJustice";
+
+// What the object form answers for something that stands in no realm at all.
+const NO_POSITION_ERROR := "Object has no position in the world";
 
 // Well outside it, where the background region the core builds for itself
 // applies. That one comes from an empty config element, so its name is the
@@ -55,12 +59,9 @@ function region_pc()
   return pc;
 endfunction
 
-// GetRegionName reaches the justice region three different ways depending on
-// what it is handed, because UObject::isa is exact class equality: an item is
-// resolved through its top level owner, a player character through its own
-// position (or its client's cached region while logged in), and anything else --
-// an NPC is CLASS_NPC, a container is CLASS_CONTAINER -- straight from where it
-// stands.
+// GetRegionName reaches the justice region two different ways depending on what
+// it is handed: a mobile through its own position, or its client's cached region
+// while it is logged in, and anything else through whatever ultimately holds it.
 exported function region_name_of_objects( resmngr )
   var npc := resmngr.CreateNPCFromTemplate( ":TestNPC:probe_npc", JR_X, JR_Y, 0, 0, _DEFAULT_REALM,
                                             1 );
@@ -102,6 +103,54 @@ exported function region_name_of_objects( resmngr )
   endif
 
   return 1;
+endfunction
+
+// A region is a painted patch of one realm, so only something standing in one
+// has a region to report. A storage root has no coordinates, and nor has
+// anything inside it.
+exported function region_name_without_position( unused resmngr )
+  var area := FindStorageArea( "uoregion" );
+  if ( !area )
+    area := CreateStorageArea( "uoregion" );
+    if ( !area )
+      return ret_error( $"could not make the storage area: {area}" );
+    endif
+  endif
+
+  var root := CreateRootItemInStorageArea( area, "regionbox", 0xE75 );
+  if ( !root )
+    return ret_error( $"could not make the root item: {root}" );
+  endif
+
+  var coin := CreateItemInContainer( root, 0x0eed, 1 );
+
+  var res := 1;
+  do
+    if ( !coin )
+      res := ret_error( $"could not make the contents: {coin}" );
+      break;
+    endif
+
+    // The exact message matters: the background region's empty name is falsy
+    // just like an error, and so is the error a lookup off the painted range
+    // answers with.
+    var name := GetRegionName( root );
+    if ( name.errortext != NO_POSITION_ERROR )
+      res := ret_error( $"expected '{NO_POSITION_ERROR}' for a storage root, got '{name}'" );
+      break;
+    endif
+
+    name := GetRegionName( coin );
+    if ( name.errortext != NO_POSITION_ERROR )
+      res := ret_error( $"expected '{NO_POSITION_ERROR}' for its contents, got '{name}'" );
+    endif
+  dowhile ( false );
+
+  if ( coin )
+    DestroyItem( coin );
+  endif
+  DestroyRootItemInStorageArea( area, "regionbox" );
+  return res;
 endfunction
 
 // The by-location form needs no object at all, and answers the background


### PR DESCRIPTION
Follow-up to #952 - same root cause, three more casualties of items no longer having their position forged (#928).

A bank box, a vendor's stock, a trade container and an item on a cursor stand nowhere: their `Pos4d` has no realm. `Pos4d::pol_distance()` reports 65535 for any realm mismatch, and null mismatches everything.

### Before -> after

| call | before | after |
|---|---|---|
| `Distance( chr, itemInOpenBankBox )` | 65535 | 0 |
| `DistanceEuclidean( chr, itemInOpenBankBox )` | ~141 - measured from map (0,0) | 0.0 |
| `DistanceEuclidean( itemInBritannia, itemInBritannia2 )` | 0.0 for identical coords in two realms | 65535.0 |
| `Distance( chr, itemOnChrCursor )` | 65535 | 0 |
| `GetRegionName( bankBox )` / `( char.backpack )` | **server crash** | error |

`DistanceEuclidean()` never looked at a realm at all, so it disagreed with `Distance()` and gave plausible-looking numbers for pairs it could not measure. Both now resolve the same way: geometry when both objects stand in some world and the same one, then 0 for a pair sharing a holder or a container the character was shown, then 65535.

Geometry deliberately comes **first**. `SendOpenSpecialContainer()` accepts a chest that really does stand in the world, and answering 0 for one 40 tiles away would be a wrong measurement rather than the honest absence of one - so nothing standing anywhere changes behaviour.

`GetRegionName()` crashed because `RegionGroupBase::getregionid()` reads `pos.realm()` unchecked, and `isa()` is exact class equality - a bank box and a worn backpack are `CLASS_CONTAINER`, so neither took the item branch and both asked after coordinates of their own.

**Note:** two objects in different storage areas used to measure 0 apart (both at (0,0,null), and two null realms compare equal). They now report 65535 - nowhere is not the same place as nowhere. Objects sharing the same holder still measure 0.

`CoordinateDistance()` / `CoordinateDistanceEuclidean()` are untouched - pure coordinate functions, no object, no realm.

### Tests

Five new shard cases. Two are worth calling out:

- `shown_worldbox_still_measures` pins the geometry-first ordering, so a later "simplification" cannot flip it.
- `region_name_without_position` failed by **taking the shard down** before the fix, not by returning the wrong string.