### PR TITLE
Clamp AOS tooltip text before narrowing it to 16 bits

### DIFF
--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,9 +2,16 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>09-03-2026</datemodified>
+		<datemodified>09-05-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
+		<entry>
+			<date>09-05-2026</date>
+			<author>Ins:</author>
+			<change type="Fixed">an AOS tooltip with more than 65535 characters of text could shut the shard<br/>
+down, since the length was narrowed to 16 bits before the range check. A<br/>
+script can set a name that long, so it was script-reachable.</change>
+		</entry>
 		<entry>
 			<date>09-03-2026</date>
 			<author>AsYlum:</author>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -1,4 +1,8 @@
 -- POL100.3.0 --
+09-05-2026 Ins:
+    Fixed: an AOS tooltip with more than 65535 characters of text could shut the shard
+           down, since the length was narrowed to 16 bits before the range check. A
+           script can set a name that long, so it was script-reachable.
 09-03-2026 AsYlum:
     Fixed: uo::Distance() returned 65535 for the contents of a container opened with
            uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.

--- a/pol-core/pol/tooltips.cpp
+++ b/pol-core/pol/tooltips.cpp
@@ -145,12 +145,12 @@ void SendAOSTooltip( Network::Client* client, UObject* obj, bool vendor_content 
     msg->WriteFlipped<u32>( 1042971u );  // ~1_NOTHING~
 
   std::vector<u16> utf16 = Bscript::String::toUTF16( desc );
+  // Clamp before narrowing to u16, or a longer text wraps and passes the
+  // check. 25 bytes of the packet are not text.
+  constexpr size_t max_text_length = ( 0xFFFF - 25 ) / 2;
+  if ( utf16.size() > max_text_length )
+    utf16.resize( max_text_length );
   u16 textlen = static_cast<u16>( utf16.size() );
-  if ( ( textlen * 2 ) > ( 0xFFFF - 22 ) )
-  {
-    textlen = 0xFFFF / 2 - 22;
-    utf16.resize( textlen );
-  }
   msg->WriteFlipped<u16>( textlen * 2u );
   msg->Write( utf16, false );
   msg->offset += 4;  // indicates end of property list


### PR DESCRIPTION
utf16.size() was cast to u16 before the range check, so a text longer than 65535 characters wrapped to a small value, passed the check unresized, and tripped the packet-size assertion in Write, which can shut the shard down. A script can set a name or description of any length.

The old 0xFFFF / 2 - 22 was not a mis-parenthesised ( 0xFFFF - 22 ) / 2 - that would overflow the packet, since the fixed overhead is 25 bytes, not 22: id 1, length 2, unk1 2, serial 4, unk2/unk3 2, revision 4, cliloc 4, text length 2 and the 4-byte terminator. ( 0xFFFF - 25 ) / 2 is 32755 characters, which fills the packet to exactly 65535 bytes.