### PR TITLE
Repaint the client's weather and light after anything that resets them

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -13,7 +13,7 @@
       <list>elipsis ... : repeat entries are allowed.</list>
       <bottom>This means the punctuation in these cases should NOT be in the actual config files used by POL, they only appear here for information purposes. Exception: curly braces { } are used to define an element in a config file. These must be present in the actual file.</bottom>
     </desc>
-    <datemodified>08/15/2026</datemodified>
+    <datemodified>09/05/2026</datemodified>
 </fileheader>
 
 
@@ -442,8 +442,9 @@ Spell (int spellid)
   <explain><i>SpeechRange:</i> definies the range of normal speech</explain>
   <explain><i>WhisperRange:</i> definies the range of whispered speech</explain>
   <explain><i>YellRange:</i> definies the range of yelled speech</explain>
-  <explain><i>CoreSendsSeason:</i> Determines if the core should send season packet on char creation/logon/reconnect and realm
-        change based on the season entry in realm.cfg</explain>
+  <explain><i>CoreSendsSeason:</i> Determines if the core should send season packet on char creation/logon/reconnect,
+        realm change and the client version handshake, based on the season entry in realm.cfg. The season packet resets
+        the client's light level, so the core restores it behind each packet it sends.</explain>
   <explain><i>CoreHandledTags:</i> bitfield to determine which tags are displayed on singleclick, current used bits are:<br/>
     0x1  [title_guild]<br/>
     0x2  [frozen]<br/>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -53,9 +53,31 @@ orders below true, and below any other value that is true.</change>
 		<entry>
 			<date>09-05-2026</date>
 			<author>Ins:</author>
-			<change type="Fixed">an AOS tooltip with more than 65535 characters of text could shut the shard<br/>
-down, since the length was narrowed to 16 bits before the range check. A<br/>
-script can set a name that long, so it was script-reachable.</change>
+			<change type="Fixed">a client was left with a clear sky, or the wrong light level, after several<br/>
+ordinary events: logging in, reconnecting, its own resync request, dying, being<br/>
+resurrected, having its graphic, colour or facing set from a script, a gargoyle<br/>
+toggling flight, and a boat carrying it between realms. Each of those resends<br/>
+the character's position or a season packet, and the client stops drawing<br/>
+weather when it gets either. Nothing sent it again, so the sky stayed wrong<br/>
+until the character crossed into another weather region, teleported, or the<br/>
+weather changed on its own.</change>
+			<change type="Fixed">after a season packet the light level was only restored for weather regions<br/>
+that carry a LightOverride. Everywhere else, and for a character holding a<br/>
+light override of its own, the client kept whatever the packet had reset it to.</change>
+			<change type="Fixed">a light override expiring inside a weather region that carries a LightOverride<br/>
+never restored the region's level - the client stayed on the expired level<br/>
+until it left the region. Both the timed expiry and uo::SetRegionLightLevel()<br/>
+were affected.</change>
+			<change type="Fixed">a character logging into a light region whose level is 0 was never sent a light<br/>
+level at all, on the assumption that a fresh client already shows 0.</change>
+			<change type="Changed">chr.setseason() and uo::SendOverallSeason() still leave resending the light<br/>
+and weather to the script, as documented, but no longer leave the core<br/>
+recording a light level and weather region that the client no longer has - so<br/>
+the next weather or region change repairs a client whose script did not.</change>
+			<change type="Changed">chr.facing :=, chr.setfacing() and npc::Face() no longer resend the<br/>
+character's position to itself, or its movement to onlookers, when the facing<br/>
+did not actually change. A script using a same-direction turn as a resync<br/>
+nudge no longer gets one.</change>
 		</entry>
 		<entry>
 			<date>09-03-2026</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -39,9 +39,31 @@
     Fixed: client.clientinfo it was partially garbage
     Fixed: a one byte packet (0xFA) disconnected the client on some platforms
 09-05-2026 Ins:
-    Fixed: an AOS tooltip with more than 65535 characters of text could shut the shard
-           down, since the length was narrowed to 16 bits before the range check. A
-           script can set a name that long, so it was script-reachable.
+    Fixed: a client was left with a clear sky, or the wrong light level, after several
+           ordinary events: logging in, reconnecting, its own resync request, dying, being
+           resurrected, having its graphic, colour or facing set from a script, a gargoyle
+           toggling flight, and a boat carrying it between realms. Each of those resends
+           the character's position or a season packet, and the client stops drawing
+           weather when it gets either. Nothing sent it again, so the sky stayed wrong
+           until the character crossed into another weather region, teleported, or the
+           weather changed on its own.
+    Fixed: after a season packet the light level was only restored for weather regions
+           that carry a LightOverride. Everywhere else, and for a character holding a
+           light override of its own, the client kept whatever the packet had reset it to.
+    Fixed: a light override expiring inside a weather region that carries a LightOverride
+           never restored the region's level - the client stayed on the expired level
+           until it left the region. Both the timed expiry and uo::SetRegionLightLevel()
+           were affected.
+    Fixed: a character logging into a light region whose level is 0 was never sent a light
+           level at all, on the assumption that a fresh client already shows 0.
+    Changed: chr.setseason() and uo::SendOverallSeason() still leave resending the light
+             and weather to the script, as documented, but no longer leave the core
+             recording a light level and weather region that the client no longer has - so
+             the next weather or region change repairs a client whose script did not.
+    Changed: chr.facing :=, chr.setfacing() and npc::Face() no longer resend the
+             character's position to itself, or its movement to onlookers, when the facing
+             did not actually change. A script using a same-direction turn as a resync
+             nudge no longer gets one.
 09-03-2026 AsYlum:
     Fixed: uo::Distance() returned 65535 for the contents of a container opened with
            uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -254,10 +254,14 @@ void handle_client_version( Client* client, PKTBI_BD* msg )
       client->setClientType( CLIENTTYPE_4000 );
 
     if ( settingsManager.ssopt.core_sends_season )
+    {
       send_season_info(
           client );  // Scott 10/11/2007 added for login fixes and handling 1.x clients.
                      // Season info needs to check client version to keep from crashing 1.x
                      // version not set until shortly after login complete.
+      if ( client->getversiondetail().major >= 1 )
+        client->chr->check_weather_region_change( true );
+    }
     // send_feature_enable(client); //dave commented out 8/21/03, unexpected problems with people
     // sending B9 via script with this too.
     if ( client->acctSupports( Plib::ExpansionVersion::AOS ) )
@@ -367,6 +371,7 @@ void handle_msg_BF( Client* client, PKTBI_BF* msg )
       client->chr->movemode = (Plib::MOVEMODE)( client->chr->movemode ^ Plib::MOVEMODE_FLY );
       send_move_mobile_to_nearby_cansee( client->chr );
       send_goxyz( client, client->chr );
+      client->chr->check_weather_region_change( true );
     }
     break;
   case PKTBI_BF::TYPE_CLIENTTYPE:

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -1656,7 +1656,10 @@ bool Character::setgraphic( u16 newgraphic )
   graphic = newgraphic;
   send_remove_character_to_nearby_cansee( this );
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_create_mobile_to_nearby_cansee( this );
 
   return true;
@@ -1666,7 +1669,10 @@ void Character::on_color_changed()
 {
   send_remove_character_to_nearby_cansee( this );
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_create_mobile_to_nearby_cansee( this );
 }
 
@@ -1715,7 +1721,10 @@ void Character::on_cmdlevel_changed()
 void Character::on_facing_changed()
 {
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_move_mobile_to_nearby_cansee( this );
 }
 
@@ -2063,6 +2072,7 @@ void Character::resurrect()
                                                         if ( !is_visible_to_me( zonechr ) )
                                                           send_remove_character( client, zonechr );
                                                       } );
+    check_weather_region_change( true );
     client->restart();
   }
 
@@ -2107,6 +2117,7 @@ void Character::on_death( Items::Item* corpse )
             send_owncreate( client, zonechr );
         } );
 
+    check_weather_region_change( true );
     client->restart();
   }
 
@@ -3562,14 +3573,7 @@ void Character::check_attack_after_move( bool check_opponents_after_check )
 
 void Character::check_light_region_change()
 {
-  auto light_unil = lightoverride_until();
-  if ( light_unil < Core::read_gameclock() && light_unil != ~0u )
-  {
-    lightoverride_until( 0 );
-    lightoverride( -1 );
-  }
-  if ( client->gd->weather_region && client->gd->weather_region->lightoverride != -1 &&
-       !has_lightoverride() )
+  if ( Core::weather_region_owns_light( client ) )
     return;
 
   int newlightlevel;
@@ -3695,7 +3699,8 @@ void Character::check_weather_region_change( bool force )  // dave changed 5/26/
   if ( force || ( cur_weather_region != new_weather_region ) )
   {
     if ( new_weather_region != nullptr && new_weather_region->lightoverride != -1 &&
-         !has_lightoverride() )
+         !has_lightoverride() &&
+         client->gd->lightlevel != new_weather_region->lightoverride )
     {
       Core::send_light( client, new_weather_region->lightoverride );
       client->gd->lightlevel = new_weather_region->lightoverride;
@@ -4077,6 +4082,7 @@ void Character::realm_changed()
     // these are important to keep here in this order
     Core::send_realm_change( client, stored_realm() );
     Core::send_map_difs( client );
+    // Callers repaint after their own send_goxyz; one here would be undone.
     if ( Core::settingsManager.ssopt.core_sends_season )
       Core::send_season_info( client );
     Core::send_full_statmsg( client, this );

--- a/pol-core/pol/module/npcmod.cpp
+++ b/pol-core/pol/module/npcmod.cpp
@@ -298,10 +298,12 @@ BObjectImp* NPCExecutorModule::mf_Face()
     return nullptr;
   }
 
+  u8 oldfacing = npc.facing;
   if ( !npc.face( i_facing, flags ) )
     return new BLong( 0 );
 
-  npc.on_facing_changed();
+  if ( npc.facing != oldfacing )
+    npc.on_facing_changed();
   return new BLong( i_facing );
 }
 

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -5082,6 +5082,9 @@ BObjectImp* UOExecutorModule::mf_SendOverallSeason( /*season_id, playsound := 1*
       if ( !client->chr || !client->chr->logged_in() || client->getversiondetail().major < 1 )
         continue;
       msg.Send( client );
+      // The packet stopped both; -1 is not a sendable level.
+      client->gd->weather_region = nullptr;
+      client->gd->lightlevel = -1;
     }
     return new BLong( 1 );
   }

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -827,7 +827,8 @@ void UBoat::move_boat_mobile( Mobile::Character* chr, const Core::Pos4d& newpos 
   chr->position_changed();
   if ( chr->has_active_client() )
   {
-    if ( oldpos.realm() != chr->stored_realm() )
+    bool crossed_realms = ( oldpos.realm() != chr->stored_realm() );
+    if ( crossed_realms )
     {
       Core::send_new_subserver( chr->client );
       Core::send_owncreate( chr->client, chr );
@@ -849,6 +850,11 @@ void UBoat::move_boat_mobile( Mobile::Character* chr, const Core::Pos4d& newpos 
       // should be consolidated.
       Core::send_objects_newly_inrange_on_boat( chr->client, this->serial );
     }
+
+    // Below the goxyz above, which would undo it. Forced, because an unpainted
+    // zone in either realm is the same background region.
+    if ( crossed_realms )
+      chr->check_weather_region_change( true );
   }
   chr->move_reason = Mobile::Character::MULTIMOVE;
   // multis are visible before a client accepts objects, we need to resend them

--- a/pol-core/pol/network/cgdata.cpp
+++ b/pol-core/pol/network/cgdata.cpp
@@ -46,7 +46,7 @@ ClientGameData::ClientGameData()
       menu( nullptr ),
       on_menu_selection( nullptr ),
       on_popup_menu_selection( nullptr ),
-      lightlevel( 0 ),
+      lightlevel( -1 ),  // not a sendable level: nothing has been sent yet
       custom_house_serial( 0 ),
       custom_house_chrserial( 0 ),
       script_defined_update_range( false ),
@@ -62,6 +62,9 @@ ClientGameData::~ClientGameData()
 
 void ClientGameData::clear()
 {
+  weather_region = nullptr;
+  lightlevel = -1;
+
   if ( textentry_uoemod )
   {
     textentry_uoemod->uoexec().revive();

--- a/pol-core/pol/pol.cpp
+++ b/pol-core/pol/pol.cpp
@@ -300,8 +300,6 @@ void start_client_char( Network::Client* client )
   login_complete( client );
   client->chr->tellmove();
 
-  client->chr->check_weather_region_change( true );
-
   if ( settingsManager.ssopt.core_sends_season )
     send_season_info( client );
 
@@ -311,6 +309,9 @@ void start_client_char( Network::Client* client )
   send_owncreate( client, client->chr );
 
   send_goxyz( client, client->chr );
+
+  // Both send_goxyz and the season packet stop the client's weather.
+  client->chr->check_weather_region_change( true );
 
   client->restart();
 
@@ -485,6 +486,8 @@ void handle_resync_request( Network::Client* client, PKTBI_22_SYNC* /*msg*/ )
 
   send_inrange_items( client );
   send_inrange_multis( client );
+
+  client->chr->check_weather_region_change( true );
 
   client->send_restart();  // dave removed force=true 5/10/3
 }

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -1739,6 +1739,30 @@ void update_lightregion( Client* client, LightRegion* /*lightregion*/ )
   client->chr->check_light_region_change();
 }
 
+// Expires a lapsed personal lightoverride, then reports whether the client's
+// weather region owns its light - sending the region's level if the client had
+// drifted off it, which a just-expired override leaves behind.
+bool weather_region_owns_light( Client* client )
+{
+  auto light_until = client->chr->lightoverride_until();
+  if ( light_until < read_gameclock() && light_until != ~0u )
+  {
+    client->chr->lightoverride_until( 0 );
+    client->chr->lightoverride( -1 );
+  }
+
+  if ( client->gd->weather_region == nullptr || client->gd->weather_region->lightoverride == -1 ||
+       client->chr->has_lightoverride() )
+    return false;
+
+  if ( client->gd->lightlevel != client->gd->weather_region->lightoverride )
+  {
+    send_light( client, client->gd->weather_region->lightoverride );
+    client->gd->lightlevel = client->gd->weather_region->lightoverride;
+  }
+  return true;
+}
+
 void SetRegionLightLevel( LightRegion* lightregion, int lightlevel )
 {
   lightregion->lightlevel = lightlevel;
@@ -1749,15 +1773,7 @@ void SetRegionLightLevel( LightRegion* lightregion, int lightlevel )
     if ( !client->ready )
       continue;
 
-    auto light_until = client->chr->lightoverride_until();
-    if ( light_until < read_gameclock() && light_until != ~0u )
-    {
-      client->chr->lightoverride_until( 0 );
-      client->chr->lightoverride( -1 );
-    }
-
-    if ( client->gd->weather_region && client->gd->weather_region->lightoverride != -1 &&
-         !client->chr->has_lightoverride() )
+    if ( weather_region_owns_light( client ) )
       continue;
 
     int newlightlevel;
@@ -1798,7 +1814,9 @@ void update_weatherregion( Client* client, WeatherRegion* weatherregion )
   if ( !client->ready )
     return;
 
-  if ( client->gd->weather_region == weatherregion )
+  // A client with no remembered region needs it too: the forced call looks the
+  // region up from pos(), and nulling is how a reset marks itself.
+  if ( client->gd->weather_region == weatherregion || client->gd->weather_region == nullptr )
   {
     // client->gd->weather_region = nullptr;  //dave commented this out 5/26/03, causing no
     // processing to happen in following function, added force bool instead.
@@ -2130,11 +2148,7 @@ void send_season_info( Client* client )
     msg.Send( client );
 
     // Sending Season info resets light level in client, this fixes it during login
-    if ( client->gd->weather_region != nullptr && client->gd->weather_region->lightoverride != -1 &&
-         !client->chr->has_lightoverride() )
-    {
-      send_light( client, client->gd->weather_region->lightoverride );
-    }
+    send_light( client, client->gd->lightlevel );
   }
 }
 

--- a/pol-core/pol/ufunc.h
+++ b/pol-core/pol/ufunc.h
@@ -129,6 +129,8 @@ void remove_objects_inrange( Network::Client* client );
 
 void send_goxyz( Network::Client* client, const Mobile::Character* chr );
 void send_light( Network::Client* client, int lightlevel );
+// Expires a lapsed lightoverride and may send a light packet; see ufunc.cpp.
+bool weather_region_owns_light( Network::Client* client );
 void send_weather( Network::Client* client, unsigned char type, unsigned char severity,
                    unsigned char aux );
 void send_mode( Network::Client* client );

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -2417,10 +2417,15 @@ BObjectImp* Character::set_script_member_id( const int id, int value )
     }
     return new BLong( carrying_capacity_mod() );
   case MBR_FACING:
+  {
+    // face() reports success whether or not it actually turned.
+    u8 oldfacing = facing;
     if ( !face( static_cast<Core::UFACING>( value & PKTIN_02_FACING_MASK ), 0 ) )
       return new BLong( 0 );
-    on_facing_changed();
+    if ( facing != oldfacing )
+      on_facing_changed();
     return new BLong( 1 );
+  }
   case MBR_FIRE_RESIST_MOD:
     fire_resist( fire_resist().setAsMod( Clib::clamp_convert<s16>( value ) ) );
     refresh_ar();
@@ -2829,6 +2834,9 @@ BObjectImp* Character::script_method_id( const int id, Core::UOExecutor& ex )
         msg->Write<u8>( Clib::clamp_convert<u8>( season_id ) );
         msg->Write<u8>( Clib::clamp_convert<u8>( playsound ) );
         msg.Send( client );
+        // The packet stopped both; -1 is not a sendable level.
+        client->gd->weather_region = nullptr;
+        client->gd->lightlevel = -1;
         return new BLong( 1 );
       }
     }
@@ -3077,10 +3085,12 @@ BObjectImp* Character::script_method_id( const int id, Core::UOExecutor& ex )
     else
       return new BError( "Invalid type for parameter 0" );
 
+    u8 oldfacing = facing;
     if ( !face( i_facing, flags ) )
       return new BLong( 0 );
 
-    on_facing_changed();
+    if ( facing != oldfacing )
+      on_facing_changed();
     return new BLong( 1 );
     break;
   }


### PR DESCRIPTION
The client stops drawing weather when it is sent a new position, and the season packet resets its light level. Both go out from many places, and only move_character_to handled the consequence - it nulls the client's remembered weather region so its own tellmove repaints. Everywhere else the sky stayed wrong until the character crossed into another weather region, teleported, or the weather changed on its own.

A caveat first, since most of this rests on it. That send_goxyz stops the weather is the core's own claim, not something I measured, and both statements of it are hedged: "send_goxyz seems to stop the weather" beside the null in move_character_to, and dave's 2003 note in check_weather_region_change, "send_goxyz causes weather effects to stop if character is walking/running too". move_character_to has acted on it for twenty years. Eight of the repaints below depend on it and I have not tested it against a client. The light half stands better: send_season_info's own comment says the season packet resets the light, and an undated POL097 entry records the intent that the core "sends light level whenever season info is sent to the client".

Repaints added at: the client's resync request, death, resurrection, a graphic, colour or facing change, the gargoyle fly toggle, the client version handshake, and a boat crossing realms. Login already had one, but it went out before the season packet and the final send_goxyz and so undid itself - that one moves rather than appears. Only the handshake rests on the season premise; it sends no position packet at all. The rest stand on send_goxyz alone.

The boat repaint has to sit below the branch that sends goxyz to pre-7.0.9.0 clients, or that undoes it, and has to be forced: region grids are zero-filled per realm and the lookup indexes one shared vector, so an unpainted zone in either realm is the same background region and an unforced check sees no change.

send_season_info knew the season packet resets the light but only restored it for a weather region carrying a LightOverride - and where it declined, a character holding its own override, the light stayed reset. It now re-sends gd->lightlevel, which is what the client was last told in every case.

That exposed the bug it had been masking: a personal override expiring inside such a region never restored the region's level, because both places that decide who owns the light skipped the character on the assumption the client already had it. Those two are now weather_region_owns_light(). regen_stats open-codes the expiry half as well and is left alone; only the skip was duplicated.

update_weatherregion now also accepts a client with no remembered weather region. It gated on the pointer matching the region being changed, so the two calls below
- which null it - would have made that client invisible to SetRegionWeatherLevel, the main way weather is driven. Inferred, not stated: the commented-out 2003 line in that same function looks like the same edge from the other side.

setseason and SendOverallSeason keep their documented contract - resending the light and weather is the script's job - but no longer leave the core recording state the client has lost. Both are invalidated instead: the weather region is nulled, and the light level set to -1, which VALID_LIGHTLEVEL rejects so it can never be sent by accident. No packet goes out, so the contract holds. The repair is not immediate, though: it lands on the character's next region change or the next SetRegionWeatherLevel.

ClientGameData::lightlevel now starts at -1 rather than 0, and clear() resets it. Zero is a real level, so the old value claimed the client had been told something it never had - a character logging into a region whose level is genuinely 0 was never sent one at all.

chr.facing :=, chr.setfacing() and npc::Face() now call on_facing_changed only when the facing actually changed. face() reports success either way, so a script turning to face a target it already faced was resending the position to itself and its movement to onlookers every call. Scripts using a same-direction turn as a resync nudge lose that side effect.

The repaint is not free where facing changes are frequent: a client announces the weather on every packet it accepts, so each repaint is also a journal line while weather is falling. A clear sky is silent - that packet carries no message.

Deliberately unchanged: a boat step or turn sends goxyz to every traveller on a pre-7.0.9.0 client, so those clients still lose the weather while sailing even within one realm. The repaint belongs in do_tellmoves, the single end-of-move point for move_to, move and turn, and wants testing against a real client first.