### PR TITLE
Repaint the client's weather and light after anything that resets them

### DIFF
--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -13,7 +13,7 @@
       <list>elipsis ... : repeat entries are allowed.</list>
       <bottom>This means the punctuation in these cases should NOT be in the actual config files used by POL, they only appear here for information purposes. Exception: curly braces { } are used to define an element in a config file. These must be present in the actual file.</bottom>
     </desc>
-    <datemodified>09/05/2026</datemodified>
+    <datemodified>09/06/2026</datemodified>
 </fileheader>
 
 
@@ -443,8 +443,9 @@ Spell (int spellid)
   <explain><i>WhisperRange:</i> definies the range of whispered speech</explain>
   <explain><i>YellRange:</i> definies the range of yelled speech</explain>
   <explain><i>CoreSendsSeason:</i> Determines if the core should send season packet on char creation/logon/reconnect,
-        realm change and the client version handshake, based on the season entry in realm.cfg. The season packet resets
-        the client's light level, so the core restores it behind each packet it sends.</explain>
+        realm change, the client version handshake and resurrection, based on the season entry in realm.cfg. The season
+        packet resets the client's light level, so the core restores it behind each packet it sends. The one on
+        resurrection is there because a season sent while the character was dead does not stick.</explain>
   <explain><i>CoreHandledTags:</i> bitfield to determine which tags are displayed on singleclick, current used bits are:<br/>
     0x1  [title_guild]<br/>
     0x2  [frozen]<br/>

--- a/docs/docs.polserver.com/pol100/configfiles.xml
+++ b/docs/docs.polserver.com/pol100/configfiles.xml
@@ -13,7 +13,7 @@
       <list>elipsis ... : repeat entries are allowed.</list>
       <bottom>This means the punctuation in these cases should NOT be in the actual config files used by POL, they only appear here for information purposes. Exception: curly braces { } are used to define an element in a config file. These must be present in the actual file.</bottom>
     </desc>
-    <datemodified>08/15/2026</datemodified>
+    <datemodified>09/05/2026</datemodified>
 </fileheader>
 
 
@@ -442,8 +442,9 @@ Spell (int spellid)
   <explain><i>SpeechRange:</i> definies the range of normal speech</explain>
   <explain><i>WhisperRange:</i> definies the range of whispered speech</explain>
   <explain><i>YellRange:</i> definies the range of yelled speech</explain>
-  <explain><i>CoreSendsSeason:</i> Determines if the core should send season packet on char creation/logon/reconnect and realm
-        change based on the season entry in realm.cfg</explain>
+  <explain><i>CoreSendsSeason:</i> Determines if the core should send season packet on char creation/logon/reconnect,
+        realm change and the client version handshake, based on the season entry in realm.cfg. The season packet resets
+        the client's light level, so the core restores it behind each packet it sends.</explain>
   <explain><i>CoreHandledTags:</i> bitfield to determine which tags are displayed on singleclick, current used bits are:<br/>
     0x1  [title_guild]<br/>
     0x2  [frozen]<br/>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -2,7 +2,7 @@
 <ESCRIPT>
 	<header>
 		<topic>Latest Core Changes</topic>
-		<datemodified>09-05-2026</datemodified>
+		<datemodified>09-06-2026</datemodified>
 	</header>
 	<version name="POL100.3.0">
 		<entry>
@@ -61,6 +61,9 @@ the character's position or a season packet, and the client stops drawing<br/>
 weather when it gets either. Nothing sent it again, so the sky stayed wrong<br/>
 until the character crossed into another weather region, teleported, or the<br/>
 weather changed on its own.</change>
+			<change type="Fixed">a character that logged in while dead came back in the wrong season once it<br/>
+was resurrected. A season sent while the character is dead does not stick,<br/>
+so the one login sent was gone, and resurrection sent no other.</change>
 			<change type="Fixed">after a season packet the light level was only restored for weather regions<br/>
 that carry a LightOverride. Everywhere else, and for a character holding a<br/>
 light override of its own, the client kept whatever the packet had reset it to.</change>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -53,9 +53,31 @@ orders below true, and below any other value that is true.</change>
 		<entry>
 			<date>09-05-2026</date>
 			<author>Ins:</author>
-			<change type="Fixed">an AOS tooltip with more than 65535 characters of text could shut the shard<br/>
-down, since the length was narrowed to 16 bits before the range check. A<br/>
-script can set a name that long, so it was script-reachable.</change>
+			<change type="Fixed">a client was left with a clear sky, or the wrong light level, after several<br/>
+ordinary events: logging in, reconnecting, its own resync request, dying, being<br/>
+resurrected, having its graphic, colour or facing set from a script, a gargoyle<br/>
+toggling flight, and a boat carrying it between realms. Each of those resends<br/>
+the character's position or a season packet, and the client stops drawing<br/>
+weather when it gets either. Nothing sent it again, so the sky stayed wrong<br/>
+until the character crossed into another weather region, teleported, or the<br/>
+weather changed on its own.</change>
+			<change type="Fixed">after a season packet the light level was only restored for weather regions<br/>
+that carry a LightOverride. Everywhere else, and for a character holding a<br/>
+light override of its own, the client kept whatever the packet had reset it to.</change>
+			<change type="Fixed">a light override expiring inside a weather region that carries a LightOverride<br/>
+never restored the region's level - the client stayed on the expired level<br/>
+until it left the region. Both the timed expiry and uo::SetRegionLightLevel()<br/>
+were affected.</change>
+			<change type="Fixed">a character logging into a light region whose level is 0 was never sent a light<br/>
+level at all, on the assumption that a fresh client already shows 0.</change>
+			<change type="Changed">chr.setseason() and uo::SendOverallSeason() still leave resending the light<br/>
+and weather to the script, as documented, but no longer leave the core<br/>
+recording a light level and weather region that the client no longer has - so<br/>
+the next weather or region change repairs a client whose script did not.</change>
+			<change type="Changed">chr.facing :=, chr.setfacing() and npc::Face() no longer resend the<br/>
+character's position to itself, or its movement to onlookers, when the facing<br/>
+did not actually change. A script using a same-direction turn as a resync<br/>
+nudge no longer gets one.</change>
 		</entry>
 		<entry>
 			<date>09-03-2026</date>

--- a/docs/docs.polserver.com/pol100/corechanges.xml
+++ b/docs/docs.polserver.com/pol100/corechanges.xml
@@ -80,7 +80,14 @@ the next weather or region change repairs a client whose script did not.</change
 			<change type="Changed">chr.facing :=, chr.setfacing() and npc::Face() no longer resend the<br/>
 character's position to itself, or its movement to onlookers, when the facing<br/>
 did not actually change. A script using a same-direction turn as a resync<br/>
-nudge no longer gets one.</change>
+nudge no longer gets one: uo::UpdateMobile() redraws a mobile for its<br/>
+onlookers without a position packet, and MoveObjectToLocation() to the<br/>
+character's own position resynchronises the character itself.</change>
+			<change type="Note">a client older than 7.0.9.0 aboard a boat is sent its position on every step,<br/>
+not only when the boat crosses realms, and only the crossing repaints. Those<br/>
+clients still lose the weather while sailing within one realm. The repaint<br/>
+belongs in do_tellmoves, where it would cost a weather packet per step, and<br/>
+wants testing against a real client first.</change>
 		</entry>
 		<entry>
 			<date>09-03-2026</date>

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -66,7 +66,14 @@
     Changed: chr.facing :=, chr.setfacing() and npc::Face() no longer resend the
              character's position to itself, or its movement to onlookers, when the facing
              did not actually change. A script using a same-direction turn as a resync
-             nudge no longer gets one.
+             nudge no longer gets one: uo::UpdateMobile() redraws a mobile for its
+             onlookers without a position packet, and MoveObjectToLocation() to the
+             character's own position resynchronises the character itself.
+    Note:  a client older than 7.0.9.0 aboard a boat is sent its position on every step,
+           not only when the boat crosses realms, and only the crossing repaints. Those
+           clients still lose the weather while sailing within one realm. The repaint
+           belongs in do_tellmoves, where it would cost a weather packet per step, and
+           wants testing against a real client first.
 09-03-2026 AsYlum:
     Fixed: uo::Distance() returned 65535 for the contents of a container opened with
            uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -39,9 +39,31 @@
     Fixed: client.clientinfo it was partially garbage
     Fixed: a one byte packet (0xFA) disconnected the client on some platforms
 09-05-2026 Ins:
-    Fixed: an AOS tooltip with more than 65535 characters of text could shut the shard
-           down, since the length was narrowed to 16 bits before the range check. A
-           script can set a name that long, so it was script-reachable.
+    Fixed: a client was left with a clear sky, or the wrong light level, after several
+           ordinary events: logging in, reconnecting, its own resync request, dying, being
+           resurrected, having its graphic, colour or facing set from a script, a gargoyle
+           toggling flight, and a boat carrying it between realms. Each of those resends
+           the character's position or a season packet, and the client stops drawing
+           weather when it gets either. Nothing sent it again, so the sky stayed wrong
+           until the character crossed into another weather region, teleported, or the
+           weather changed on its own.
+    Fixed: after a season packet the light level was only restored for weather regions
+           that carry a LightOverride. Everywhere else, and for a character holding a
+           light override of its own, the client kept whatever the packet had reset it to.
+    Fixed: a light override expiring inside a weather region that carries a LightOverride
+           never restored the region's level - the client stayed on the expired level
+           until it left the region. Both the timed expiry and uo::SetRegionLightLevel()
+           were affected.
+    Fixed: a character logging into a light region whose level is 0 was never sent a light
+           level at all, on the assumption that a fresh client already shows 0.
+    Changed: chr.setseason() and uo::SendOverallSeason() still leave resending the light
+             and weather to the script, as documented, but no longer leave the core
+             recording a light level and weather region that the client no longer has - so
+             the next weather or region change repairs a client whose script did not.
+    Changed: chr.facing :=, chr.setfacing() and npc::Face() no longer resend the
+             character's position to itself, or its movement to onlookers, when the facing
+             did not actually change. A script using a same-direction turn as a resync
+             nudge no longer gets one.
 09-03-2026 AsYlum:
     Fixed: uo::Distance() returned 65535 for the contents of a container opened with
            uo::SendOpenSpecialContainer(), a bank box for instance. It is 0 again.

--- a/pol-core/doc/core-changes.txt
+++ b/pol-core/doc/core-changes.txt
@@ -47,6 +47,9 @@
            weather when it gets either. Nothing sent it again, so the sky stayed wrong
            until the character crossed into another weather region, teleported, or the
            weather changed on its own.
+    Fixed: a character that logged in while dead came back in the wrong season once it
+           was resurrected. A season sent while the character is dead does not stick,
+           so the one login sent was gone, and resurrection sent no other.
     Fixed: after a season packet the light level was only restored for weather regions
            that carry a LightOverride. Everywhere else, and for a character holding a
            light override of its own, the client kept whatever the packet had reset it to.

--- a/pol-core/pol/miscmsg.cpp
+++ b/pol-core/pol/miscmsg.cpp
@@ -254,10 +254,14 @@ void handle_client_version( Client* client, PKTBI_BD* msg )
       client->setClientType( CLIENTTYPE_4000 );
 
     if ( settingsManager.ssopt.core_sends_season )
+    {
       send_season_info(
           client );  // Scott 10/11/2007 added for login fixes and handling 1.x clients.
                      // Season info needs to check client version to keep from crashing 1.x
                      // version not set until shortly after login complete.
+      if ( client->getversiondetail().major >= 1 )
+        client->chr->check_weather_region_change( true );
+    }
     // send_feature_enable(client); //dave commented out 8/21/03, unexpected problems with people
     // sending B9 via script with this too.
     if ( client->acctSupports( Plib::ExpansionVersion::AOS ) )
@@ -367,6 +371,7 @@ void handle_msg_BF( Client* client, PKTBI_BF* msg )
       client->chr->movemode = (Plib::MOVEMODE)( client->chr->movemode ^ Plib::MOVEMODE_FLY );
       send_move_mobile_to_nearby_cansee( client->chr );
       send_goxyz( client, client->chr );
+      client->chr->check_weather_region_change( true );
     }
     break;
   case PKTBI_BF::TYPE_CLIENTTYPE:

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -1656,7 +1656,10 @@ bool Character::setgraphic( u16 newgraphic )
   graphic = newgraphic;
   send_remove_character_to_nearby_cansee( this );
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_create_mobile_to_nearby_cansee( this );
 
   return true;
@@ -1666,7 +1669,10 @@ void Character::on_color_changed()
 {
   send_remove_character_to_nearby_cansee( this );
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_create_mobile_to_nearby_cansee( this );
 }
 
@@ -1715,7 +1721,10 @@ void Character::on_cmdlevel_changed()
 void Character::on_facing_changed()
 {
   if ( client )
+  {
     send_goxyz( client, client->chr );
+    check_weather_region_change( true );
+  }
   send_move_mobile_to_nearby_cansee( this );
 }
 
@@ -2063,6 +2072,7 @@ void Character::resurrect()
                                                         if ( !is_visible_to_me( zonechr ) )
                                                           send_remove_character( client, zonechr );
                                                       } );
+    check_weather_region_change( true );
     client->restart();
   }
 
@@ -2107,6 +2117,7 @@ void Character::on_death( Items::Item* corpse )
             send_owncreate( client, zonechr );
         } );
 
+    check_weather_region_change( true );
     client->restart();
   }
 
@@ -3562,14 +3573,7 @@ void Character::check_attack_after_move( bool check_opponents_after_check )
 
 void Character::check_light_region_change()
 {
-  auto light_unil = lightoverride_until();
-  if ( light_unil < Core::read_gameclock() && light_unil != ~0u )
-  {
-    lightoverride_until( 0 );
-    lightoverride( -1 );
-  }
-  if ( client->gd->weather_region && client->gd->weather_region->lightoverride != -1 &&
-       !has_lightoverride() )
+  if ( Core::weather_region_owns_light( client ) )
     return;
 
   int newlightlevel;
@@ -3695,7 +3699,8 @@ void Character::check_weather_region_change( bool force )  // dave changed 5/26/
   if ( force || ( cur_weather_region != new_weather_region ) )
   {
     if ( new_weather_region != nullptr && new_weather_region->lightoverride != -1 &&
-         !has_lightoverride() )
+         !has_lightoverride() &&
+         client->gd->lightlevel != new_weather_region->lightoverride )
     {
       Core::send_light( client, new_weather_region->lightoverride );
       client->gd->lightlevel = new_weather_region->lightoverride;
@@ -4077,6 +4082,7 @@ void Character::realm_changed()
     // these are important to keep here in this order
     Core::send_realm_change( client, stored_realm() );
     Core::send_map_difs( client );
+    // Callers repaint after their own send_goxyz; one here would be undone.
     if ( Core::settingsManager.ssopt.core_sends_season )
       Core::send_season_info( client );
     Core::send_full_statmsg( client, this );

--- a/pol-core/pol/mobile/charactr.cpp
+++ b/pol-core/pol/mobile/charactr.cpp
@@ -2072,6 +2072,10 @@ void Character::resurrect()
                                                         if ( !is_visible_to_me( zonechr ) )
                                                           send_remove_character( client, zonechr );
                                                       } );
+    // A season sent while the character was dead does not stick, so a client that
+    // logged in as a ghost has none. Nothing else sends one on the way back.
+    if ( Core::settingsManager.ssopt.core_sends_season )
+      Core::send_season_info( client );
     check_weather_region_change( true );
     client->restart();
   }

--- a/pol-core/pol/module/npcmod.cpp
+++ b/pol-core/pol/module/npcmod.cpp
@@ -298,10 +298,12 @@ BObjectImp* NPCExecutorModule::mf_Face()
     return nullptr;
   }
 
+  u8 oldfacing = npc.facing;
   if ( !npc.face( i_facing, flags ) )
     return new BLong( 0 );
 
-  npc.on_facing_changed();
+  if ( npc.facing != oldfacing )
+    npc.on_facing_changed();
   return new BLong( i_facing );
 }
 

--- a/pol-core/pol/module/uomod.cpp
+++ b/pol-core/pol/module/uomod.cpp
@@ -5082,6 +5082,9 @@ BObjectImp* UOExecutorModule::mf_SendOverallSeason( /*season_id, playsound := 1*
       if ( !client->chr || !client->chr->logged_in() || client->getversiondetail().major < 1 )
         continue;
       msg.Send( client );
+      // The packet stopped both; -1 is not a sendable level.
+      client->gd->weather_region = nullptr;
+      client->gd->lightlevel = -1;
     }
     return new BLong( 1 );
   }

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -851,8 +851,15 @@ void UBoat::move_boat_mobile( Mobile::Character* chr, const Core::Pos4d& newpos 
       Core::send_objects_newly_inrange_on_boat( chr->client, this->serial );
     }
 
-    // Below the goxyz above, which would undo it. Forced, because an unpainted
-    // zone in either realm is the same background region.
+    // After both branches: the older clients above were sent a goxyz, the newer
+    // ones a season packet by realm_changed(), and either stops the weather.
+    // Forced, because an unpainted zone in either realm is the same background
+    // region, so an ordinary check would see no change.
+    //
+    // Only on a realm crossing. A pre-7.0.9.0 client is also sent a goxyz on
+    // every ordinary step and turn, and repainting there would put a weather
+    // packet - and the journal line that comes with it - on every step. That
+    // belongs in do_tellmoves, and wants testing against a real client first.
     if ( crossed_realms )
       chr->check_weather_region_change( true );
   }

--- a/pol-core/pol/multi/boat.cpp
+++ b/pol-core/pol/multi/boat.cpp
@@ -827,7 +827,8 @@ void UBoat::move_boat_mobile( Mobile::Character* chr, const Core::Pos4d& newpos 
   chr->position_changed();
   if ( chr->has_active_client() )
   {
-    if ( oldpos.realm() != chr->stored_realm() )
+    bool crossed_realms = ( oldpos.realm() != chr->stored_realm() );
+    if ( crossed_realms )
     {
       Core::send_new_subserver( chr->client );
       Core::send_owncreate( chr->client, chr );
@@ -849,6 +850,11 @@ void UBoat::move_boat_mobile( Mobile::Character* chr, const Core::Pos4d& newpos 
       // should be consolidated.
       Core::send_objects_newly_inrange_on_boat( chr->client, this->serial );
     }
+
+    // Below the goxyz above, which would undo it. Forced, because an unpainted
+    // zone in either realm is the same background region.
+    if ( crossed_realms )
+      chr->check_weather_region_change( true );
   }
   chr->move_reason = Mobile::Character::MULTIMOVE;
   // multis are visible before a client accepts objects, we need to resend them

--- a/pol-core/pol/network/cgdata.cpp
+++ b/pol-core/pol/network/cgdata.cpp
@@ -46,7 +46,7 @@ ClientGameData::ClientGameData()
       menu( nullptr ),
       on_menu_selection( nullptr ),
       on_popup_menu_selection( nullptr ),
-      lightlevel( 0 ),
+      lightlevel( -1 ),  // not a sendable level: nothing has been sent yet
       custom_house_serial( 0 ),
       custom_house_chrserial( 0 ),
       script_defined_update_range( false ),
@@ -62,6 +62,9 @@ ClientGameData::~ClientGameData()
 
 void ClientGameData::clear()
 {
+  weather_region = nullptr;
+  lightlevel = -1;
+
   if ( textentry_uoemod )
   {
     textentry_uoemod->uoexec().revive();

--- a/pol-core/pol/pol.cpp
+++ b/pol-core/pol/pol.cpp
@@ -300,8 +300,6 @@ void start_client_char( Network::Client* client )
   login_complete( client );
   client->chr->tellmove();
 
-  client->chr->check_weather_region_change( true );
-
   if ( settingsManager.ssopt.core_sends_season )
     send_season_info( client );
 
@@ -311,6 +309,9 @@ void start_client_char( Network::Client* client )
   send_owncreate( client, client->chr );
 
   send_goxyz( client, client->chr );
+
+  // Both send_goxyz and the season packet stop the client's weather.
+  client->chr->check_weather_region_change( true );
 
   client->restart();
 
@@ -485,6 +486,8 @@ void handle_resync_request( Network::Client* client, PKTBI_22_SYNC* /*msg*/ )
 
   send_inrange_items( client );
   send_inrange_multis( client );
+
+  client->chr->check_weather_region_change( true );
 
   client->send_restart();  // dave removed force=true 5/10/3
 }

--- a/pol-core/pol/ufunc.cpp
+++ b/pol-core/pol/ufunc.cpp
@@ -1739,6 +1739,30 @@ void update_lightregion( Client* client, LightRegion* /*lightregion*/ )
   client->chr->check_light_region_change();
 }
 
+// Expires a lapsed personal lightoverride, then reports whether the client's
+// weather region owns its light - sending the region's level if the client had
+// drifted off it, which a just-expired override leaves behind.
+bool weather_region_owns_light( Client* client )
+{
+  auto light_until = client->chr->lightoverride_until();
+  if ( light_until < read_gameclock() && light_until != ~0u )
+  {
+    client->chr->lightoverride_until( 0 );
+    client->chr->lightoverride( -1 );
+  }
+
+  if ( client->gd->weather_region == nullptr || client->gd->weather_region->lightoverride == -1 ||
+       client->chr->has_lightoverride() )
+    return false;
+
+  if ( client->gd->lightlevel != client->gd->weather_region->lightoverride )
+  {
+    send_light( client, client->gd->weather_region->lightoverride );
+    client->gd->lightlevel = client->gd->weather_region->lightoverride;
+  }
+  return true;
+}
+
 void SetRegionLightLevel( LightRegion* lightregion, int lightlevel )
 {
   lightregion->lightlevel = lightlevel;
@@ -1749,15 +1773,7 @@ void SetRegionLightLevel( LightRegion* lightregion, int lightlevel )
     if ( !client->ready )
       continue;
 
-    auto light_until = client->chr->lightoverride_until();
-    if ( light_until < read_gameclock() && light_until != ~0u )
-    {
-      client->chr->lightoverride_until( 0 );
-      client->chr->lightoverride( -1 );
-    }
-
-    if ( client->gd->weather_region && client->gd->weather_region->lightoverride != -1 &&
-         !client->chr->has_lightoverride() )
+    if ( weather_region_owns_light( client ) )
       continue;
 
     int newlightlevel;
@@ -1798,7 +1814,9 @@ void update_weatherregion( Client* client, WeatherRegion* weatherregion )
   if ( !client->ready )
     return;
 
-  if ( client->gd->weather_region == weatherregion )
+  // A client with no remembered region needs it too: the forced call looks the
+  // region up from pos(), and nulling is how a reset marks itself.
+  if ( client->gd->weather_region == weatherregion || client->gd->weather_region == nullptr )
   {
     // client->gd->weather_region = nullptr;  //dave commented this out 5/26/03, causing no
     // processing to happen in following function, added force bool instead.
@@ -2130,11 +2148,7 @@ void send_season_info( Client* client )
     msg.Send( client );
 
     // Sending Season info resets light level in client, this fixes it during login
-    if ( client->gd->weather_region != nullptr && client->gd->weather_region->lightoverride != -1 &&
-         !client->chr->has_lightoverride() )
-    {
-      send_light( client, client->gd->weather_region->lightoverride );
-    }
+    send_light( client, client->gd->lightlevel );
   }
 }
 

--- a/pol-core/pol/ufunc.h
+++ b/pol-core/pol/ufunc.h
@@ -129,6 +129,8 @@ void remove_objects_inrange( Network::Client* client );
 
 void send_goxyz( Network::Client* client, const Mobile::Character* chr );
 void send_light( Network::Client* client, int lightlevel );
+// Expires a lapsed lightoverride and may send a light packet; see ufunc.cpp.
+bool weather_region_owns_light( Network::Client* client );
 void send_weather( Network::Client* client, unsigned char type, unsigned char severity,
                    unsigned char aux );
 void send_mode( Network::Client* client );

--- a/pol-core/pol/uoscrobj.cpp
+++ b/pol-core/pol/uoscrobj.cpp
@@ -2417,10 +2417,15 @@ BObjectImp* Character::set_script_member_id( const int id, int value )
     }
     return new BLong( carrying_capacity_mod() );
   case MBR_FACING:
+  {
+    // face() reports success whether or not it actually turned.
+    u8 oldfacing = facing;
     if ( !face( static_cast<Core::UFACING>( value & PKTIN_02_FACING_MASK ), 0 ) )
       return new BLong( 0 );
-    on_facing_changed();
+    if ( facing != oldfacing )
+      on_facing_changed();
     return new BLong( 1 );
+  }
   case MBR_FIRE_RESIST_MOD:
     fire_resist( fire_resist().setAsMod( Clib::clamp_convert<s16>( value ) ) );
     refresh_ar();
@@ -2829,6 +2834,9 @@ BObjectImp* Character::script_method_id( const int id, Core::UOExecutor& ex )
         msg->Write<u8>( Clib::clamp_convert<u8>( season_id ) );
         msg->Write<u8>( Clib::clamp_convert<u8>( playsound ) );
         msg.Send( client );
+        // The packet stopped both; -1 is not a sendable level.
+        client->gd->weather_region = nullptr;
+        client->gd->lightlevel = -1;
         return new BLong( 1 );
       }
     }
@@ -3077,10 +3085,12 @@ BObjectImp* Character::script_method_id( const int id, Core::UOExecutor& ex )
     else
       return new BError( "Invalid type for parameter 0" );
 
+    u8 oldfacing = facing;
     if ( !face( i_facing, flags ) )
       return new BLong( 0 );
 
-    on_facing_changed();
+    if ( facing != oldfacing )
+      on_facing_changed();
     return new BLong( 1 );
     break;
   }

--- a/testsuite/pol/testpkgs/client/communication.inc
+++ b/testsuite/pol/testpkgs/client/communication.inc
@@ -37,7 +37,8 @@ const EVT_ANIMATION := "animation";
 const ANIM_PKT_OLD := 0x6E;
 const ANIM_PKT_NEW := 0xE2;
 // What the shard tells one client and nothing else: the arrow pointing at a place, the cursor for
-// placing a multi, an old style menu, a tip window, the season, and the skill list.
+// placing a multi, an old style menu, a tip window, the season, the skill list, and the weather
+// and light level it should be drawing.
 const EVT_QUEST_ARROW := "quest_arrow";
 const EVT_MULTI_PLACEMENT := "multi_placement";
 // The ack of the place_multi todo: whether a placement cursor was there to answer.
@@ -51,6 +52,8 @@ const EVT_PROMPT := "prompt";
 const EVT_MENU := "menu";
 const EVT_TIP_WINDOW := "tip_window";
 const EVT_SEASON := "season";
+const EVT_WEATHER := "weather";
+const EVT_LIGHT := "light";
 const EVT_SKILLS := "skills";
 // What the "kind" of an effect says the client should draw. Named for the field rather than for
 // the effect, because eScript identifiers are case insensitive and a case called

--- a/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
+++ b/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
@@ -11,43 +11,9 @@
 // client otherwise visits, so nothing else can be sending these packets - and
 // because it is water, anything that checks walkheight there has to be forced.
 //
-// STILL UNTESTED. Every repaint the core does is listed here; the ones without
-// a case below are left for whoever gets to them, with what each would need.
-//
-//   start_client_char (pol.cpp)  - the repaint after login's last position
-//       send. Needs the client to go away and come back: the todos are
-//       "disconnect" and "connect" (see testclient.py). The catch is that a
-//       reconnect reorders whose events are whose, so drain carefully or the
-//       case passes for the wrong reason.
-//
-//   handle_client_version (miscmsg.cpp) - same trip as above; the core sends
-//       the season here because the one during login is too early for the
-//       client to keep. Falls out of the reconnect case for free.
-//
-//   handle_msg_BF, the gargoyle flight toggle (miscmsg.cpp) - a 0xBF
-//       subcommand through the "raw_packet" todo, like the resync case below.
-//       Needs the subcommand id and a gargoyle body: a non-gargoyle is
-//       refused before anything is sent.
-//
-//   move_boat_mobile (boat.cpp) - a boat carrying this character across into
-//       britannia2. testpkgs/boat/test_boat.src already moves a boat between
-//       realms, and test_client_boat.src already sails one with a client
-//       aboard; this is the two put together.
-//
-//   The three light fixes (ufunc.cpp, charactr.cpp) - EVT_LIGHT is wired up
-//       and unused. regions/light.cfg has TestLightBase at 10 and
-//       TestLightDark at 25 (108..115). Each fix is a restoration after
-//       something resets the level, so the case has to catch the reset first
-//       and then the value coming back:
-//         - the level after a season packet, outside a weather region that
-//           carries a LightOverride
-//         - a light override expiring inside a region that carries one, both
-//           on its timer and through uo::SetRegionLightLevel()
-//         - logging into a light region whose level is 0
-//
-//   npc::Face() (npcmod.cpp) - the same no-resend guard as
-//       facing_unchanged_is_quiet below, but for an NPC turning. Needs a
-//       second client watching, and an assert that it is told nothing.
+// The repaints this does not reach yet - login, the version handshake, the
+// gargoyle fly toggle, a boat crossing realms, two of the light fixes and
+// npc::Face() - are listed in the pull request, with what each would need.
 
 use os;
 use uo;
@@ -65,7 +31,6 @@ const HOME_X := 100;
 const HOME_Y := 50;
 
 // A human body to turn into; what to turn back into is read off the character.
-// setgraphic refuses anything past MaxAnimID, and this is well inside it.
 const BODY_FEMALE := 0x191;
 
 const CLIENT_ID := 0;
@@ -80,6 +45,13 @@ const SEASON_DEFAULT := 0;
 // with -1, which is what the core reads as "no override".
 const TEST_LIGHT := 12;
 const NO_LIGHT_OVERRIDE := -1;
+
+// TestLightDark in regions/light.cfg, and the level it carries. Away from the
+// storm, so the background weather region applies and it holds no
+// LightOverride of its own - which is the case the light fix is about.
+const DARK_X := 111;
+const DARK_Y := 111;
+const DARK_LEVEL := 25;
 
 var char;
 
@@ -121,10 +93,9 @@ function wait_weather( what, timeout := 10 )
 endfunction
 
 
-// Resurrection sends the season first and the weather second, so waiting for
-// one at a time would throw the other away. Which season it is depends on the
-// realm, so only that one was sent is asserted: a client that was dead never
-// kept the season login gave it, and before the fix nothing sent another.
+// Resurrection sends the season first and the weather second, so waiting for one
+// at a time would throw the other away. Only that a season arrived is asserted;
+// which one depends on the realm.
 function wait_season_and_weather( what, timeout := 10 )
   var deadline := ReadMillisecondClock() + timeout * 1000;
   var got_season := 0;
@@ -154,9 +125,24 @@ function wait_season_and_weather( what, timeout := 10 )
 endfunction
 
 
-// Fails if the event turns up at all, for the cases whose fix is that a packet
-// is no longer sent. Polls rather than sleeping a second at a time, so a
-// negative assertion costs what it was asked for.
+function wait_light( level, what, timeout := 10 )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    var ev := Wait_For_Event( POLL_INTERVAL );
+    if ( !ev or ev.type != EVT_LIGHT or CInt( ev.id ) != CLIENT_ID )
+      continue;
+    endif
+    if ( CInt( ev.level ) != level )
+      return ret_error( $"{what}: light {ev.level}, wanted {level}" );
+    endif
+    return 1;
+  endwhile
+  return ret_error( $"{what}: the client was never sent the light level again" );
+endfunction
+
+
+// Fails if the event turns up at all, for the cases whose fix is that a packet is
+// no longer sent. Polls, so a negative assertion costs what it was asked for.
 function no_event_for( type, what, timeout := QUIET_SECS )
   var deadline := ReadMillisecondClock() + timeout * 1000;
   while ( ReadMillisecondClock() < deadline )
@@ -177,16 +163,14 @@ function watch_weather( on )
 endfunction
 
 
-// Puts the character in the storm. The drain comes first, so the toggle above
-// has landed before anything can be sent; then it waits for the packet walking
-// in causes rather than draining blindly, since one that arrived late would
-// otherwise satisfy the wait the case makes afterwards.
+// Drain first, so the toggle above has landed before anything can be sent, then
+// wait for the packet walking in causes: draining blindly would let a late one
+// satisfy the wait the case makes afterwards.
 function enter_storm()
   watch_weather( 1 );
-  // Pinned rather than taken on trust from weather.cfg: TestMisc's
-  // test_uoregion turns this region off and puts back "no weather" rather than
-  // what the config says, and a filtered run can order that before this file.
-  // Nobody is standing in the region yet, so this reaches no client.
+  // Pinned, not trusted to weather.cfg: test_uoregion leaves this region off,
+  // and a filtered run can order that package first. Nobody is standing in it
+  // yet, so this reaches no client.
   var pinned := SetRegionWeatherLevel( STORM_REGION, STORM_TYPE, STORM_SEVERITY, 0, -1 );
   if ( !pinned )
     watch_weather( 0 );
@@ -218,6 +202,32 @@ function leave_storm( res )
   if ( res && !moved )
     return ret_error( "could not take the character back out of the weather region" );
   endif
+  return res;
+endfunction
+
+
+// enter_storm for the light region: walking in changes the level, so waiting
+// for that proves the events are armed before the case starts.
+function enter_dark()
+  watch_weather( 1 );
+  drain_events();
+  if ( !MoveObjectToLocation( char, DARK_X, DARK_Y, 0,
+                              flags := MOVEOBJECT_FORCELOCATION ) )
+    return leave_dark( ret_error( "could not move into the light region" ) );
+  endif
+  var res := wait_light( DARK_LEVEL, "entering the dark" );
+  if ( !res )
+    return leave_dark( res );
+  endif
+  drain_events();
+  return 1;
+endfunction
+
+
+function leave_dark( res )
+  MoveObjectToLocation( char, HOME_X, HOME_Y, 0, flags := MOVEOBJECT_FORCELOCATION );
+  drain_events();
+  watch_weather( 0 );
   return res;
 endfunction
 
@@ -366,4 +376,33 @@ exported function weather_repaint_after_setseason( unused resources )
   // gated the way the weather events are, so a later case would inherit this.
   char.setseason( SEASON_DEFAULT, 0 );
   return leave_storm( res );
+endfunction
+
+
+// A season packet resets the client's light, and the core sends one on
+// resurrection. Outside a weather region carrying a LightOverride - which is
+// everywhere on this shard - nothing used to put the level back, so the client
+// kept whatever the packet had left it on.
+exported function light_restored_after_season( unused resources )
+  var res := enter_dark();
+  if ( !res )
+    return res;
+  endif
+
+  ApplyRawDamage( char, GetVital( char, "Life" ) / 100 + 10 );
+  if ( !char.dead )
+    return leave_dark( revive( ret_error( "the character did not die" ) ) );
+  endif
+  drain_events();
+
+  var corpse := char.getcorpse();
+  if ( !Resurrect( char, RESURRECT_FORCELOCATION ) )
+    return leave_dark( revive( ret_error( "the character could not be resurrected" ) ) );
+  endif
+  res := wait_light( DARK_LEVEL, "resurrection" );
+  if ( corpse )
+    DestroyItem( corpse );
+  endif
+  drain_events();
+  return leave_dark( res );
 endfunction

--- a/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
+++ b/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
@@ -1,0 +1,369 @@
+// Several ordinary events resend the character's position, and a client that
+// gets one stops drawing weather. The core repaints afterwards so the sky
+// survives; each case here proves one of those paths.
+//
+// The shape is the same every time: stand in a weather region so there is a
+// sky to lose, swallow what walking in sent, trigger the event, then wait for
+// the weather to come back. Without the repaint the wait times out, which is
+// exactly the regression these guard.
+//
+// TestWeatherStorm is defined in regions/weather.cfg. It sits in open water no
+// client otherwise visits, so nothing else can be sending these packets - and
+// because it is water, anything that checks walkheight there has to be forced.
+//
+// STILL UNTESTED. Every repaint the core does is listed here; the ones without
+// a case below are left for whoever gets to them, with what each would need.
+//
+//   start_client_char (pol.cpp)  - the repaint after login's last position
+//       send. Needs the client to go away and come back: the todos are
+//       "disconnect" and "connect" (see testclient.py). The catch is that a
+//       reconnect reorders whose events are whose, so drain carefully or the
+//       case passes for the wrong reason.
+//
+//   handle_client_version (miscmsg.cpp) - same trip as above; the core sends
+//       the season here because the one during login is too early for the
+//       client to keep. Falls out of the reconnect case for free.
+//
+//   handle_msg_BF, the gargoyle flight toggle (miscmsg.cpp) - a 0xBF
+//       subcommand through the "raw_packet" todo, like the resync case below.
+//       Needs the subcommand id and a gargoyle body: a non-gargoyle is
+//       refused before anything is sent.
+//
+//   move_boat_mobile (boat.cpp) - a boat carrying this character across into
+//       britannia2. testpkgs/boat/test_boat.src already moves a boat between
+//       realms, and test_client_boat.src already sails one with a client
+//       aboard; this is the two put together.
+//
+//   The three light fixes (ufunc.cpp, charactr.cpp) - EVT_LIGHT is wired up
+//       and unused. regions/light.cfg has TestLightBase at 10 and
+//       TestLightDark at 25 (108..115). Each fix is a restoration after
+//       something resets the level, so the case has to catch the reset first
+//       and then the value coming back:
+//         - the level after a season packet, outside a weather region that
+//           carries a LightOverride
+//         - a light override expiring inside a region that carries one, both
+//           on its timer and through uo::SetRegionLightLevel()
+//         - logging into a light region whose level is 0
+//
+//   npc::Face() (npcmod.cpp) - the same no-resend guard as
+//       facing_unchanged_is_quiet below, but for an NPC turning. Needs a
+//       second client watching, and an assert that it is told nothing.
+
+use os;
+use uo;
+
+include "testutil";
+include "communication";
+
+const STORM_REGION := "TestWeatherStorm";
+const STORM_X := 177;
+const STORM_Y := 177;
+const STORM_TYPE := 1;
+const STORM_SEVERITY := 10;
+
+const HOME_X := 100;
+const HOME_Y := 50;
+
+// A human body to turn into; what to turn back into is read off the character.
+// setgraphic refuses anything past MaxAnimID, and this is well inside it.
+const BODY_FEMALE := 0x191;
+
+const CLIENT_ID := 0;
+
+// The whole resync request: the message type and two unread bytes.
+const RESYNC_PACKET := "220000";
+const SEASON_DESOLATION := 4;
+// What the rest of the suite runs in, put back after the season case.
+const SEASON_DEFAULT := 0;
+
+// Any override at all, so setlightlevel has something to do; cleared again
+// with -1, which is what the core reads as "no override".
+const TEST_LIGHT := 12;
+const NO_LIGHT_OVERRIDE := -1;
+
+var char;
+
+// takes ownership of the client events, which is what puts them in this queue
+var clientcon := getClientConnection();
+
+program test_client_weather_repaint()
+  var a := FindAccount( "testclient0" );
+  char := a.getcharacter( 1 );
+  if ( !char )
+    return ret_error( "Could not find char at slot 1" );
+  endif
+  return 1;
+endprogram
+
+
+// The storm rather than the "no weather" the core sends on leaving a region.
+function check_storm( ev, what )
+  if ( CInt( ev.weather ) != STORM_TYPE )
+    return ret_error( $"{what}: repainted weather {ev.weather}, wanted {STORM_TYPE}" );
+  endif
+  if ( CInt( ev.severity ) != STORM_SEVERITY )
+    return ret_error( $"{what}: repainted severity {ev.severity}, wanted {STORM_SEVERITY}" );
+  endif
+  return 1;
+endfunction
+
+
+function wait_weather( what, timeout := 10 )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    var ev := Wait_For_Event( POLL_INTERVAL );
+    if ( !ev or ev.type != EVT_WEATHER or CInt( ev.id ) != CLIENT_ID )
+      continue;
+    endif
+    return check_storm( ev, what );
+  endwhile
+  return ret_error( $"{what}: the client was never sent the weather again" );
+endfunction
+
+
+// Resurrection sends the season first and the weather second, so waiting for
+// one at a time would throw the other away. Which season it is depends on the
+// realm, so only that one was sent is asserted: a client that was dead never
+// kept the season login gave it, and before the fix nothing sent another.
+function wait_season_and_weather( what, timeout := 10 )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  var got_season := 0;
+  var got_weather := 0;
+  while ( ReadMillisecondClock() < deadline )
+    var ev := Wait_For_Event( POLL_INTERVAL );
+    if ( !ev or CInt( ev.id ) != CLIENT_ID )
+      continue;
+    endif
+    if ( ev.type == EVT_SEASON )
+      got_season := 1;
+    elseif ( ev.type == EVT_WEATHER )
+      var res := check_storm( ev, what );
+      if ( !res )
+        return res;
+      endif
+      got_weather := 1;
+    endif
+    if ( got_season && got_weather )
+      return 1;
+    endif
+  endwhile
+  if ( !got_weather )
+    return ret_error( $"{what}: the client was never sent the weather again" );
+  endif
+  return ret_error( $"{what}: the client was never sent a season" );
+endfunction
+
+
+// Fails if the event turns up at all, for the cases whose fix is that a packet
+// is no longer sent. Polls rather than sleeping a second at a time, so a
+// negative assertion costs what it was asked for.
+function no_event_for( type, what, timeout := QUIET_SECS )
+  var deadline := ReadMillisecondClock() + timeout * 1000;
+  while ( ReadMillisecondClock() < deadline )
+    var ev := Wait_For_Event( POLL_INTERVAL );
+    if ( ev and ev.type == type and CInt( ev.id ) == CLIENT_ID )
+      return ret_error( $"{what}: the client was sent a {type} it should not have been" );
+    endif
+  endwhile
+  return 1;
+endfunction
+
+
+// Weather and light raise no event unless a test asks for them: before this
+// they raised none at all, and the rest of the suite is written against that
+// silence. Turned on only while a case is standing in the storm.
+function watch_weather( on )
+  clientcon.sendevent( struct{ todo := "weather_events", arg := on, id := CLIENT_ID } );
+endfunction
+
+
+// Puts the character in the storm. The drain comes first, so the toggle above
+// has landed before anything can be sent; then it waits for the packet walking
+// in causes rather than draining blindly, since one that arrived late would
+// otherwise satisfy the wait the case makes afterwards.
+function enter_storm()
+  watch_weather( 1 );
+  // Pinned rather than taken on trust from weather.cfg: TestMisc's
+  // test_uoregion turns this region off and puts back "no weather" rather than
+  // what the config says, and a filtered run can order that before this file.
+  // Nobody is standing in the region yet, so this reaches no client.
+  var pinned := SetRegionWeatherLevel( STORM_REGION, STORM_TYPE, STORM_SEVERITY, 0, -1 );
+  if ( !pinned )
+    watch_weather( 0 );
+    return ret_error( $"could not set up {STORM_REGION}: {pinned}" );
+  endif
+  drain_events();
+
+  // Every exit from here on goes through leave_storm: it disarms the toggle
+  // and takes the character home, and a case left standing in the storm turns
+  // one failure into a run of them.
+  if ( !MoveObjectToLocation( char, STORM_X, STORM_Y, 0,
+                              flags := MOVEOBJECT_FORCELOCATION ) )
+    return leave_storm( ret_error( "could not move into the weather region" ) );
+  endif
+  var res := wait_weather( "entering the storm" );
+  if ( !res )
+    return leave_storm( res );
+  endif
+  drain_events();
+  return 1;
+endfunction
+
+
+function leave_storm( res )
+  var moved := MoveObjectToLocation( char, HOME_X, HOME_Y, 0,
+                                     flags := MOVEOBJECT_FORCELOCATION );
+  drain_events();
+  watch_weather( 0 );
+  if ( res && !moved )
+    return ret_error( "could not take the character back out of the weather region" );
+  endif
+  return res;
+endfunction
+
+
+// Killing the shared character is the most destructive thing here, so every
+// path out of that case goes through this - the same shape as revive() in
+// test_client_speech_raw.src. Forced, because the storm is water and
+// walkheight has no reason to accept it.
+function revive( res )
+  var corpse := char.getcorpse();
+  Resurrect( char, RESURRECT_FORCELOCATION );
+  if ( corpse )
+    DestroyItem( corpse );
+  endif
+  drain_events();
+  return res;
+endfunction
+
+
+// chr.graphic := is the member form of setgraphic, which is what a polymorph
+// spell uses.
+exported function weather_repaint_setgraphic( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  var oldgraphic := char.graphic;
+  char.graphic := BODY_FEMALE;
+  res := wait_weather( "setgraphic" );
+  char.graphic := oldgraphic;
+  return leave_storm( res );
+endfunction
+
+
+exported function weather_repaint_color( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  // Derived, not fixed: setcolor only tells anyone when the colour differs.
+  var oldcolor := char.color;
+  var newcolor := 0x8FF;
+  if ( oldcolor == newcolor )
+    newcolor := 0x8FE;
+  endif
+  char.color := newcolor;
+  res := wait_weather( "colour change" );
+  char.color := oldcolor;
+  return leave_storm( res );
+endfunction
+
+
+// Death and resurrection both resend the position, and the season goes with
+// the resurrection: one sent while the character was dead does not stick, so a
+// client that logged in as a ghost has none.
+exported function weather_repaint_resurrect( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  ApplyRawDamage( char, GetVital( char, "Life" ) / 100 + 10 );
+  if ( !char.dead )
+    return leave_storm( revive( ret_error( "the character did not die" ) ) );
+  endif
+  res := wait_weather( "death" );
+  if ( !res )
+    return leave_storm( revive( res ) );
+  endif
+
+  drain_events();
+  var corpse := char.getcorpse();
+  if ( !Resurrect( char, RESURRECT_FORCELOCATION ) )
+    return leave_storm( revive( ret_error( "the character could not be resurrected" ) ) );
+  endif
+  res := wait_season_and_weather( "resurrection" );
+  if ( corpse )
+    DestroyItem( corpse );
+  endif
+  drain_events();
+  return leave_storm( res );
+endfunction
+
+
+// The client asks to be resynchronised and the core answers with the position,
+// which is what costs it the weather.
+exported function weather_repaint_resync( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  clientcon.sendevent( struct{ todo := "raw_packet", arg := RESYNC_PACKET, id := CLIENT_ID } );
+  if ( !waitForClient( CLIENT_ID, { EVT_PACKET_SENT } ) )
+    return leave_storm( ret_error( "the client never put the resync request on the wire" ) );
+  endif
+  res := wait_weather( "resync request" );
+  return leave_storm( res );
+endfunction
+
+
+// Turning to the way you already face is not a change and no longer resends
+// the position. The own client is never told it moved either way, so the
+// weather is the discriminator: without the guard the resend would cost the
+// client its sky and the repaint would put it back.
+exported function facing_unchanged_is_quiet( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  // setfacing rather than the member form: it applies the same guard but says
+  // whether it turned. can_face refuses when frozen, paralyzed or out of
+  // stamina, and a refusal would satisfy the assertion below for the wrong
+  // reason - the exact vacuous pass this case exists to avoid.
+  if ( !char.setfacing( char.facing ) )
+    return leave_storm( ret_error( "the character refused to turn" ) );
+  endif
+  res := no_event_for( EVT_WEATHER, "same-direction turn" );
+  return leave_storm( res );
+endfunction
+
+
+// A season sent by a script leaves the client with neither weather nor light,
+// and the core no longer records that it still has them. The next unforced
+// region check repairs it, even though the region has not changed.
+//
+// setlightlevel is the trigger because it runs check_region_changes() without
+// moving: move_character_to nulls the weather region itself, so a move would
+// repaint whether or not setseason had invalidated anything.
+exported function weather_repaint_after_setseason( unused resources )
+  var res := enter_storm();
+  if ( !res )
+    return res;
+  endif
+
+  char.setseason( SEASON_DESOLATION, 0 );
+  drain_events();
+
+  char.setlightlevel( TEST_LIGHT, 0 );
+  res := wait_weather( "light change after setseason" );
+  char.setlightlevel( NO_LIGHT_OVERRIDE, 0 );
+  // Put the season back: nothing asserts on it today, but EVT_SEASON is not
+  // gated the way the weather events are, so a later case would inherit this.
+  char.setseason( SEASON_DEFAULT, 0 );
+  return leave_storm( res );
+endfunction

--- a/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
+++ b/testsuite/pol/testpkgs/client/test_client_weather_repaint.src
@@ -14,6 +14,11 @@
 // The repaints this does not reach yet - login, the version handshake, the
 // gargoyle fly toggle, a boat crossing realms, two of the light fixes and
 // npc::Face() - are listed in the pull request, with what each would need.
+//
+// The first two need more than a case: startclient selects the character
+// before it attaches a brain, so nothing sent during login can raise an
+// event. Reaching them means recording what the client last received and
+// asking it afterwards, rather than watching for it.
 
 use os;
 use uo;

--- a/testsuite/testclient/pyuo/pyuo/brain.py
+++ b/testsuite/testclient/pyuo/pyuo/brain.py
@@ -232,6 +232,8 @@ class Event:
   EVT_MULTI_PLACED = 135
   EVT_REFRESH_OBJ = 136
   EVT_PROMPT = 137
+  EVT_WEATHER = 138
+  EVT_LIGHT = 139
 
   EVT_INIT = 254
   EVT_CLIENT_CRASH = 255
@@ -300,6 +302,10 @@ class Event:
       return "refresh_obj"
     elif self.type==Event.EVT_PROMPT:
       return "prompt"
+    elif self.type==Event.EVT_WEATHER:
+      return "weather"
+    elif self.type==Event.EVT_LIGHT:
+      return "light"
     elif self.type==Event.EVT_CLOSE_WINDOW:
       return "close_window"
     elif self.type==Event.EVT_GUMP_REPLY:

--- a/testsuite/testclient/pyuo/pyuo/client.py
+++ b/testsuite/testclient/pyuo/pyuo/client.py
@@ -632,6 +632,7 @@ class Client(threading.Thread):
     self.disable_item_logging = False # do not signal or log new items
     self.view_range = 18 # default client view range
     self.auto_delete_objs = True
+    self.weather_events = False # weather/light events, for the tests that assert on them
 
     self.gumps=[] # open gumps
     self.next_gump_reply=None # armed by the gump_reply todo, consumed by the next gump
@@ -1144,10 +1145,19 @@ class Client(threading.Thread):
           title=pkt.title, utext=pkt.utext, etext=pkt.etext))
 
     elif isinstance(pkt, packets.SetWeatherPacket):
-      self.log.info('Ignoring weather packet')
+      # No 'assert self.lc' here or below: the core can send both of these
+      # before login completes - check_region_changes() runs ahead of
+      # login_complete() in start_client_char.
+      self.log.debug('Weather %s severity %s aux %s', pkt.type, pkt.num, pkt.temp)
+      if self.weather_events:
+        # 'weather', not 'type': Event takes its own type as the first argument.
+        self.brain.event(brain.Event(brain.Event.EVT_WEATHER, weather=pkt.type,
+            num=pkt.num, temp=pkt.temp))
 
     elif isinstance(pkt, packets.OverallLightLevelPacket):
-      self.log.info('Ignoring light level packet')
+      self.log.debug('Light level %s', pkt.level)
+      if self.weather_events:
+        self.brain.event(brain.Event(brain.Event.EVT_LIGHT, level=pkt.level))
 
     elif isinstance(pkt, packets.SendSkillsPacket):
       self.brain.event(brain.Event(brain.Event.EVT_SKILLS, skills=pkt.skills))

--- a/testsuite/testclient/pyuo/testclient.py
+++ b/testsuite/testclient/pyuo/testclient.py
@@ -402,6 +402,10 @@ class TestBrain(brain.Brain):
             res = res is not None))
       elif todo=="disable_item_logging":
         self.client.addTodo(brain.Event(brain.Event.EVT_DISABLE_ITEM_LOGGING, value = arg))
+      elif todo=="weather_events":
+        # Off for everyone else: these two packets raised no event at all before,
+        # and the rest of the suite is written against that silence.
+        self.client.weather_events = arg
       elif todo=="auto_delete_objs":
         self.client.auto_delete_objs = arg
         self.server.addevent(
@@ -741,6 +745,13 @@ class PolServer:
     elif ev.type==Event.EVT_SEASON:
       res["season"]=ev.season
       res["playsound"]=ev.playsound
+    elif ev.type==Event.EVT_WEATHER:
+      # named for the wire, not for pyuo's decoder: 0x65 is type, severity, aux
+      res["weather"]=ev.weather
+      res["severity"]=ev.num
+      res["aux"]=ev.temp
+    elif ev.type==Event.EVT_LIGHT:
+      res["level"]=ev.level
     elif ev.type==Event.EVT_SKILLS:
       res["skills"]=len(ev.skills)
     elif ev.type==Event.EVT_ANIMATION:


### PR DESCRIPTION
The client stops drawing weather when it is sent a new position, and the season packet resets its light level. Both go out from many places, and only move_character_to handled the consequence - it nulls the client's remembered weather region so its own tellmove repaints. Everywhere else the sky stayed wrong until the character crossed into another weather region, teleported, or the weather changed on its own.

Both halves are measured, not inherited. The tree only ever hedged on the weather half - "send_goxyz seems to stop the weather" beside the null in move_character_to, and dave's 2003 note in check_weather_region_change, "send_goxyz causes weather effects to stop if character is walking/running too". Sending a bare, well-formed 0x20 to a standing character in the rain, with no repaint behind it, stops the weather: the sky goes clear and stays clear. So the effect is real and the walking/running qualifier is not limiting. For the light, send_season_info's own comment says the season packet resets it, and an undated POL097 entry records the intent that the core "sends light level whenever season info is sent to the client".

Repaints added at: the client's resync request, death, resurrection, a graphic, colour or facing change, the gargoyle fly toggle, the client version handshake, and a boat crossing realms. Login already had one, but it went out before the season packet and the final send_goxyz and so undid itself - that one moves rather than appears. Only the handshake rests on the season premise; it sends no position packet at all. The rest stand on send_goxyz alone.

The boat repaint has to sit below the branch that sends goxyz to pre-7.0.9.0 clients, or that undoes it, and has to be forced: region grids are zero-filled per realm and the lookup indexes one shared vector, so an unpainted zone in either realm is the same background region and an unforced check sees no change.

send_season_info knew the season packet resets the light but only restored it for a weather region carrying a LightOverride - and where it declined, a character holding its own override, the light stayed reset. It now re-sends gd->lightlevel, which is what the client was last told in every case.

That exposed the bug it had been masking: a personal override expiring inside such a region never restored the region's level, because both places that decide who owns the light skipped the character on the assumption the client already had it. Those two are now weather_region_owns_light(). regen_stats open-codes the expiry half as well and is left alone; only the skip was duplicated.

update_weatherregion now also accepts a client with no remembered weather region. It gated on the pointer matching the region being changed, so the two calls below
- which null it - would have made that client invisible to SetRegionWeatherLevel, the main way weather is driven. Inferred, not stated: the commented-out 2003 line in that same function looks like the same edge from the other side.

setseason and SendOverallSeason keep their documented contract - resending the light and weather is the script's job - but no longer leave the core recording state the client has lost. Both are invalidated instead: the weather region is nulled, and the light level set to -1, which VALID_LIGHTLEVEL rejects so it can never be sent by accident. No packet goes out, so the contract holds. The repair is not immediate, though: it lands on the character's next region change or the next SetRegionWeatherLevel.

ClientGameData::lightlevel now starts at -1 rather than 0, and clear() resets it. Zero is a real level, so the old value claimed the client had been told something it never had - a character logging into a region whose level is genuinely 0 was never sent one at all.

chr.facing :=, chr.setfacing() and npc::Face() now call on_facing_changed only when the facing actually changed. face() reports success either way, so a script turning to face a target it already faced was resending the position to itself and its movement to onlookers every call. Scripts using a same-direction turn as a resync nudge lose that side effect.

The repaint is not free where facing changes are frequent: a client announces the weather on every packet it accepts, so each repaint is also a journal line while weather is falling. A clear sky is silent - that packet carries no message.

Deliberately unchanged: a boat step or turn sends goxyz to every traveller on a pre-7.0.9.0 client, so those clients still lose the weather while sailing even within one realm. The repaint belongs in do_tellmoves, the single end-of-move point for move_to, move and turn, and wants testing against a real client first.


Claude-Session: https://claude.ai/code/session_01XWxMZWAVo2agN6axNF22o2